### PR TITLE
#9 Refactorings for reference architecture

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -28,6 +28,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Start Test Harness
+      run: |
+        manage up
     - name: Test with pytest
       run: |
         pytest --cov
@@ -35,6 +38,9 @@ jobs:
       run: |
         pip install pylint
         pylint admin routers oicd tests --rcfile=.pylintrc -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" --exit-zero > pylintreport.txt
+    - name: Tear down test harnless
+      run: |
+       manage down
     - name: SonarCloud Scan
       uses: SonarSource/sonarcloud-github-action@master
       env:

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -40,7 +40,7 @@ jobs:
         pylint admin routers oicd tests --rcfile=.pylintrc -r n --msg-template="{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}" --exit-zero > pylintreport.txt
     - name: Tear down test harnless
       run: |
-       manage down
+       ./manage down
     - name: SonarCloud Scan
       uses: SonarSource/sonarcloud-github-action@master
       env:

--- a/app/core/agent_factory.py
+++ b/app/core/agent_factory.py
@@ -1,0 +1,19 @@
+from distutils.util import strtobool
+
+import os
+
+import aries_cloudcontroller
+
+admin_url = os.getenv("ACAPY_ADMIN_URL")
+admin_port = os.getenv("ACAPY_ADMIN_PORT")
+admin_api_key = os.getenv("ACAPY_ADMIN_API_KEY")
+is_multitenant = strtobool(os.getenv("IS_MULTITENANT", "False"))
+ledger_url = os.getenv("LEDGER_NETWORK_URL")
+
+
+def create_aries_agentcontroller():
+    return aries_cloudcontroller.AriesAgentController(
+            admin_url=f"{admin_url}:{admin_port}",
+            api_key=admin_api_key,
+            is_multitenant=is_multitenant,
+    )

--- a/app/core/agent_factory.py
+++ b/app/core/agent_factory.py
@@ -8,7 +8,6 @@ admin_url = os.getenv("ACAPY_ADMIN_URL")
 admin_port = os.getenv("ACAPY_ADMIN_PORT")
 admin_api_key = os.getenv("ACAPY_ADMIN_API_KEY")
 is_multitenant = strtobool(os.getenv("IS_MULTITENANT", "False"))
-ledger_url = os.getenv("LEDGER_NETWORK_URL")
 
 
 def create_aries_agentcontroller():

--- a/app/core/delegates.py
+++ b/app/core/delegates.py
@@ -1,0 +1,41 @@
+import os
+
+import json
+
+import requests
+from fastapi import HTTPException
+
+from schemas import LedgerRequest
+
+SOVRIN_NETWORK = os.getenv("SOVRIN_NETWORK", "stagingnet")
+
+ledger_url = os.getenv("LEDGER_NETWORK_URL")
+
+class LedgerDelegate:
+
+    async def get_nym(self, did_object=None, did=None, verkey=None):
+        # TODO: not sure what this method should be called... please help
+        # TODO: Network and paymentaddr should be definable on the fly/via args/via request body
+        # TODO: Should this really be a schema or is using schema overkill here?
+        # If we leave it as schema like this I suppose it is at least usable elsewhere
+        if not did_object:
+            did = did_object["did"]
+            verkey = did_object["verkey"]
+        payload = LedgerRequest(
+            network=SOVRIN_NETWORK,
+            did=did,
+            verkey=verkey,
+            paymentaddr="",
+        ).dict()
+        r = requests.post(ledger_url, data=json.dumps(payload), headers={})
+        if r.status_code != 200:
+            error_json = r.json()
+            raise HTTPException(
+                status_code=r.status_code,
+                detail=f"Something went wrong.\nCould not write to StagingNet.\n{error_json}",
+            )
+        return r
+
+
+
+ledger = LedgerDelegate()

--- a/app/core/delegates.py
+++ b/app/core/delegates.py
@@ -18,7 +18,7 @@ class LedgerDelegate:
         # TODO: Network and paymentaddr should be definable on the fly/via args/via request body
         # TODO: Should this really be a schema or is using schema overkill here?
         # If we leave it as schema like this I suppose it is at least usable elsewhere
-        if not did_object:
+        if did_object:
             did = did_object["did"]
             verkey = did_object["verkey"]
         payload = LedgerRequest(

--- a/app/core/wallet.py
+++ b/app/core/wallet.py
@@ -109,6 +109,6 @@ async def create_public_did():
         raise HTTPException(
             status_code=500,
             detail=f"Something went wrong: {e!r}",
-        )
+        ) from e
 
 

--- a/app/core/wallet.py
+++ b/app/core/wallet.py
@@ -1,0 +1,114 @@
+import json
+
+import logging
+
+from distutils.util import strtobool
+import requests
+import os
+
+import aries_cloudcontroller
+from fastapi import HTTPException
+
+from core import agent_factory
+from core.delegates import ledger
+from schemas import LedgerRequest, DidCreationResponse
+
+logger = logging.getLogger(__name__)
+
+is_multitenant = strtobool(os.getenv("IS_MULTITENANT", "False"))
+
+
+async def create_public_did():
+    """
+    Create a new public DID and
+    write it to the ledger and
+    receive its public info.
+
+    Returns:
+    * DID object (json)
+    * Issuer verkey (str)
+    * Issuer Endpoint (url)
+    """
+    # TODO Can we break down this endpoint into smaller functions?
+    # Because this really is too complex/too much happening at once.
+    # This way not really testible/robust
+    try:
+        aries_agent_controller = agent_factory.create_aries_agentcontroller()
+        # TODO: Should this come from env var or from the client request?
+        # Adding empty header as parameters are being sent in payload
+        generate_did_res = await aries_agent_controller.wallet.create_did()
+        if not generate_did_res["result"]:
+            raise HTTPException(
+                # TODO: Should this return HTTPException, if so which status code?
+                # Check same for occurences below
+                status_code=404,
+                detail=f"Something went wrong.\nCould not generate DID.\n{generate_did_res}",
+            )
+        did_object = generate_did_res["result"]
+        await ledger.get_nym(did_object)
+        taa_response = await aries_agent_controller.ledger.get_taa()
+        logger.info(f"taa_response:\n{taa_response}")
+        if not taa_response["result"]:
+            error_json = taa_response.json()
+            raise HTTPException(
+                status_code=404,
+                detail=f"Something went wrong. Could not get TAA. {error_json}",
+            )
+        TAA = taa_response["result"]["taa_record"]
+        TAA["mechanism"] = "service_agreement"
+        accept_taa_response = await aries_agent_controller.ledger.accept_taa(TAA)
+        logger.info(f"accept_taa_response: {accept_taa_response}")
+        if accept_taa_response != {}:
+            error_json = accept_taa_response.json()
+            raise HTTPException(
+                status_code=404,
+                detail=f"Something went wrong. Could not accept TAA. {error_json}",
+            )
+        assign_pub_did_response = await aries_agent_controller.wallet.assign_public_did(
+            did_object["did"]
+        )
+        logger.info(f"assign_pub_did_response:\n{assign_pub_did_response}")
+        if (
+            not assign_pub_did_response["result"]
+            or assign_pub_did_response["result"] == {}
+        ):
+            error_json = assign_pub_did_response.json()
+            raise HTTPException(
+                status_code=500,
+                detail=f"Something went wrong.\nCould not assign DID. {error_json}",
+            )
+        get_pub_did_response = await aries_agent_controller.wallet.get_public_did()
+        logger.info(f"get_pub_did_response:\n{get_pub_did_response}")
+        if not get_pub_did_response["result"] or get_pub_did_response["result"] == {}:
+            error_json = get_pub_did_response.json()
+            raise HTTPException(
+                status_code=404,
+                detail=f"Something went wrong. Could not obtain public DID. {error_json}",
+            )
+        issuer_nym = get_pub_did_response["result"]["did"]
+        issuer_verkey = get_pub_did_response["result"]["verkey"]
+        issuer_endpoint = await aries_agent_controller.ledger.get_did_endpoint(
+            issuer_nym
+        )
+        if not issuer_endpoint:
+            raise HTTPException(
+                status_code=404,
+                detail="Something went wrong. Could not obtain issuer endpoint.",
+            )
+        issuer_endpoint_url = issuer_endpoint["endpoint"]
+        final_response = DidCreationResponse(
+            did_object=did_object,
+            issuer_verkey=issuer_verkey,
+            issuer_endpoint=issuer_endpoint_url,
+        )
+        await aries_agent_controller.terminate()
+        return final_response
+    except Exception as e:
+        await aries_agent_controller.terminate()
+        logger.error(f"The following error occured:\n{e!r}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Something went wrong: {e!r}",
+        )
+
+

--- a/app/routers/wallet.py
+++ b/app/routers/wallet.py
@@ -4,7 +4,7 @@ import json
 import os
 import logging
 
-
+from core import wallet
 from schemas import LedgerRequest, DidCreationResponse, InitWalletRequest
 
 import aries_cloudcontroller
@@ -25,117 +25,7 @@ ledger_url = os.getenv("LEDGER_NETWORK_URL")
     "/create-pub-did", tags=["did"], response_model=DidCreationResponse
 )
 async def create_public_did():
-    """
-    Create a new public DID and
-    write it to the ledger and
-    receive its public info.
-
-    Returns:
-    * DID object (json)
-    * Issuer verkey (str)
-    * Issuer Endpoint (url)
-    """
-    # TODO Can we break down this endpoint into smaller functions?
-    # Because this really is too complex/too much happening at once.
-    # This way not really testible/robust
-    try:
-        aries_agent_controller = aries_cloudcontroller.AriesAgentController(
-            admin_url=f"{admin_url}:{admin_port}",
-            api_key=admin_api_key,
-            is_multitenant=is_multitenant,
-        )
-        # TODO: Should this come from env var or from the client request?
-        url = ledger_url
-        # Adding empty header as parameters are being sent in payload
-        generate_did_res = await aries_agent_controller.wallet.create_did()
-        if not generate_did_res["result"]:
-            raise HTTPException(
-                # TODO: Should this return HTTPException, if so which status code?
-                # Check same for occurences below
-                status_code=404,
-                detail=f"Something went wrong.\nCould not generate DID.\n{generate_did_res}",
-            )
-        did_object = generate_did_res["result"]
-        # TODO: Network and paymentaddr should be definable on the fly/via args/via request body
-        # TODO: Should this really be a schema or is using schema overkill here?
-        # If we leave it as schema like this I suppose it is at least usable elsewhere
-        payload = LedgerRequest(
-            network="stagingnet",
-            did=did_object["did"],
-            verkey=did_object["verkey"],
-            paymentaddr="",
-        ).dict()
-        r = requests.post(url, data=json.dumps(payload), headers={})
-        if r.status_code != 200:
-            error_json = r.json()
-            raise HTTPException(
-                status_code=r.status_code,
-                detail=f"Something went wrong.\nCould not write to StagingNet.\n{error_json}",
-            )
-        taa_response = await aries_agent_controller.ledger.get_taa()
-        logger.info(f"taa_response:\n{taa_response}")
-        if not taa_response["result"]:
-            error_json = taa_response.json()
-            raise HTTPException(
-                status_code=404,
-                detail=f"Something went wrong. Could not get TAA. {error_json}",
-            )
-        TAA = taa_response["result"]["taa_record"]
-        TAA["mechanism"] = "service_agreement"
-        accept_taa_response = await aries_agent_controller.ledger.accept_taa(TAA)
-        logger.info(f"accept_taa_response: {accept_taa_response}")
-        if accept_taa_response != {}:
-            error_json = accept_taa_response.json()
-            raise HTTPException(
-                status_code=404,
-                detail=f"Something went wrong. Could not accept TAA. {error_json}",
-            )
-        assign_pub_did_response = await aries_agent_controller.wallet.assign_public_did(
-            did_object["did"]
-        )
-        logger.info(f"assign_pub_did_response:\n{assign_pub_did_response}")
-        if (
-            not assign_pub_did_response["result"]
-            or assign_pub_did_response["result"] == {}
-        ):
-            error_json = assign_pub_did_response.json()
-            raise HTTPException(
-                status_code=500,
-                detail=f"Something went wrong.\nCould not assign DID. {error_json}",
-            )
-        get_pub_did_response = await aries_agent_controller.wallet.get_public_did()
-        logger.info(f"get_pub_did_response:\n{get_pub_did_response}")
-        if not get_pub_did_response["result"] or get_pub_did_response["result"] == {}:
-            error_json = get_pub_did_response.json()
-            raise HTTPException(
-                status_code=404,
-                detail=f"Something went wrong. Could not obtain public DID. {error_json}",
-            )
-        issuer_nym = get_pub_did_response["result"]["did"]
-        issuer_verkey = get_pub_did_response["result"]["verkey"]
-        issuer_endpoint = await aries_agent_controller.ledger.get_did_endpoint(
-            issuer_nym
-        )
-        if not issuer_endpoint:
-            raise HTTPException(
-                status_code=404,
-                detail="Something went wrong. Could not obtain issuer endpoint.",
-            )
-        issuer_endpoint_url = issuer_endpoint["endpoint"]
-        final_response = DidCreationResponse(
-            did_object=did_object,
-            issuer_verkey=issuer_verkey,
-            issuer_endpoint=issuer_endpoint_url,
-        )
-        await aries_agent_controller.terminate()
-        return final_response
-    except Exception as e:
-        await aries_agent_controller.terminate()
-        logger.error(f"The following error occured:\n{e!r}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Something went wrong: {e!r}",
-        )
+    return wallet.create_public_did()
 
 
 @router.get("/")

--- a/app/tests/test_wallet.py
+++ b/app/tests/test_wallet.py
@@ -1,7 +1,20 @@
+import pytest
+
 import routers.governance
+from core import wallet, agent_factory, delegates
+
 
 def test_foo():
     pass
 
-def test_bar():
-    pass
+
+@pytest.mark.asyncio
+async def test_create_public_did():
+    agent_factory.admin_url = 'http://localhost'
+    agent_factory.admin_port = '3021'
+    agent_factory.admin_api_key = 'adminApiKey'
+    agent_factory.is_multitenant = False
+
+    delegates.ledger_url = "https://selfserve.sovrin.org/nym"
+    result = await wallet.create_public_did()
+    print(result)


### PR DESCRIPTION
I took the wallet.create_public_did and refactored it to create a pattern for us going forward.

To summarise:
1. introduced a "core" context which is the "core" processing of our application (no decorators or fastapi "annotations"). Not a great name but not sure what else to call this.
2. removed the router into its own context - it provides the entry point into core
3. created delegates for the remote (http) calls. Don't think it necessary to add this for calls to the agent controller
4. created an agent factory for creating the agent controller

What I'm trying to do is create smaller pieces of functionality and knowledge - that is that classes/functions know only what they need to know and don't know "too much". Wanting to make the code more "[SOLID](https://en.wikipedia.org/wiki/SOLID#:~:text=In%20object%2Doriented%20computer%20programming,understandable%2C%20flexible%2C%20and%20maintainable.&text=The%20Interface%20segregation%20principle%3A%20%22Many,one%20general%2Dpurpose%20interface.%22)".

I welcome any thoughts/comments/suggestions or push back... let's pool our skills and knowledge to create something good.

I still want to add some tests to this, but that will probably be in a different pull request.
