### PR TITLE
add "pagination" that is rather retrieving a slice of the data.

### DIFF
--- a/trustregistry/main.py
+++ b/trustregistry/main.py
@@ -1,4 +1,6 @@
+from optparse import Option
 from fastapi import FastAPI, Depends
+from typing import Optional
 from sqlalchemy.orm import Session
 import os
 
@@ -7,6 +9,7 @@ from trustregistry import crud
 from trustregistry import models
 from trustregistry.db import get_db
 from trustregistry.database import engine
+from trustregistry.utils import get_data_slice
 
 OPENAPI_NAME = os.getenv("OPENAPI_NAME", "Trust Registry")
 PROJECT_VERSION = os.getenv("PROJECT_VERSION", "0.0.1BETA")
@@ -23,13 +26,21 @@ app.include_router(registry_schemas.router)
 
 
 @app.get("/")
-async def root(db: Session = Depends(get_db)):
+async def root(
+    actor_start: Optional[int] = None,
+    actor_end: Optional[int] = None,
+    schema_start: Optional[int] = None,
+    schema_end: Optional[int] = None,
+    db: Session = Depends(get_db),
+):
     db_schemas = crud.get_schemas(db)
     db_actors = crud.get_actors(db)
     schemas_repr = [schema.id for schema in db_schemas]
-    return {"actors": db_actors, "schemas": schemas_repr}
+    schemas = get_data_slice(schemas_repr, schema_start, schema_end)
+    actors = get_data_slice(db_actors, actor_start, actor_end)
+    return {"actors": actors, "schemas": schemas}
 
 
 @app.get("/registry")
 async def registry(db: Session = Depends(get_db)):
-    return await root(db)
+    return await root(db=db)

--- a/trustregistry/registry/registry_actors.py
+++ b/trustregistry/registry/registry_actors.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 from sqlalchemy.orm import Session
@@ -5,14 +6,20 @@ from sqlalchemy.orm import Session
 from trustregistry import crud
 from trustregistry.db import get_db
 from trustregistry.schemas import Actor
+from trustregistry.utils import get_data_slice
 
 router = APIRouter(prefix="/registry/actors", tags=["actor"])
 
 
 @router.get("/")
-async def get_actors(db: Session = Depends(get_db)):
+async def get_actors(
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    db: Session = Depends(get_db),
+):
     db_actors = crud.get_actors(db)
-    return {"actors": db_actors}
+    data = get_data_slice(db_actors, start, end)
+    return {"actors": data}
 
 
 @router.post("/")

--- a/trustregistry/registry/registry_schemas.py
+++ b/trustregistry/registry/registry_schemas.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from fastapi import APIRouter, HTTPException
 from fastapi.params import Depends
 from sqlalchemy.orm import Session
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from trustregistry import crud
 from trustregistry.db import get_db
 from trustregistry.schemas import Schema
+from trustregistry.utils import get_data_slice
 
 router = APIRouter(prefix="/registry/schemas", tags=["schema"])
 
@@ -20,10 +21,15 @@ class SchemaID(BaseModel):
 
 
 @router.get("/", response_model=GetSchemasResponse)
-async def get_schemas(db: Session = Depends(get_db)) -> GetSchemasResponse:
+async def get_schemas(
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    db: Session = Depends(get_db),
+) -> GetSchemasResponse:
     db_schemas = crud.get_schemas(db)
     schemas_repr = [schema.id for schema in db_schemas]
-    return GetSchemasResponse(schemas=schemas_repr)
+    data = get_data_slice(schemas_repr, start, end)
+    return GetSchemasResponse(schemas=data)
 
 
 @router.post("/")

--- a/trustregistry/utils.py
+++ b/trustregistry/utils.py
@@ -1,0 +1,25 @@
+from typing import List
+
+
+def get_data_slice(data: List, start: int = None, end: int = None):
+    data_entries_total = len(data)
+    if not start:
+        start = 0
+    if not end:
+        end = data_entries_total
+    # Entries must be positive
+    start = abs(start)
+    end = abs(end)
+    range_of_entries = abs(end - start)
+    if start > end:
+        # swap start and end
+        temp = end
+        end = start
+        start = temp
+    if data_entries_total < start or data_entries_total < end:
+        # get the last n entries if range out of bounce
+        end = data_entries_total - 1
+        start = data_entries_total - range_of_entries
+        if start < 0:
+            start = 0
+    return data[start:end]


### PR DESCRIPTION
This helps prevent SWAGGER from freezing when a lot of data is present.

Also tried using https://uriyyo-fastapi-pagination.netlify.app/ but that is not very convenient as 1)it breaks the data return type and also 2) disallows just getting all data by default.

Could also create actual pagination instead where we can say n entries and get page m instead if you prefer that @TimoGlastra ?!

Signed-off-by: morrieinmaas <moritz@animo.id>