### PR TITLE
chore: update cloud-controller to 0.3.2

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.7.4.post0
 appdirs~=1.4.4
-aries-cloudcontroller==0.3.0
+aries-cloudcontroller==0.3.2
 async-timeout==3.0.1
 asyncio==3.4.3
 attrs==21.2.0


### PR DESCRIPTION
No breaking changes but fixes the issues you had with the `-1` validation for revocation and also fixes the fixme's in #165

Signed-off-by: Timo Glastra <timo@animo.id>