### PR TITLE
Remove inital wait/sleep in github actions.

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -30,18 +30,18 @@ jobs:
       - name: Start Test Harness
         run: |
           chmod u+x manage
-          ./manage up-as-daemon
+          ./manage up-daemon-usecache
           i=0
+          echo echo waiting for dockers to startup
           while [ $i -le 2 ]
           do
-            echo echo waiting for dockers to startup
             if (docker logs $(docker ps -f name="yoma-ga-agent" | awk 'FNR == 2 {print $1}') | grep -q "::::::::::::::::::::::::::::::::::::::::::::::
             :: Alice                                    ::
             ::                                          ::
             ::                                          ::
             :: Inbound Transports:                      ::
             ::                                          ::
-            :: "); then ((i++)); echo wait over, continue; exit 0; fi
+            :: "); echo wait over; exit 0; then ((i++)); fi
           done
         shell: bash
       - name: Test with pytest

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -31,9 +31,20 @@ jobs:
         run: |
           chmod u+x manage
           ./manage up-as-daemon
-          echo waiting for dockers to startup, sleeping for 240 seconds
-          sleep 240
+          i=0
+          while [ $i -le 2 ]
+          do
+            echo echo waiting for dockers to startup
+            if (docker logs $(docker ps -f name="yoma-ga-agent" | awk 'FNR == 2 {print $1}') | grep -q "::::::::::::::::::::::::::::::::::::::::::::::
+            :: Alice                                    ::
+            ::                                          ::
+            ::                                          ::
+            :: Inbound Transports:                      ::
+            ::                                          ::
+            :: "); then ((i++)); fi
+          done
           echo wait over, continuing
+          exit 0
         shell: bash
       - name: Test with pytest
         id: test

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ stop_n_clean:
 clean:
 	docker rm $(shell docker ps -a -q)
 
+start_usecache:
+	./manage up-daemon-usecache
+
 .PHONY: start
 start:
 	./manage start

--- a/manage
+++ b/manage
@@ -220,7 +220,6 @@ start | up)
   echoYellow "Starting up... This can take a couple of minutes."
   _startupParams=$(getStartupParams $@)
   configureEnvironment "$@"
-  docker-compose \
   --log-level ERROR up \
   --build --remove-orphans \
   -d ${_startupParams}
@@ -235,6 +234,15 @@ start | up)
   docker-compose \
   --log-level ERROR up \
   --build --remove-orphans --force-recreate\
+  -d ${_startupParams}
+  ;;
+up-daemon-usecache)
+  echoYellow "Starting up... This can take a couple of minutes."
+  _startupParams=$(getStartupParams $@)
+  configureEnvironment "$@"
+  docker-compose \
+  --log-level ERROR up \
+  --build \
   -d ${_startupParams}
   ;;
 restart)


### PR DESCRIPTION
Replace it by checking the logs of one of the aca-py containers for signalling ready.

Best I could come up with for now. That's what works for me on local machine. 

Happy if there are better suggestions. Couldn't find any poll events to look for in particular as suggested in the ticket.

closes #174 