### PR TITLE
added dos2unix hack to agent dockerfile for windows builds

### DIFF
--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -1,20 +1,22 @@
 FROM bcgovimages/von-image:py36-1.16-0
-#FROM bcgovimages/aries-cloudagent:py36-1.15-1_0.6.0
-
 
 USER root
 RUN apt-get update
 RUN apt-get update && apt-get install -y gcc
 
-
 RUN pip3 install aries-cloudagent[askar]==0.7.3
+
+# TBC: hack for building on windows platforms (to be confirmed working on linux)
+RUN apt-get install dos2unix
 
 ADD https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 ./jq
 RUN chmod +x ./jq
-COPY scripts/startup.sh startup.sh
+COPY scripts/startup.sh ./startup.sh
+
+# TBC: hack for building on windows platforms (to be confirmed working on linux)
+RUN dos2unix ./startup.sh
+
 RUN chmod +x ./startup.sh
-# COPY scripts/ngrok-wait.sh wait.sh
-# RUN chmod +x ./wait.sh
 
 USER $user
 


### PR DESCRIPTION
On a Windows machine, I received the following error on container startup:

/bin/sh: 1: ./startup.sh: not found

To resolve this, I added a 'dos2unix' step in the agent dockerfile. Please confirm working on linux machines.