### PR TITLE
added error handler for dealing elegantly with ClientResponseError

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,8 +47,7 @@ def read_openapi_yaml() -> Response:
 async def client_response_error_exception_handler(
     request: Request, exc: ClientResponseError
 ):
-    """
-    This is the handler for handling the ClientResponseError
+    """This is the handler for handling the ClientResponseError
 
     that is the error fired by the aries cloud controller.
     It converts this erro into a nice json response which indicates the status and the

--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,9 @@ def read_openapi_yaml() -> Response:
 
 
 @app.exception_handler(ClientResponseError)
-async def unicorn_exception_handler(request: Request, exc: ClientResponseError):
+async def client_response_error_exception_handler(
+    request: Request, exc: ClientResponseError
+):
     """
     This is the handler for handling the ClientResponseError
 

--- a/app/tests/test_exception_handler.py
+++ b/app/tests/test_exception_handler.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_error_handler(async_client):
+    response = await async_client.get("/admin/wallet-multitenant/query-subwallet")
+    assert response.status_code == 401


### PR DESCRIPTION
ClientResponseError is what is sent back by the arise cloud controller.

Currently we just return 500 when we get an error in cloud controller as we don't handle this exception. This change will modify things so that we do handle this exception elegantly.