### PR TITLE
Selecting agent based on role

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import Header
 
 import logging
@@ -37,6 +39,24 @@ async def yoma_agent(x_api_key: str = Header(None)):
     finally:
         if agent:
             await agent.terminate()
+
+
+async def ecosystem_or_member_agent(
+    x_api_key: str = Header(None),
+    authorization: str = Header(None),
+    x_wallet_id=Header(None),
+    x_role=Header(...),
+):
+    if x_role == "member":
+        async with asynccontextmanager(member_agent)(authorization, x_wallet_id) as x:
+            yield x
+    elif x_role == "eco-system" or x_role == "ecosystem":
+        async with asynccontextmanager(ecosystem_agent)(
+            x_api_key, authorization, x_wallet_id
+        ) as x:
+            yield x
+    else:
+        raise HTTPException(400, "invalid role")
 
 
 async def ecosystem_agent(

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -41,7 +41,7 @@ async def yoma_agent(x_api_key: str = Header(None)):
             await agent.terminate()
 
 
-async def ecosystem_or_member_agent(
+async def agent_selector(
     x_api_key: str = Header(None),
     authorization: str = Header(None),
     x_wallet_id=Header(None),
@@ -50,10 +50,34 @@ async def ecosystem_or_member_agent(
     if x_role == "member":
         async with asynccontextmanager(member_agent)(authorization, x_wallet_id) as x:
             yield x
-    elif x_role == "eco-system" or x_role == "ecosystem":
+    elif (
+        x_role == "eco-system" or x_role == "ecosystem"
+    ):  # cannot use in as it's not a string
         async with asynccontextmanager(ecosystem_agent)(
             x_api_key, authorization, x_wallet_id
         ) as x:
+            yield x
+    elif x_role == "yoma":
+        async with asynccontextmanager(yoma_agent)(x_api_key) as x:
+            yield x
+    else:
+        raise HTTPException(400, "invalid role")
+
+
+async def admin_agent_selector(
+    x_api_key: str = Header(None),
+    authorization: str = Header(None),
+    x_wallet_id=Header(None),
+    x_role=Header(...),
+):
+    if x_role == "member":
+        async with asynccontextmanager(member_admin_agent)(x_api_key) as x:
+            yield x
+    elif x_role == "eco-system" or x_role == "ecosystem":
+        async with asynccontextmanager(ecosystem_admin_agent)(x_api_key) as x:
+            yield x
+    elif x_role == "yoma":
+        async with asynccontextmanager(yoma_agent)(x_api_key) as x:
             yield x
     else:
         raise HTTPException(400, "invalid role")
@@ -78,7 +102,7 @@ async def ecosystem_agent(
         # yield the controller
         agent = AriesTenantController(
             admin_url=ECOSYSTEM_AGENT_URL,
-            api_key=x_api_key,
+            api_key=EMBEDDED_API_KEY,
             tenant_jwt=tenant_jwt,
             wallet_id=x_wallet_id,
         )

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,4 @@
-from admin import admin
-from fastapi import Depends, FastAPI
+from fastapi import FastAPI
 from routers import issuer, schema, verifier
 from admin.governance import schemas, credential_definitions
 from admin.governance.multitenant_wallet import wallet

--- a/app/tests/test_dependencies.py
+++ b/app/tests/test_dependencies.py
@@ -7,6 +7,8 @@ import dependencies
 
 from assertpy import assert_that
 
+TEST_BEARER_HEADER = "Bearer x"
+
 
 def test_extract_token_from_bearer():
     # assert_that(yoma_agent).is_type_of(AriesAgentController)
@@ -84,7 +86,7 @@ async def test_member_or_ecosystem_agent():
     with pytest.raises(HTTPException) as e:
         await async_next(
             dependencies.ecosystem_or_member_agent(
-                x_api_key="apikey", authorization="Bearer x"
+                x_api_key="apikey", authorization=TEST_BEARER_HEADER
             )
         )
     assert e.value.status_code == 400
@@ -96,7 +98,7 @@ async def test_member_or_ecosystem_agent():
 
     c = await async_next(
         dependencies.ecosystem_or_member_agent(
-            x_api_key="apikey", authorization="Bearer x", x_role="ecosystem"
+            x_api_key="apikey", authorization=TEST_BEARER_HEADER, x_role="ecosystem"
         )
     )
     assert type(c) == AriesTenantController
@@ -104,11 +106,14 @@ async def test_member_or_ecosystem_agent():
 
     c = await async_next(
         dependencies.ecosystem_or_member_agent(
-            x_api_key="apikey", authorization="Bearer x", x_role="member"
+            x_api_key="apikey", authorization=TEST_BEARER_HEADER, x_role="member"
         )
     )
     assert type(c) == AriesTenantController
     assert c.admin_url == "member-agent-url"
+
+    dependencies.ECOSYSTEM_AGENT_URL = ecosystem_agent_url
+    dependencies.MEMBER_AGENT_URL = member_agent_url
 
 
 @pytest.mark.asyncio

--- a/app/tests/test_dependencies.py
+++ b/app/tests/test_dependencies.py
@@ -1,11 +1,18 @@
 import pytest
-from aries_cloudcontroller import AriesTenantController
-from fastapi import HTTPException
+from aries_cloudcontroller import (
+    AriesTenantController,
+    AriesAgentController,
+    AriesAgentControllerBase,
+)
+from fastapi import HTTPException, APIRouter, Depends
 from contextlib import asynccontextmanager
+from httpx import AsyncClient
 
 import dependencies
 
 from assertpy import assert_that
+
+from main import app
 
 TEST_BEARER_HEADER = "Bearer x"
 
@@ -77,43 +84,202 @@ async def async_next(param):
         return None
 
 
+@pytest.fixture
+def setup_agent_urls_for_testing():
+    # fixture overrides the default config values
+    # this is important as the default config values (as they are at the point of writing this code) have
+    # an equal value in the member agent url and the eco system agent url so tests cannot correctly validate
+    # the correct value is being used. This fixture ensures they are unique.
+    ecosystem_agent_url = dependencies.ECOSYSTEM_AGENT_URL
+    member_agent_url = dependencies.MEMBER_AGENT_URL
+    yoma_agent_url = dependencies.YOMA_AGENT_URL
+    embedded_api_key = dependencies.EMBEDDED_API_KEY
+    dependencies.ECOSYSTEM_AGENT_URL = "ecosystem-agent-url"
+    dependencies.MEMBER_AGENT_URL = "member-agent-url"
+    dependencies.YOMA_AGENT_URL = "yoma-agent-url"
+    dependencies.EMBEDDED_API_KEY = "test-embedded-api-key"
+    yield
+    dependencies.ECOSYSTEM_AGENT_URL = ecosystem_agent_url
+    dependencies.MEMBER_AGENT_URL = member_agent_url
+    dependencies.YOMA_AGENT_URL = yoma_agent_url
+    dependencies.EMBEDDED_API_KEY = embedded_api_key
+
+
+agent_selector_data = [
+    (dependencies.agent_selector, False, AriesTenantController),
+    (dependencies.admin_agent_selector, True, AriesAgentController),
+]
+
+
+@pytest.mark.parametrize(
+    "dependency_function, is_multitenant, controller_type", agent_selector_data
+)
 @pytest.mark.asyncio
-async def test_member_or_ecosystem_agent():
+async def test_agent_selector(
+    dependency_function, is_multitenant, controller_type, setup_agent_urls_for_testing
+):
     # apologies fro the use of async_next... maybe we should just add the async context manager to these methods
     # even though fastapi does that for us. I'd assume it will play nice if they are already there.
     # then we can at least have a consistency of calling pattern. tests can use as is. WE don't have to wrap.
     # maybe create another ticket to look at this.
     with pytest.raises(HTTPException) as e:
         await async_next(
-            dependencies.ecosystem_or_member_agent(
-                x_api_key="apikey", authorization=TEST_BEARER_HEADER
-            )
+            dependency_function(x_api_key="apikey", authorization=TEST_BEARER_HEADER)
         )
     assert e.value.status_code == 400
     assert e.value.detail == "invalid role"
-    ecosystem_agent_url = dependencies.ECOSYSTEM_AGENT_URL
-    member_agent_url = dependencies.MEMBER_AGENT_URL
-    dependencies.ECOSYSTEM_AGENT_URL = "eco-system-agent-url"
-    dependencies.MEMBER_AGENT_URL = "member-agent-url"
 
     c = await async_next(
-        dependencies.ecosystem_or_member_agent(
+        dependency_function(
             x_api_key="apikey", authorization=TEST_BEARER_HEADER, x_role="ecosystem"
         )
     )
-    assert type(c) == AriesTenantController
-    assert c.admin_url == "eco-system-agent-url"
+    assert type(c) == controller_type
+    assert c.admin_url == "ecosystem-agent-url"
 
     c = await async_next(
-        dependencies.ecosystem_or_member_agent(
+        dependency_function(
             x_api_key="apikey", authorization=TEST_BEARER_HEADER, x_role="member"
         )
     )
-    assert type(c) == AriesTenantController
+    assert type(c) == controller_type
     assert c.admin_url == "member-agent-url"
 
-    dependencies.ECOSYSTEM_AGENT_URL = ecosystem_agent_url
-    dependencies.MEMBER_AGENT_URL = member_agent_url
+    c = await async_next(
+        dependency_function(
+            x_api_key="apikey", authorization=TEST_BEARER_HEADER, x_role="yoma"
+        )
+    )
+    assert type(c) == AriesAgentController
+    assert c.admin_url == "yoma-agent-url"
+
+
+@pytest.mark.asyncio
+async def test_web_ecosystem_or_member(setup_agent_urls_for_testing):
+    # Test adds two methods to the router it creates (/testabc) - called this to make
+    # sure it doesn't interfere with normal operation
+    # this method then saves the injected agent and then the test validates the injected
+    # agent is injected as it expects.
+
+    # a parameterised test might be a better way to go - I'm not sure. Parameterised tests can be quite opaque
+    # sometimes
+
+    router = APIRouter(prefix="/testsabc")
+
+    injected_controller = None
+
+    @router.get("/admin")
+    async def call_admin(
+        aries_controller: AriesAgentControllerBase = Depends(
+            dependencies.admin_agent_selector
+        ),
+    ):
+        nonlocal injected_controller
+        injected_controller = aries_controller
+
+    @router.get("/")
+    async def call(
+        aries_controller: AriesAgentControllerBase = Depends(
+            dependencies.agent_selector
+        ),
+    ):
+        nonlocal injected_controller
+        injected_controller = aries_controller
+
+    app.include_router(router)
+
+    async def make_call(route_suffix="", headers=None):
+        async with AsyncClient(app=app, base_url="http://localhost:8000") as ac:
+            response = await ac.get("/testsabc" + route_suffix, headers={**headers})
+            return response
+
+    # default (non admin) agents
+    # when
+    response = await make_call(headers={})
+    # then
+    assert response.status_code == 422
+    assert (
+        response.text
+        == '{"detail":[{"loc":["header","x-role"],"msg":"field required","type":"value_error.missing"}]}'
+    )
+
+    # when
+    await make_call(
+        headers={
+            "x-role": "yoma",
+            "x-api-key": "ADDASDFDFF",
+        }
+    )
+    # then
+    assert injected_controller.admin_url == dependencies.YOMA_AGENT_URL
+    assert injected_controller.api_key == "ADDASDFDFF"
+    assert type(injected_controller) == AriesAgentController
+
+    # when
+    await make_call(headers={"x-role": "ecosystem", "Authorization": "Bearer X"})
+    # then
+    assert injected_controller.admin_url == dependencies.ECOSYSTEM_AGENT_URL
+    assert injected_controller.tenant_jwt == "X"
+    assert injected_controller.api_key == dependencies.EMBEDDED_API_KEY
+    assert type(injected_controller) == AriesTenantController
+
+    # when
+    await make_call(headers={"x-role": "member", "Authorization": "Bearer Y"})
+    # then
+    assert injected_controller.admin_url == dependencies.MEMBER_AGENT_URL
+    assert injected_controller.tenant_jwt == "Y"
+    assert injected_controller.api_key == dependencies.EMBEDDED_API_KEY
+    assert type(injected_controller) == AriesTenantController
+
+    # admin agents
+    # when
+    response = await make_call(headers={}, route_suffix="/admin")
+    # then
+    assert response.status_code == 422
+    assert (
+        response.text
+        == '{"detail":[{"loc":["header","x-role"],"msg":"field required","type":"value_error.missing"}]}'
+    )
+    # when
+    await make_call(
+        route_suffix="/admin",
+        headers={
+            "x-role": "yoma",
+            "x-api-key": "ADDASDFDFF",
+        },
+    )
+    # then
+    assert injected_controller.admin_url == dependencies.YOMA_AGENT_URL
+    assert injected_controller.api_key == "ADDASDFDFF"
+    assert type(injected_controller) == AriesAgentController
+
+    # when
+    await make_call(
+        route_suffix="/admin",
+        headers={
+            "x-api-key": "provided-api-key",
+            "x-role": "ecosystem",
+            "Authorization": "Bearer X",
+        },
+    )
+    # then
+    assert injected_controller.admin_url == dependencies.ECOSYSTEM_AGENT_URL
+    assert injected_controller.api_key == "provided-api-key"
+    assert type(injected_controller) == AriesAgentController
+
+    # when
+    await make_call(
+        route_suffix="/admin",
+        headers={
+            "x-api-key": "provided-x-api-key-1",
+            "x-role": "member",
+            "Authorization": "Bearer Y",
+        },
+    )
+    # then
+    assert injected_controller.admin_url == dependencies.MEMBER_AGENT_URL
+    assert injected_controller.api_key == "provided-x-api-key-1"
+    assert type(injected_controller) == AriesAgentController
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
So this is a poc at this stage.

It uses the x_role header to switch to the relevant agent.

So not sure if there are existing end points (in development branch) that use a token to authenticate so not sure if I can actually use this new fast api depends function. But suffice to say when the end point is shared the following will be used...


```
@router.get("/shared-endoint", tags=["did"])
async def get_api_call_that_works_on_both_member_and_ecosystem(
    aries_controller: AriesAgentControllerBase = Depends(ecosystem_or_member_agent),
):

```
see other comments inline

UPDATE: promoted from poc - now becomes the real code

