### PR TITLE
refactor: combine member and ecosystem roles

### DIFF
--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -32,7 +32,7 @@ class OnboardResult(BaseModel):
     didcomm_invitation: Optional[AnyHttpUrl]
 
 
-async def handle_ecosystem_tenant_update(
+async def handle_tenant_update(
     admin_controller: AcaPyClient,
     tenant_id: str,
     update: UpdateTenantRequest,
@@ -66,7 +66,7 @@ async def handle_ecosystem_tenant_update(
                 wallet_id=tenant_id, body=CreateWalletTokenRequest()
             )
 
-            onboard_result = await onboard_ecosystem_tenant(
+            onboard_result = await onboard_tenant(
                 name=updated_actor["name"],
                 roles=added_roles,
                 tenant_auth_token=token_response.token,
@@ -81,13 +81,13 @@ async def handle_ecosystem_tenant_update(
         await update_actor(updated_actor)
 
 
-async def onboard_ecosystem_tenant(
+async def onboard_tenant(
     *, name: str, roles: List[TrustRegistryRole], tenant_auth_token: str, tenant_id: str
 ) -> OnboardResult:
     if "issuer" in roles:
         # Get governance and tenant controllers, onboard issuer
         async with get_governance_controller() as governance_controller, get_tenant_controller(
-            Role.ECOSYSTEM, tenant_auth_token
+            Role.TENANT, tenant_auth_token
         ) as tenant_controller:
             return await onboard_issuer(
                 name=name,
@@ -98,7 +98,7 @@ async def onboard_ecosystem_tenant(
 
     elif "verifier" in roles:
         async with get_tenant_controller(
-            Role.ECOSYSTEM, tenant_auth_token
+            Role.TENANT, tenant_auth_token
         ) as tenant_controller:
             return await onboard_verifier(
                 name=name, verifier_controller=tenant_controller

--- a/app/admin/tenants/tenants.py
+++ b/app/admin/tenants/tenants.py
@@ -10,7 +10,6 @@ from aries_cloudcontroller import (
     RemoveWalletRequest,
     UpdateWalletRequest,
 )
-from aries_cloudcontroller.model.wallet_record import WalletRecord
 from fastapi import APIRouter, Depends
 
 from app.admin.tenants.models import (
@@ -22,8 +21,8 @@ from app.admin.tenants.models import (
     tenant_from_wallet_record,
 )
 from app.admin.tenants.onboarding import (
-    handle_ecosystem_tenant_update,
-    onboard_ecosystem_tenant,
+    handle_tenant_update,
+    onboard_tenant,
 )
 from app.dependencies import AcaPyAuth, Role, acapy_auth, agent_role
 from app.error import CloudApiException
@@ -33,13 +32,12 @@ from app.facades.trust_registry import (
     register_actor,
     remove_actor_by_id,
 )
-from app.role import AgentType
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/tenants", tags=["admin: tenants"])
 
-multitenant_admin = agent_role([Role.MEMBER_ADMIN, Role.ECOSYSTEM_ADMIN])
+multitenant_admin = agent_role(Role.TENANT_ADMIN)
 
 
 def tenant_api_key(role: Role, tenant_token: str):
@@ -51,52 +49,6 @@ def tenant_api_key(role: Role, tenant_token: str):
     return f"{role.agent_type.tenant_role.name}.{tenant_token}"
 
 
-async def get_tenant_for_admin_role(
-    aries_controller: AcaPyClient, tenant_id: str, role: Role
-) -> WalletRecord:
-    """Get the wallet record for a tenant with specified id.
-
-    Will throw an error if the wallet is not created with same role as
-    role specified in method parameters. This is identified by a role prefix
-    to the wallet name. E.g. wallet name "member.xxxxxxxxxxxxxxxx" means
-    the wallet was created in the context of a member.
-
-    Args:
-        aries_controller (AcaPyClient): aries controller to use
-        tenant_id (str): Tenant id to retrieve the wallet for
-        role (Role): Role the wallet should be in
-
-    Raises:
-        CloudApiException: When the role of the wallet does not match the
-            role from the method parameteres
-
-    Returns:
-        WalletRecord: The wallet record.
-    """
-
-    # We retrieve the wallet to make sure it exists
-    wallet = await aries_controller.multitenancy.get_wallet(wallet_id=tenant_id)
-
-    # This checks if the role of the wallet is in the current context. It would be possible
-    # to retrieve a member wallet while authorized as an ecosystem admin.
-    if not wallet_is_for_admin_role(wallet, role):
-        raise CloudApiException(f"Unauthorized", 401)
-
-    return wallet
-
-
-def wallet_is_for_admin_role(wallet: WalletRecord, role: Role):
-    wallet_name: str = wallet.settings.get("wallet.name")
-
-    tenant_agent_type = role.agent_type.tenant_role
-
-    return wallet_name.startswith(f"{tenant_agent_type.name}.")
-
-
-def get_wallet_name_for_role(agent_type: AgentType) -> str:
-    return f"{agent_type.name}.{uuid4().hex}"
-
-
 @router.post("/", response_model=CreateTenantResponse)
 async def create_tenant(
     body: CreateTenantRequest,
@@ -104,12 +56,6 @@ async def create_tenant(
     auth: AcaPyAuth = Depends(acapy_auth),
 ) -> Tenant:
     """Create a new tenant."""
-    if auth.role == Role.MEMBER_ADMIN and body.roles and len(body.roles) > 0:
-        raise CloudApiException(
-            "Not allowed to provide roles for member tenants, only ecosystem tenants",
-            403,
-        )
-
     tenant_role = auth.role.agent_type.tenant_role
 
     if not tenant_role:
@@ -123,13 +69,13 @@ async def create_tenant(
             key_management_mode="managed",
             label=body.name,
             wallet_key=token_urlsafe(48),
-            wallet_name=get_wallet_name_for_role(tenant_role),
+            wallet_name=uuid4().hex,
             wallet_type="indy",
         )
     )
 
-    if auth.role == Role.ECOSYSTEM_ADMIN and body.roles and len(body.roles) > 0:
-        onboard_result = await onboard_ecosystem_tenant(
+    if body.roles and len(body.roles) > 0:
+        onboard_result = await onboard_tenant(
             name=body.name,
             roles=body.roles,
             tenant_auth_token=wallet_response.token,
@@ -158,16 +104,10 @@ async def create_tenant(
 
 @router.delete("/{tenant_id}")
 async def delete_tenant_by_id(
-    tenant_id: str,
-    aries_controller: AcaPyClient = Depends(multitenant_admin),
-    auth: AcaPyAuth = Depends(acapy_auth),
+    tenant_id: str, aries_controller: AcaPyClient = Depends(multitenant_admin)
 ):
     """Delete tenant by id."""
-    wallet = await get_tenant_for_admin_role(
-        aries_controller=aries_controller,
-        tenant_id=tenant_id,
-        role=auth.role,
-    )
+    wallet = await aries_controller.multitenancy.get_wallet(wallet_id=tenant_id)
 
     # wallet_id is the id of the actor in the trust registry.
     # This makes it a lot easier to link a tenant to an actor
@@ -190,9 +130,7 @@ async def get_tenant_auth_token(
     aries_controller: AcaPyClient = Depends(multitenant_admin),
     auth: AcaPyAuth = Depends(acapy_auth),
 ):
-    wallet = await get_tenant_for_admin_role(
-        aries_controller=aries_controller, tenant_id=tenant_id, role=auth.role
-    )
+    wallet = await aries_controller.multitenancy.get_wallet(wallet_id=tenant_id)
 
     response = await aries_controller.multitenancy.get_auth_token(
         wallet_id=wallet.wallet_id, body=CreateWalletTokenRequest()
@@ -206,21 +144,13 @@ async def update_tenant(
     tenant_id: str,
     body: UpdateTenantRequest,
     aries_controller: AcaPyClient = Depends(multitenant_admin),
-    auth: AcaPyAuth = Depends(acapy_auth),
 ) -> Tenant:
     """Update tenant by id."""
-    wallet = await get_tenant_for_admin_role(
-        aries_controller=aries_controller, tenant_id=tenant_id, role=auth.role
+    wallet = await aries_controller.multitenancy.get_wallet(wallet_id=tenant_id)
+
+    await handle_tenant_update(
+        admin_controller=aries_controller, tenant_id=tenant_id, update=body
     )
-
-    # Only when in ecosystem context we update the trust registry / ecosystem onboarding steps
-    if auth.role == Role.ECOSYSTEM_ADMIN:
-        await handle_ecosystem_tenant_update(
-            admin_controller=aries_controller, tenant_id=tenant_id, update=body
-        )
-
-    elif auth.role == Role.MEMBER_ADMIN and body.roles and len(body.roles) > 0:
-        raise CloudApiException("Roles not allowed for member", 403)
 
     wallet = await aries_controller.multitenancy.update_wallet(
         wallet_id=tenant_id,
@@ -236,7 +166,6 @@ async def update_tenant(
 @router.get("/", response_model=List[Tenant])
 async def get_tenants(
     aries_controller: AcaPyClient = Depends(multitenant_admin),
-    auth: AcaPyAuth = Depends(acapy_auth),
 ) -> List[Tenant]:
 
     """Get tenants."""
@@ -247,21 +176,15 @@ async def get_tenants(
 
     # Only return wallet with current authentication role.
     return [
-        tenant_from_wallet_record(wallet_record)
-        for wallet_record in wallets.results
-        if wallet_is_for_admin_role(wallet_record, auth.role)
+        tenant_from_wallet_record(wallet_record) for wallet_record in wallets.results
     ]
 
 
 @router.get("/{tenant_id}", response_model=Tenant)
 async def get_tenant(
-    tenant_id: str,
-    aries_controller: AcaPyClient = Depends(multitenant_admin),
-    auth: AcaPyAuth = Depends(acapy_auth),
+    tenant_id: str, aries_controller: AcaPyClient = Depends(multitenant_admin)
 ) -> Tenant:
     """Get tenant by id."""
-    wallet = await get_tenant_for_admin_role(
-        aries_controller=aries_controller, tenant_id=tenant_id, role=auth.role
-    )
+    wallet = await aries_controller.multitenancy.get_wallet(wallet_id=tenant_id)
 
     return tenant_from_wallet_record(wallet)

--- a/app/constants.py
+++ b/app/constants.py
@@ -3,11 +3,8 @@ import os
 GOVERNANCE_AGENT_URL = os.getenv("ACAPY_GOVERNANCE_AGENT_URL", "http://localhost:3021")
 GOVERNANCE_AGENT_API_KEY = os.getenv("ACAPY_GOVERNANCE_AGENT_API_KEY", "adminApiKey")
 
-ECOSYSTEM_AGENT_URL = os.getenv("ACAPY_ECOSYSTEM_AGENT_URL", "http://localhost:4021")
-ECOSYSTEM_AGENT_API_KEY = os.getenv("ACAPY_ECOSYSTEM_AGENT_API_KEY", "adminApiKey")
-
-MEMBER_AGENT_URL = os.getenv("ACAPY_MEMBER_AGENT_URL", "http://localhost:4021")
-MEMBER_AGENT_API_KEY = os.getenv("ACAPY_MEMBER_AGENT_API_KEY", "adminApiKey")
+TENANT_AGENT_URL = os.getenv("ACAPY_TENANT_AGENT_URL", "http://localhost:4021")
+TENANT_AGENT_API_KEY = os.getenv("ACAPY_TENANT_AGENT_API_KEY", "adminApiKey")
 
 TRUST_REGISTRY_URL = os.getenv("TRUST_REGISTRY_URL", "http://localhost:8001")
 

--- a/app/generic/definitions.py
+++ b/app/generic/definitions.py
@@ -177,11 +177,7 @@ async def get_credential_definition_by_id(
 @router.post("/credentials", response_model=CredentialDefinition)
 async def create_credential_definition(
     credential_definition: CreateCredentialDefinition,
-    # Only governance and ecosystem issuers can create credential definitions. Further validation
-    # done inside the endpoint implementation.
-    aries_controller: AcaPyClient = Depends(
-        agent_role([Role.GOVERNANCE, Role.ECOSYSTEM])
-    ),
+    aries_controller: AcaPyClient = Depends(agent_selector),
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ):
     """

--- a/app/role.py
+++ b/app/role.py
@@ -2,12 +2,10 @@ from enum import Enum
 from typing import NamedTuple, Optional
 
 from app.constants import (
-    ECOSYSTEM_AGENT_API_KEY,
-    ECOSYSTEM_AGENT_URL,
-    MEMBER_AGENT_API_KEY,
-    MEMBER_AGENT_URL,
     GOVERNANCE_AGENT_API_KEY,
     GOVERNANCE_AGENT_URL,
+    TENANT_AGENT_API_KEY,
+    TENANT_AGENT_URL,
 )
 
 
@@ -29,49 +27,29 @@ GOVERNANCE_AGENT_TYPE = AgentType(
     x_api_key=GOVERNANCE_AGENT_API_KEY,
 )
 
-ECOSYSTEM_AGENT_TYPE = AgentType(
-    name="ecosystem",
-    base_url=ECOSYSTEM_AGENT_URL,
+TENANT_AGENT_TYPE = AgentType(
+    name="tenant",
+    base_url=TENANT_AGENT_URL,
     is_multitenant=True,
     tenant_role=None,
     is_admin=False,
-    x_api_key=ECOSYSTEM_AGENT_API_KEY,
+    x_api_key=TENANT_AGENT_API_KEY,
 )
 
-ECOSYSTEM_ADMIN_AGENT_TYPE = AgentType(
-    name="ecosystem-admin",
-    base_url=ECOSYSTEM_AGENT_URL,
+TENANT_ADMIN_AGENT_TYPE = AgentType(
+    name="tenant-admin",
+    base_url=TENANT_AGENT_URL,
     is_multitenant=True,
-    tenant_role=ECOSYSTEM_AGENT_TYPE,
+    tenant_role=TENANT_AGENT_TYPE,
     is_admin=True,
-    x_api_key=ECOSYSTEM_AGENT_API_KEY,
-)
-
-MEMBER_AGENT_TYPE = AgentType(
-    name="member",
-    base_url=MEMBER_AGENT_URL,
-    is_multitenant=True,
-    tenant_role=None,
-    is_admin=False,
-    x_api_key=MEMBER_AGENT_API_KEY,
-)
-
-MEMBER_ADMIN_AGENT_TYPE = AgentType(
-    name="member-admin",
-    base_url=MEMBER_AGENT_URL,
-    is_multitenant=True,
-    tenant_role=MEMBER_AGENT_TYPE,
-    is_admin=True,
-    x_api_key=MEMBER_AGENT_API_KEY,
+    x_api_key=TENANT_AGENT_API_KEY,
 )
 
 
 class Role(Enum):
     GOVERNANCE = GOVERNANCE_AGENT_TYPE
-    ECOSYSTEM = ECOSYSTEM_AGENT_TYPE
-    ECOSYSTEM_ADMIN = ECOSYSTEM_ADMIN_AGENT_TYPE
-    MEMBER = MEMBER_AGENT_TYPE
-    MEMBER_ADMIN = MEMBER_ADMIN_AGENT_TYPE
+    TENANT = TENANT_AGENT_TYPE
+    TENANT_ADMIN = TENANT_ADMIN_AGENT_TYPE
 
     @staticmethod
     def from_str(role: str) -> Optional["Role"]:

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,12 +1,10 @@
 import pytest
 import mockito
 from app.tests.util.client_fixtures import (
-    member_admin_acapy_client,
-    member_admin_client,
+    tenant_admin_client,
+    tenant_admin_acapy_client,
     governance_acapy_client,
     governance_client,
-    ecosystem_admin_acapy_client,
-    ecosystem_admin_client,
 )
 from app.tests.util.client import get_mock_agent_controller
 from app.tests.util.member_personas import (

--- a/app/tests/e2e/test_trust_registry_integration.py
+++ b/app/tests/e2e/test_trust_registry_integration.py
@@ -2,10 +2,8 @@ from httpx import AsyncClient
 import pytest
 from app.facades.trust_registry import actor_by_id
 from app.tests.util.client import (
-    ecosystem_admin_client,
-    ecosystem_client,
-    member_admin_client,
-    member_client,
+    tenant_client,
+    tenant_admin_client,
 )
 from app.tests.util.string import base64_to_json, get_random_string
 from app.tests.util.tenants import (
@@ -21,18 +19,17 @@ from app.webhook_listener import start_listener
 async def test_accept_proof_request_verifier_no_public_did(
     governance_client: AsyncClient,
 ):
-    ecosystem_admin = ecosystem_admin_client()
-    member_admin = member_admin_client()
+    tenant_admin = tenant_admin_client()
 
     # Create tenants
-    verifier_tenant = await create_verifier_tenant(ecosystem_admin, "acme")
-    issuer_tenant = await create_issuer_tenant(ecosystem_admin, "this-is-it")
-    holder_tenant = await create_tenant(member_admin, "alice")
+    verifier_tenant = await create_verifier_tenant(tenant_admin, "acme")
+    issuer_tenant = await create_issuer_tenant(tenant_admin, "this-is-it")
+    holder_tenant = await create_tenant(tenant_admin, "alice")
 
     # Get clients
-    verifier_client = ecosystem_client(token=verifier_tenant["access_token"])
-    issuer_client = ecosystem_client(token=issuer_tenant["access_token"])
-    holder_client = member_client(token=holder_tenant["access_token"])
+    verifier_client = tenant_client(token=verifier_tenant["access_token"])
+    issuer_client = tenant_client(token=issuer_tenant["access_token"])
+    holder_client = tenant_client(token=holder_tenant["access_token"])
 
     # Create connection between issuer and holder
     invitation = (
@@ -233,6 +230,6 @@ async def test_accept_proof_request_verifier_no_public_did(
     )
 
     # Delete all tenants
-    await delete_tenant(ecosystem_admin, issuer_tenant["tenant_id"])
-    await delete_tenant(ecosystem_admin, verifier_tenant["tenant_id"])
-    await delete_tenant(member_admin, holder_tenant["tenant_id"])
+    await delete_tenant(tenant_admin, issuer_tenant["tenant_id"])
+    await delete_tenant(tenant_admin, verifier_tenant["tenant_id"])
+    await delete_tenant(tenant_admin, holder_tenant["tenant_id"])

--- a/app/tests/test_dependencies.py
+++ b/app/tests/test_dependencies.py
@@ -10,7 +10,7 @@ import app.dependencies as dependencies
 from app.dependencies import Role, AcaPyAuth
 from app.main import app
 
-from app.tests.util.constants import GOVERNANCE_ACAPY_API_KEY
+from app.tests.util.constants import TENANT_ACAPY_API_KEY, GOVERNANCE_ACAPY_API_KEY
 
 TEST_BEARER_HEADER = "Bearer x"
 TEST_BEARER_HEADER_2 = "Bearer Y"
@@ -29,34 +29,23 @@ async def test_governance_agent():
 
 
 @pytest.mark.asyncio
-async def test_ecosystem_agent():
-    async with asynccontextmanager(dependencies.agent_role(Role.ECOSYSTEM))(
-        AcaPyAuth(role=Role.ECOSYSTEM, token=BEARER_TOKEN)
+async def test_tenant_agent():
+    async with asynccontextmanager(dependencies.agent_role(Role.TENANT))(
+        AcaPyAuth(role=Role.TENANT, token=BEARER_TOKEN)
     ) as c:
         assert isinstance(c, AcaPyClient)
-        assert c.base_url == Role.ECOSYSTEM.agent_type.base_url
+        assert c.base_url == Role.TENANT.agent_type.base_url
         assert c.client.headers["Authorization"] == f"Bearer {BEARER_TOKEN}"
-        assert c.client.headers["x-api-key"] == GOVERNANCE_ACAPY_API_KEY
+        assert c.client.headers["x-api-key"] == TENANT_ACAPY_API_KEY
 
 
 @pytest.mark.asyncio
-async def test_member_agent():
-    async with asynccontextmanager(dependencies.agent_role(Role.MEMBER))(
-        AcaPyAuth(role=Role.MEMBER, token=BEARER_TOKEN)
+async def test_tenant_admin_agent():
+    async with asynccontextmanager(dependencies.agent_role(Role.TENANT_ADMIN))(
+        AcaPyAuth(role=Role.TENANT_ADMIN, token=TENANT_ACAPY_API_KEY)
     ) as c:
         assert isinstance(c, AcaPyClient)
-        assert c.base_url == Role.MEMBER.agent_type.base_url
-        assert c.client.headers["Authorization"] == f"Bearer {BEARER_TOKEN}"
-        assert c.client.headers["x-api-key"] == GOVERNANCE_ACAPY_API_KEY
-
-
-@pytest.mark.asyncio
-async def test_member_admin_agent():
-    async with asynccontextmanager(dependencies.agent_role(Role.MEMBER_ADMIN))(
-        AcaPyAuth(role=Role.MEMBER_ADMIN, token=GOVERNANCE_ACAPY_API_KEY)
-    ) as c:
-        assert isinstance(c, AcaPyClient)
-        assert c.client.headers["x-api-key"] == GOVERNANCE_ACAPY_API_KEY
+        assert c.client.headers["x-api-key"] == TENANT_ACAPY_API_KEY
         assert "Authorization" not in c.client.headers
 
 
@@ -76,16 +65,10 @@ agent_selector_data = [
 @pytest.mark.asyncio
 async def test_agent_selector():
     c = await async_next(
-        dependencies.agent_selector(AcaPyAuth(token="apiKey", role=Role.ECOSYSTEM))
+        dependencies.agent_selector(AcaPyAuth(token="apiKey", role=Role.TENANT))
     )
     assert isinstance(c, AcaPyClient)
-    assert c.base_url == Role.ECOSYSTEM.agent_type.base_url
-
-    c = await async_next(
-        dependencies.agent_selector(AcaPyAuth(token="apiKey", role=Role.MEMBER))
-    )
-    assert isinstance(c, AcaPyClient)
-    assert c.base_url == Role.MEMBER.agent_type.base_url
+    assert c.base_url == Role.TENANT.agent_type.base_url
 
     c = await async_next(
         dependencies.agent_selector(AcaPyAuth(token="apiKey", role=Role.GOVERNANCE))
@@ -98,21 +81,11 @@ async def test_agent_selector():
 async def test_admin_agent_selector():
     c = await async_next(
         dependencies.admin_agent_selector(
-            AcaPyAuth(token="apiKey", role=Role.ECOSYSTEM_ADMIN)
+            AcaPyAuth(token="apiKey", role=Role.TENANT_ADMIN)
         )
     )
     assert isinstance(c, AcaPyClient)
-    assert c.base_url == Role.ECOSYSTEM.agent_type.base_url
-    assert c.client.headers["x-api-key"] == "apiKey"
-    assert "Authorization" not in c.client.headers
-
-    c = await async_next(
-        dependencies.admin_agent_selector(
-            AcaPyAuth(token="apiKey", role=Role.MEMBER_ADMIN)
-        )
-    )
-    assert isinstance(c, AcaPyClient)
-    assert c.base_url == Role.MEMBER.agent_type.base_url
+    assert c.base_url == Role.TENANT.agent_type.base_url
     assert c.client.headers["x-api-key"] == "apiKey"
     assert "Authorization" not in c.client.headers
 
@@ -129,13 +102,13 @@ async def test_admin_agent_selector():
     with pytest.raises(fastapi.exceptions.HTTPException):
         await async_next(
             dependencies.admin_agent_selector(
-                AcaPyAuth(token="apiKey", role=Role.MEMBER)
+                AcaPyAuth(token="apiKey", role=Role.TENANT)
             )
         )
 
 
 @pytest.mark.asyncio
-async def test_web_ecosystem_or_member():
+async def test_web_tenant():
     # Test adds two methods to the router it creates (/testabc) - called this to make
     # sure it doesn't interfere with normal operation
     # this method then saves the injected agent and then the test validates the injected
@@ -188,31 +161,16 @@ async def test_web_ecosystem_or_member():
     assert isinstance(injected_controller, AcaPyClient)
 
     # when
-    await make_call(headers={"x-api-key": f"ecosystem.{TEST_BEARER_HEADER}"})
+    await make_call(headers={"x-api-key": f"tenant.{TEST_BEARER_HEADER}"})
     # then
-    assert injected_controller.base_url == Role.ECOSYSTEM.agent_type.base_url
+    assert injected_controller.base_url == Role.TENANT.agent_type.base_url
     assert (
         injected_controller.client.headers["Authorization"]
         == f"Bearer {TEST_BEARER_HEADER}"
     )
     assert (
         injected_controller.client.headers["x-api-key"]
-        == Role.ECOSYSTEM.agent_type.x_api_key
-    )
-    assert isinstance(injected_controller, AcaPyClient)
-
-    # when
-    response = await make_call(headers={"x-api-key": f"member.{TEST_BEARER_HEADER_2}"})
-    # then
-    assert response.status_code == 200
-    assert injected_controller.base_url == Role.MEMBER.agent_type.base_url
-    assert (
-        injected_controller.client.headers["Authorization"]
-        == f"Bearer {TEST_BEARER_HEADER_2}"
-    )
-    assert (
-        injected_controller.client.headers["x-api-key"]
-        == Role.MEMBER.agent_type.x_api_key
+        == Role.TENANT.agent_type.x_api_key
     )
     assert isinstance(injected_controller, AcaPyClient)
 
@@ -245,32 +203,19 @@ async def test_web_ecosystem_or_member():
     await make_call(
         route_suffix="/admin",
         headers={
-            "x-api-key": "ecosystem-admin.provided-api-key",
+            "x-api-key": "tenant-admin.provided-api-key",
         },
     )
     # then
-    assert injected_controller.base_url == Role.ECOSYSTEM.agent_type.base_url
+    assert injected_controller.base_url == Role.TENANT.agent_type.base_url
     assert injected_controller.client.headers["x-api-key"] == "provided-api-key"
-    assert isinstance(injected_controller, AcaPyClient)
-
-    # when
-    response = await make_call(
-        route_suffix="/admin",
-        headers={
-            "x-api-key": "member-admin.provided-x-api-key-1",
-        },
-    )
-    # then
-    assert response.status_code == 200
-    assert injected_controller.base_url == Role.MEMBER.agent_type.base_url
-    assert injected_controller.client.headers["x-api-key"] == "provided-x-api-key-1"
     assert isinstance(injected_controller, AcaPyClient)
 
 
 @pytest.mark.asyncio
-async def test_ecosystem_admin_agent():
-    async with asynccontextmanager(dependencies.agent_role(role=Role.ECOSYSTEM_ADMIN))(
-        auth=AcaPyAuth(role=Role.ECOSYSTEM_ADMIN, token=GOVERNANCE_ACAPY_API_KEY)
+async def test_tenant_admin_agent():
+    async with asynccontextmanager(dependencies.agent_role(role=Role.TENANT_ADMIN))(
+        auth=AcaPyAuth(role=Role.TENANT_ADMIN, token=TENANT_ACAPY_API_KEY)
     ) as c:
         assert isinstance(c, AcaPyClient)
         assert c.client.headers["x-api-key"] == "adminApiKey"

--- a/app/tests/test_dependencies.py
+++ b/app/tests/test_dependencies.py
@@ -39,16 +39,6 @@ async def test_tenant_agent():
         assert c.client.headers["x-api-key"] == TENANT_ACAPY_API_KEY
 
 
-@pytest.mark.asyncio
-async def test_tenant_admin_agent():
-    async with asynccontextmanager(dependencies.agent_role(Role.TENANT_ADMIN))(
-        AcaPyAuth(role=Role.TENANT_ADMIN, token=TENANT_ACAPY_API_KEY)
-    ) as c:
-        assert isinstance(c, AcaPyClient)
-        assert c.client.headers["x-api-key"] == TENANT_ACAPY_API_KEY
-        assert "Authorization" not in c.client.headers
-
-
 async def async_next(param):
     async for item in param:
         return item
@@ -219,3 +209,4 @@ async def test_tenant_admin_agent():
     ) as c:
         assert isinstance(c, AcaPyClient)
         assert c.client.headers["x-api-key"] == "adminApiKey"
+        assert "Authorization" not in c.client.headers

--- a/app/tests/util/client.py
+++ b/app/tests/util/client.py
@@ -17,17 +17,14 @@ from httpx import AsyncClient, AsyncHTTPTransport
 from mockito import mock
 
 from .constants import (
-    ECOSYSTEM_FASTAPI_ENDPOINT,
     GOVERNANCE_FASTAPI_ENDPOINT,
     GOVERNANCE_ACAPY_API_KEY,
-    MEMBER_FASTAPI_ENDPOINT,
-    MEMBER_ACAPY_API_KEY,
+    TENANT_ACAPY_API_KEY,
+    TENANT_FASTAPI_ENDPOINT,
 )
 from app.constants import (
-    ECOSYSTEM_AGENT_API_KEY,
-    ECOSYSTEM_AGENT_URL,
     GOVERNANCE_AGENT_URL,
-    MEMBER_AGENT_URL,
+    TENANT_AGENT_URL,
 )
 
 # GOVERNANCE
@@ -69,35 +66,35 @@ def governance_acapy_client():
     )
 
 
-# MEMBER ADMIN
+# TENANT ADMIN
 
 
-def member_admin_client(*, app: Optional[Any] = None):
+def tenant_admin_client(*, app: Optional[Any] = None):
     return AsyncClient(
-        base_url=MEMBER_FASTAPI_ENDPOINT,
+        base_url=TENANT_FASTAPI_ENDPOINT,
         timeout=60.0,
         app=app,
         headers={
-            "x-api-key": f"member-admin.{MEMBER_ACAPY_API_KEY}",
+            "x-api-key": f"tenant-admin.{TENANT_ACAPY_API_KEY}",
             "content-type": "application/json",
         },
         transport=AsyncHTTPTransport(retries=3),
     )
 
 
-def member_admin_acapy_client():
+def tenant_admin_acapy_client():
     return AcaPyClient(
-        base_url=MEMBER_AGENT_URL,
-        api_key=MEMBER_ACAPY_API_KEY,
+        base_url=TENANT_AGENT_URL,
+        api_key=TENANT_ACAPY_API_KEY,
     )
 
 
-# MEMBER
+# TENANT
 
 
-def member_client(*, token: str, app: Optional[Any] = None):
+def tenant_client(*, token: str, app: Optional[Any] = None):
     return AsyncClient(
-        base_url=MEMBER_FASTAPI_ENDPOINT,
+        base_url=TENANT_FASTAPI_ENDPOINT,
         timeout=60.0,
         app=app,
         headers={
@@ -107,47 +104,7 @@ def member_client(*, token: str, app: Optional[Any] = None):
     )
 
 
-def member_acapy_client(*, token: str):
+def tenant_acapy_client(*, token: str):
     return AcaPyClient(
-        base_url=MEMBER_AGENT_URL, api_key=MEMBER_ACAPY_API_KEY, tenant_jwt=token
-    )
-
-
-# ECOSYSTEM ADMIN
-
-
-def ecosystem_admin_client(*, app: Optional[Any] = None):
-    return AsyncClient(
-        base_url=ECOSYSTEM_FASTAPI_ENDPOINT,
-        timeout=60.0,
-        app=app,
-        headers={
-            "x-api-key": f"ecosystem-admin.{ECOSYSTEM_AGENT_API_KEY}",
-            "content-type": "application/json",
-        },
-    )
-
-
-def ecosystem_admin_acapy_client():
-    return AcaPyClient(
-        base_url=ECOSYSTEM_AGENT_URL,
-        api_key=ECOSYSTEM_AGENT_API_KEY,
-    )
-
-
-def ecosystem_client(*, token: str, app: Optional[Any] = None):
-    return AsyncClient(
-        base_url=ECOSYSTEM_FASTAPI_ENDPOINT,
-        timeout=60.0,
-        app=app,
-        headers={
-            "x-api-key": token,
-            "content-type": "application/json",
-        },
-    )
-
-
-def ecosystem_acapy_client(*, token: str):
-    return AcaPyClient(
-        base_url=ECOSYSTEM_AGENT_URL, api_key=ECOSYSTEM_AGENT_API_KEY, tenant_jwt=token
+        base_url=TENANT_AGENT_URL, api_key=TENANT_ACAPY_API_KEY, tenant_jwt=token
     )

--- a/app/tests/util/client_fixtures.py
+++ b/app/tests/util/client_fixtures.py
@@ -3,10 +3,8 @@ import pytest
 from app.tests.util.client import (
     governance_client as _governance_client,
     governance_acapy_client as _governance_acapy_client,
-    member_admin_client as _member_admin_client,
-    member_admin_acapy_client as _member_admin_acapy_client,
-    ecosystem_admin_client as _ecosystem_admin_client,
-    ecosystem_admin_acapy_client as _ecosystem_admin_acapy_client,
+    tenant_admin_client as _tenant_admin_client,
+    tenant_admin_acapy_client as _tenant_admin_acapy_client,
 )
 
 # governance
@@ -26,35 +24,18 @@ async def governance_client():
         yield client
 
 
-# MEMBER ADMIN
+# TENANT ADMIN
 
 
 @pytest.yield_fixture(scope="module")
-async def member_admin_client():
-    async with _member_admin_client() as client:
+async def tenant_admin_client():
+    async with _tenant_admin_client() as client:
         yield client
 
 
 @pytest.yield_fixture(scope="module")
-async def member_admin_acapy_client():
-    client = _member_admin_acapy_client()
-    yield client
-
-    await client.close()
-
-
-# Ecosystem Admin
-
-
-@pytest.yield_fixture(scope="module")
-async def ecosystem_admin_client():
-    async with _ecosystem_admin_client() as client:
-        yield client
-
-
-@pytest.yield_fixture(scope="module")
-async def ecosystem_admin_acapy_client():
-    client = _ecosystem_admin_acapy_client()
+async def tenant_admin_acapy_client():
+    client = _tenant_admin_acapy_client()
     yield client
 
     await client.close()

--- a/app/tests/util/constants.py
+++ b/app/tests/util/constants.py
@@ -1,11 +1,9 @@
 GOVERNANCE_FASTAPI_ENDPOINT = "http://localhost:8000"
 GOVERNANCE_ACAPY_API_KEY = "adminApiKey"
 
-MEMBER_FASTAPI_ENDPOINT = "http://localhost:8100"
-MEMBER_ACAPY_API_KEY = "adminApiKey"
 
-ECOSYSTEM_FASTAPI_ENDPOINT = "http://localhost:8100"
-ECOSYSTEM_ACAPY_API_KEY = "adminApiKey"
+TENANT_FASTAPI_ENDPOINT = "http://localhost:8100"
+TENANT_ACAPY_API_KEY = "adminApiKey"
 
 LEDGER_REGISTRATION_URL = "http://localhost:9000/register"
 LEDGER_TYPE: str = "von"

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -5,9 +5,9 @@ from httpx import AsyncClient
 from app.facades.trust_registry import actor_by_id
 
 from app.tests.util.client import (
-    ecosystem_admin_client,
-    ecosystem_client,
-    ecosystem_acapy_client,
+    tenant_admin_client,
+    tenant_acapy_client,
+    tenant_client,
 )
 from app.tests.util.string import base64_to_json
 from app.webhook_listener import start_listener
@@ -28,13 +28,13 @@ class AcmeAliceConnect(TypedDict):
 
 @pytest.fixture(scope="module")
 async def faber_client():
-    async with ecosystem_admin_client() as client:
+    async with tenant_admin_client() as client:
         tenant = await create_issuer_tenant(client, "faber")
 
         if "access_token" not in tenant:
             raise Exception("Error creating tenant", tenant)
 
-        yield ecosystem_client(token=tenant["access_token"])
+        yield tenant_client(token=tenant["access_token"])
 
         await delete_tenant(client, tenant["tenant_id"])
 
@@ -45,7 +45,7 @@ async def faber_acapy_client(faber_client: AsyncClient):
     # method to create an AcaPyClient from an AsyncClient
     [_, token] = faber_client.headers.get("x-api-key").split(".", maxsplit=1)
 
-    client = ecosystem_acapy_client(token=token)
+    client = tenant_acapy_client(token=token)
     yield client
 
     await client.close()
@@ -53,7 +53,7 @@ async def faber_acapy_client(faber_client: AsyncClient):
 
 @pytest.fixture(scope="module")
 async def acme_tenant():
-    async with ecosystem_admin_client() as client:
+    async with tenant_admin_client() as client:
         tenant = await create_verifier_tenant(client, "acme")
 
         if "access_token" not in tenant:
@@ -66,7 +66,7 @@ async def acme_tenant():
 
 @pytest.fixture(scope="module")
 async def acme_client(acme_tenant: Any):
-    yield ecosystem_client(token=acme_tenant["access_token"])
+    yield tenant_client(token=acme_tenant["access_token"])
 
 
 @pytest.fixture(scope="module")
@@ -75,7 +75,7 @@ async def acme_acapy_client(faber_client: AsyncClient):
     # method to create an AcaPyClient from an AsyncClient
     [_, token] = faber_client.headers.get("x-api-key").split(".", maxsplit=1)
 
-    client = ecosystem_acapy_client(token=token)
+    client = tenant_acapy_client(token=token)
     yield client
 
     await client.close()

--- a/app/tests/util/member_personas.py
+++ b/app/tests/util/member_personas.py
@@ -7,9 +7,9 @@ from httpx import AsyncClient
 from app.generic.verifier.verifier_utils import ed25519_verkey_to_did_key
 
 from app.tests.util.client import (
-    member_acapy_client,
-    member_admin_client,
-    member_client,
+    tenant_acapy_client,
+    tenant_admin_client,
+    tenant_client,
 )
 from app.tests.util.ledger import create_public_did
 from app.generic.connections.connections import CreateInvitation
@@ -30,17 +30,17 @@ class BobAlicePublicDid(TypedDict):
 
 @pytest.fixture(scope="module")
 async def bob_member_client():
-    async with member_admin_client() as client:
+    async with tenant_admin_client() as client:
         tenant = await create_tenant(client, "bob")
 
-        yield member_client(token=tenant["access_token"])
+        yield tenant_client(token=tenant["access_token"])
 
         await delete_tenant(client, tenant["tenant_id"])
 
 
 @pytest.fixture(scope="module")
 async def alice_tenant():
-    async with member_admin_client() as client:
+    async with tenant_admin_client() as client:
         tenant = await create_tenant(client, "alice")
 
         yield tenant
@@ -50,7 +50,7 @@ async def alice_tenant():
 
 @pytest.fixture(scope="module")
 async def alice_member_client(alice_tenant: Any):
-    yield member_client(token=alice_tenant["access_token"])
+    yield tenant_client(token=alice_tenant["access_token"])
 
 
 @pytest.fixture(scope="module")
@@ -59,7 +59,7 @@ async def bob_acapy_client(bob_member_client: AsyncClient):
     # method to create an AcaPyClient from an AsyncClient
     [_, token] = bob_member_client.headers.get("x-api-key").split(".", maxsplit=1)
 
-    client = member_acapy_client(token=token)
+    client = tenant_acapy_client(token=token)
     yield client
 
     await client.close()
@@ -69,7 +69,7 @@ async def bob_acapy_client(bob_member_client: AsyncClient):
 async def alice_acapy_client(alice_member_client: AsyncClient):
     [_, token] = alice_member_client.headers.get("x-api-key").split(".", maxsplit=1)
 
-    client = member_acapy_client(token=token)
+    client = tenant_acapy_client(token=token)
     yield client
 
     await client.close()

--- a/app/tests/util/tenants.py
+++ b/app/tests/util/tenants.py
@@ -3,11 +3,11 @@ from httpx import AsyncClient
 from .string import get_random_string
 
 
-async def create_issuer_tenant(ecosystem_admin_client: AsyncClient, name: str):
+async def create_issuer_tenant(tenant_admin_client: AsyncClient, name: str):
     full_name = f"{name}{get_random_string(3)}"
     wallet_payload = {"name": full_name, "roles": ["issuer"]}
 
-    wallet_response = await ecosystem_admin_client.post(
+    wallet_response = await tenant_admin_client.post(
         "/admin/tenants", json=wallet_payload
     )
 
@@ -19,11 +19,11 @@ async def create_issuer_tenant(ecosystem_admin_client: AsyncClient, name: str):
     return wallet
 
 
-async def create_verifier_tenant(ecosystem_admin_client: AsyncClient, name: str):
+async def create_verifier_tenant(tenant_admin_client: AsyncClient, name: str):
     full_name = f"{name}{get_random_string(3)}"
     wallet_payload = {"name": full_name, "roles": ["verifier"]}
 
-    wallet_response = await ecosystem_admin_client.post(
+    wallet_response = await tenant_admin_client.post(
         "/admin/tenants", json=wallet_payload
     )
 
@@ -35,14 +35,14 @@ async def create_verifier_tenant(ecosystem_admin_client: AsyncClient, name: str)
     return wallet
 
 
-async def create_tenant(member_admin_client: AsyncClient, name: str):
+async def create_tenant(tenant_admin_client: AsyncClient, name: str):
     full_name = f"{name}{get_random_string(3)}"
     wallet_payload = {
         "image_url": "https://aries.ca/images/sample.png",
         "name": full_name,
     }
 
-    wallet_response = await member_admin_client.post(
+    wallet_response = await tenant_admin_client.post(
         "/admin/tenants", json=wallet_payload
     )
     wallet = wallet_response.json()

--- a/environments/governance-ga/fastapi.default.env
+++ b/environments/governance-ga/fastapi.default.env
@@ -1,11 +1,8 @@
 ACAPY_GOVERNANCE_AGENT_URL=http://governance-ga-agent:3021
 ACAPY_GOVERNANCE_AGENT_API_KEY=adminApiKey
 
-ACAPY_ECOSYSTEM_AGENT_URL=http://governance-multitenant-agent:3021
-ACAPY_ECOSYSTEM_AGENT_API_KEY=adminApiKey
-
-ACAPY_MEMBER_AGENT_URL=http://governance-multitenant-agent:3021
-ACAPY_MEMBER_AGENT_API_KEY=adminApiKey
+ACAPY_TENANT_AGENT_URL=http://governance-multitenant-agent:3021
+ACAPY_TENANT_AGENT_API_KEY=adminApiKey
 
 ACAPY_MULTITENANT_JWT_SECRET=jwtSecret
 

--- a/environments/governance-multitenant/fastapi.default.env
+++ b/environments/governance-multitenant/fastapi.default.env
@@ -1,11 +1,8 @@
 ACAPY_GOVERNANCE_AGENT_URL=http://governance-ga-agent:3021
 ACAPY_GOVERNANCE_AGENT_API_KEY=adminApiKey
 
-ACAPY_ECOSYSTEM_AGENT_URL=http://governance-multitenant-agent:3021
-ACAPY_ECOSYSTEM_AGENT_API_KEY=adminApiKey
-
-ACAPY_MEMBER_AGENT_URL=http://governance-multitenant-agent:3021
-ACAPY_MEMBER_AGENT_API_KEY=adminApiKey
+ACAPY_TENANT_AGENT_URL=http://governance-multitenant-agent:3021
+ACAPY_TENANT_AGENT_API_KEY=adminApiKey
 
 ACAPY_MULTITENANT_JWT_SECRET=jwtSecret
 

--- a/webhooks/main.py
+++ b/webhooks/main.py
@@ -99,7 +99,7 @@ async def topic_root(
     #  - topic of the event
     #  - 'all' topic, which allows to subscribe to all published events
     # FIXME: wallet_id is admin for all admin wallets from different origins. We should make a difference on this
-    # Maybe the wallet id should be the role (governance, ecosystem-admin, member-admin)?
+    # Maybe the wallet id should be the role (governance, tenant-admin)?
     await endpoint.publish(
         topics=[topic, redis_item["wallet_id"], WEBHOOK_TOPIC_ALL],
         data=webhook_event.json(),


### PR DESCRIPTION
Combines the member and ecosystem roles into a single tenant role. Permissions are determined by the trust registry rules. 


Nest step is extracting the trust registry  / yoma specific code into a separate module. I'd like to have a discussion about this friday as there's a few approaches we could take here with different implications.