### PR TITLE
ci: do not run on feature branch

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -5,7 +5,7 @@ name: Continuous Build
 
 on:
   push:
-    branches: [development, feature/*, main]
+    branches: [development, main]
   pull_request:
     branches: [development]
   workflow_dispatch:


### PR DESCRIPTION
CI was being run twice for every PR on a branch that starts with feature/*