### PR TITLE
Showing POC of using uplink to access acapy

### DIFF
--- a/app/acapy_uplink_facade.py
+++ b/app/acapy_uplink_facade.py
@@ -1,0 +1,53 @@
+from typing import List
+
+from pydantic import BaseModel, Field
+from uplink import Consumer, get, Header, returns, Body, json
+import uplink
+
+
+class WalletDids(BaseModel):
+    verkey: str
+    did: str
+    posture: str
+
+
+class WalletDidsResponse(BaseModel):
+    results: List[WalletDids]
+
+
+class Schema(BaseModel):
+    schema_version: str
+    attributes: List[str]
+    schema_name: str
+
+
+class SchemaCreated(BaseModel):
+    ver: str
+    attrNames: List[str]
+    name: str
+    version: str
+    id: str
+    seqNo: int
+
+
+class SchemaSendResults(BaseModel):
+    schema_id: str
+    schema_: SchemaCreated = Field(alias="schema")
+
+
+class AcapyWallet(Consumer):
+    """A Python Client for the GitHub API."""
+
+    @uplink.get("wallet/did")
+    def get_wallet_dids(self, x_api_key: Header("x-api-key")) -> WalletDidsResponse:
+        """Get Wallet Dids"""
+
+
+class AcapySchemas(Consumer):
+    @uplink.json
+    @uplink.headers({"content-type": "application/json"})
+    @uplink.post("schemas")
+    def create_schema(
+        self, schema: Body, x_api_key: Header("x-api-key")
+    ) -> SchemaSendResults:
+        """create a schema"""

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -60,3 +60,4 @@ httpx==0.18.1
 mockito==1.2.2
 pytest-bdd
 assertpy==1.1
+uplink==0.9.4

--- a/app/tests/test_acapy_uplink.py
+++ b/app/tests/test_acapy_uplink.py
@@ -1,0 +1,29 @@
+import pytest
+import unittest
+from aiohttp import ClientSession
+from uplink import AiohttpClient
+
+from acapy_uplink_facade import AcapyWallet, AcapySchemas, Schema
+
+
+@pytest.mark.asyncio
+async def test_list_public_dids():
+    async with ClientSession() as session:
+        wallet = AcapyWallet(base_url="http://localhost:3021", client=session)
+        result = await wallet.get_wallet_dids(x_api_key="adminApiKey")
+        print(result)
+
+
+@pytest.mark.asyncio
+async def test_create_schema():
+    async with ClientSession() as session:
+        schemas = AcapySchemas(base_url="http://localhost:3021", client=session)
+        schema = Schema(
+            schema_version="1.0",
+            schema_name="deafult_test",
+            attributes=["name", "dateofbirth"],
+        )
+        result = await schemas.create_schema(
+            schema=schema.dict(), x_api_key="adminApiKey"
+        )
+        print(result)


### PR DESCRIPTION
So [uplink](https://uplink.readthedocs.io/en/stable/index.html) is a clever library for building web api clients...

It is inspired by a java project called [retrofit](https://square.github.io/retrofit/)

Included in this pull request is a demonstration of how to use uplink to access acapy.

The key thing to note is that there is a vast amount of code reuse, so now only is the less code to write, there is also less code to go wrong.

