### PR TITLE
Improve webhooks + listener implementation

### DIFF
--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -174,7 +174,8 @@ async def onboard_issuer(
                 }
             )
         except TimeoutError:
-            raise CloudApiException("Error creating connection with endorser", 500)
+            raise CloudApiException(
+                "Error creating connection with endorser", 500)
         finally:
             listener_transaction.stop()
 
@@ -222,7 +223,8 @@ async def onboard_issuer(
                 }
             )
         except TimeoutError:
-            raise CloudApiException("Error creating connection with endorser", 500)
+            raise CloudApiException(
+                "Error creating connection with endorser", 500)
         finally:
             listener_transaction.stop()
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -26,8 +26,9 @@ class OnboardResult(BaseModel):
     did: str
     didcomm_invitation: Optional[AnyHttpUrl]
 
-# Helper method for passing MockListener to class
+
 def _create_listener(self, topic: str, wallet_id: str) -> Listener:
+    # Helper method for passing MockListener to class
     return Listener(topic=topic, wallet_id=wallet_id)
 
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -227,9 +227,9 @@ async def onboard_issuer(
                     "state": "request-received",
                 }
             )
-        except TimeoutError:
+        except TimeoutError as e:
             raise CloudApiException(
-                "Error creating connection with endorser", 500)
+                "Error creating connection with endorser", 500) from e
         finally:
             endorsements_listener.stop()
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -1,28 +1,23 @@
 import logging
-from typing import Optional, List
-from aries_cloudcontroller import (
-    AcaPyClient,
-    InvitationCreateRequest,
-)
-from aries_cloudcontroller.model.create_wallet_token_request import (
-    CreateWalletTokenRequest,
-)
+from typing import List, Optional
+
+from aries_cloudcontroller import AcaPyClient, InvitationCreateRequest
+from aries_cloudcontroller.model.create_wallet_token_request import \
+    CreateWalletTokenRequest
 from fastapi.exceptions import HTTPException
 from pydantic import BaseModel
 from pydantic.networks import AnyHttpUrl
-from app.admin.tenants.models import UpdateTenantRequest
-from app.dependencies import Role, get_tenant_controller, get_governance_controller
-from app.facades.trust_registry import (
-    TrustRegistryRole,
-    actor_by_id,
-    update_actor,
-)
-from app.constants import ACAPY_ENDORSER_ALIAS
-from app.util.did import qualified_did_sov
-from app.webhook_listener import start_listener
 
+from app.admin.tenants.models import UpdateTenantRequest
+from app.constants import ACAPY_ENDORSER_ALIAS
+from app.dependencies import (Role, get_governance_controller,
+                              get_tenant_controller)
 from app.error import CloudApiException
 from app.facades import acapy_ledger, acapy_wallet
+from app.facades.trust_registry import (TrustRegistryRole, actor_by_id,
+                                        update_actor)
+from app.listener import Listener
+from app.util.did import qualified_did_sov
 
 logger = logging.getLogger(__name__)
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -27,7 +27,7 @@ class OnboardResult(BaseModel):
     didcomm_invitation: Optional[AnyHttpUrl]
 
 
-def _create_listener(topic: str, wallet_id: str) -> Listener:
+def create_listener(topic: str, wallet_id: str) -> Listener:
     # Helper method for passing MockListener to class
     return Listener(topic=topic, wallet_id=wallet_id)
 
@@ -147,11 +147,11 @@ async def onboard_issuer(
             f"Starting webhook listener for connections with wallet id {issuer_wallet_id}"
         )
 
-        connections_listener = _create_listener(
+        connections_listener = create_listener(
             topic="connections", wallet_id="admin"
         )
 
-        endorsements_listener = _create_listener(
+        endorsements_listener = create_listener(
             topic="endorsements", wallet_id="admin"
         )
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -178,9 +178,9 @@ async def onboard_issuer(
                     "state": "completed",
                 }
             )
-        except TimeoutError:
+        except TimeoutError as e:
             raise CloudApiException(
-                "Error creating connection with endorser", 500)
+                "Error creating connection with endorser", 500) from e
         finally:
             connections_listener.stop()
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -182,7 +182,7 @@ async def onboard_issuer(
             raise CloudApiException(
                 "Error creating connection with endorser", 500)
         finally:
-            endorsements_listener.stop()
+            connections_listener.stop()
 
         logger.debug("Successfully created connection")
 

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -27,7 +27,7 @@ class OnboardResult(BaseModel):
     didcomm_invitation: Optional[AnyHttpUrl]
 
 
-def _create_listener(self, topic: str, wallet_id: str) -> Listener:
+def _create_listener(topic: str, wallet_id: str) -> Listener:
     # Helper method for passing MockListener to class
     return Listener(topic=topic, wallet_id=wallet_id)
 

--- a/app/facades/revocation_registry.py
+++ b/app/facades/revocation_registry.py
@@ -300,7 +300,7 @@ async def endorser_revoke():
                 "Failed to retrieve transaction record for endorser", 500
             )
         finally:
-            await listener.stop()
+            listener.stop()
 
         await endorser_controller.endorse_transaction.endorse_transaction(
             tran_id=txn_record["transaction_id"]

--- a/app/facades/revocation_registry.py
+++ b/app/facades/revocation_registry.py
@@ -255,7 +255,8 @@ async def revoke_credential(
             )
         )
     except ClientResponseError as e:
-        raise CloudApiException(f"Failed to revoke credential.{e.message}", 418)
+        raise CloudApiException(
+            f"Failed to revoke credential.{e.message}", 418)
 
     if not auto_publish_to_ledger:
         active_revocation_registry_id = (

--- a/app/facades/revocation_registry.py
+++ b/app/facades/revocation_registry.py
@@ -1,23 +1,16 @@
 import logging
 from typing import Optional, Union
+
 from aiohttp import ClientResponseError
+from aries_cloudcontroller import (AcaPyClient, CredRevRecordResult,
+                                   IssuerCredRevRecord, IssuerRevRegRecord,
+                                   RevokeRequest, RevRegCreateRequest,
+                                   RevRegResult, TransactionRecord,
+                                   TxnOrRevRegResult)
 
-from aries_cloudcontroller import (
-    AcaPyClient,
-    CredRevRecordResult,
-    IssuerCredRevRecord,
-    IssuerRevRegRecord,
-    RevRegCreateRequest,
-    RevRegResult,
-    RevokeRequest,
-    TransactionRecord,
-    TxnOrRevRegResult,
-)
 from app.dependencies import get_governance_controller
-
 from app.error.cloud_api_error import CloudApiException
-from app.webhook_listener import start_listener
-
+from app.listener import Listener
 
 logger = logging.getLogger(__name__)
 

--- a/app/facades/revocation_registry.py
+++ b/app/facades/revocation_registry.py
@@ -285,12 +285,12 @@ async def revoke_credential(
 
 
 async def endorser_revoke():
-    endorser_wait_for_transaction, stop_listener = await start_listener(
+    listener = Listener(
         topic="endorsements", wallet_id="admin"
     )
     async with get_governance_controller() as endorser_controller:
         try:
-            txn_record = await endorser_wait_for_transaction(
+            txn_record = await listener.wait_for_filtered_event(
                 filter_map={
                     "state": "request-received",
                 }
@@ -300,7 +300,7 @@ async def endorser_revoke():
                 "Failed to retrieve transaction record for endorser", 500
             )
         finally:
-            await stop_listener()
+            await listener.stop()
 
         await endorser_controller.endorse_transaction.endorse_transaction(
             tran_id=txn_record["transaction_id"]

--- a/app/generic/definitions.py
+++ b/app/generic/definitions.py
@@ -229,7 +229,7 @@ async def create_credential_definition(
                 "Timeout waiting for endorser to accept the endorsement request"
             )
         finally:
-            await listener.stop()
+            listener.stop()
 
         try:
             transaction = await aries_controller.endorse_transaction.get_transaction(
@@ -301,7 +301,7 @@ async def create_credential_definition(
                             "Failed to retrieve transaction record for endorser", 500
                         )
                     finally:
-                        await admin_listener.stop()
+                        admin_listener.stop()
 
                     await endorser_controller.endorse_transaction.endorse_transaction(
                         tran_id=txn_record["transaction_id"]

--- a/app/generic/definitions.py
+++ b/app/generic/definitions.py
@@ -1,38 +1,29 @@
 import asyncio
 import json
 from typing import List, Optional
-from aiohttp import ClientResponseError
 
-from aries_cloudcontroller import (
-    AcaPyClient,
-    CredentialDefinition as AcaPyCredentialDefinition,
-    ModelSchema,
-    RevRegUpdateTailsFileUri,
-    SchemaSendRequest,
-    TxnOrCredentialDefinitionSendResult,
-)
-from app.constants import ACAPY_ENDORSER_ALIAS, ACAPY_TAILS_SERVER_BASE_URL
-from app.error.cloud_api_error import CloudApiException
-from aries_cloudcontroller.model.credential_definition_send_request import (
-    CredentialDefinitionSendRequest,
-)
+from aiohttp import ClientResponseError
+from aries_cloudcontroller import AcaPyClient
+from aries_cloudcontroller import \
+    CredentialDefinition as AcaPyCredentialDefinition
+from aries_cloudcontroller import (ModelSchema, RevRegUpdateTailsFileUri,
+                                   SchemaSendRequest,
+                                   TxnOrCredentialDefinitionSendResult)
+from aries_cloudcontroller.model.credential_definition_send_request import \
+    CredentialDefinitionSendRequest
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from app.dependencies import (
-    AcaPyAuthVerified,
-    acapy_auth_verified,
-    agent_role,
-    agent_selector,
-    get_governance_controller,
-)
+from app.constants import ACAPY_ENDORSER_ALIAS, ACAPY_TAILS_SERVER_BASE_URL
+from app.dependencies import (AcaPyAuthVerified, acapy_auth_verified,
+                              agent_role, agent_selector,
+                              get_governance_controller)
+from app.error.cloud_api_error import CloudApiException
+from app.facades import acapy_wallet, trust_registry
 from app.facades.revocation_registry import (
-    create_revocation_registry,
-    publish_revocation_registry_on_ledger,
-)
+    create_revocation_registry, publish_revocation_registry_on_ledger)
+from app.listener import Listener
 from app.role import Role
-from app.facades import trust_registry, acapy_wallet
-from app.webhook_listener import start_listener
 
 router = APIRouter(
     prefix="/generic/definitions",

--- a/app/generic/definitions.py
+++ b/app/generic/definitions.py
@@ -33,7 +33,8 @@ router = APIRouter(
 
 class CreateCredentialDefinition(BaseModel):
     tag: str = Field(..., example="default")
-    schema_id: str = Field(..., example="CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3")
+    schema_id: str = Field(...,
+                           example="CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3")
     support_revocation: bool = Field(default=True)
     revocation_registry_size: int = Field(default=32767)
 
@@ -41,7 +42,8 @@ class CreateCredentialDefinition(BaseModel):
 class CredentialDefinition(BaseModel):
     id: str = Field(..., example="5Q1Zz9foMeAA8Q7mrmzCfZ:3:CL:7:default")
     tag: str = Field(..., example="default")
-    schema_id: str = Field(..., example="CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3")
+    schema_id: str = Field(...,
+                           example="CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3")
 
 
 class CreateSchema(BaseModel):
@@ -124,7 +126,8 @@ async def get_credential_definitions(
         *get_credential_definition_futures
     )
     credential_definitions = [
-        _credential_definition_from_acapy(credential_definition.credential_definition)
+        _credential_definition_from_acapy(
+            credential_definition.credential_definition)
         for credential_definition in credential_definition_results
         if credential_definition.credential_definition
     ]

--- a/app/listener.py
+++ b/app/listener.py
@@ -1,8 +1,11 @@
 import asyncio
+import logging
 from typing import Any, Dict, Optional
 
 from app.webhooks import Webhooks
 from shared_models import CloudApiTopics
+
+logger = logging.getLogger(__name__)
 
 
 class Listener:
@@ -56,7 +59,8 @@ class Listener:
                 else:
                     self._processed_events.append(item)
 
-            # Return None or raise an exception if no matching payload is found
+            # Return None if no matching payload is found
+            logger.debug("_find_matching_event found no matching events in queue")
             return None
 
         try:
@@ -69,10 +73,12 @@ class Listener:
         """
         Start the listener by registering its callback with the Webhooks class.
         """
+        logger.debug("Starting listener")
         await Webhooks.register_callback(self.handle_webhook)
 
     def stop(self):
         """
         Stop the listener by unregistering its callback from the Webhooks class.
         """
+        logger.debug("Stopping listener")
         Webhooks.unregister_callback(self.handle_webhook)

--- a/app/listener.py
+++ b/app/listener.py
@@ -30,7 +30,7 @@ class Listener:
         if data["topic"] == self.topic and data["wallet_id"] == self.wallet_id:
             await self.unprocessed_queue.put(data)
 
-    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: Optional[float] = 180):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: Optional[float] = 30):
         """
         Wait for an event that matches the specified filter_map within the given timeout period.
         """
@@ -73,7 +73,7 @@ class Listener:
         while loop.is_running:
             try:
                 # Use a smaller timeout value for asyncio.wait_for to repeatedly call _find_matching_event
-                payload = await asyncio.wait_for(_find_matching_event(), timeout=5)
+                payload = await asyncio.wait_for(_find_matching_event(), timeout=2)
                 if payload:
                     return payload
                 else:

--- a/app/listener.py
+++ b/app/listener.py
@@ -75,6 +75,8 @@ class Listener:
                 # Use a smaller timeout value for asyncio.wait_for to repeatedly call _find_matching_event
                 payload = await asyncio.wait_for(_find_matching_event(), timeout=2)
                 if payload:
+                    logger.debug(
+                        f"_find_matching_event successfully matched. payload: {payload}")
                     return payload
                 else:
                     logger.debug(
@@ -87,8 +89,10 @@ class Listener:
                 # If the total waiting time reaches the specified timeout, raise an exception, else continue
                 if loop.is_running and loop.time() - start_time >= timeout:
                     self.stop()
-                    raise ListenerTimeout(
+                    logger.warning(
                         f"Waiting for a filtered event has timed out ({timeout}s), using filter_map: {filter_map}")
+                    raise ListenerTimeout(
+                        f"Waiting for an expected event has timed out")
 
     async def start(self):
         """

--- a/app/listener.py
+++ b/app/listener.py
@@ -35,7 +35,7 @@ class Listener:
         Wait for an event that matches the specified filter_map within the given timeout period.
         """
         logger.debug(
-            f"Listener is starting to wait for a filtered event with timeout {timeout}s")
+            "Listener is starting to wait for a filtered event with timeout %ss", timeout)
 
         def _payload_matches_filter(payload: Dict[str, Any], filter_map: Dict[str, Any]) -> bool:
             """
@@ -76,7 +76,7 @@ class Listener:
                 payload = await asyncio.wait_for(_find_matching_event(), timeout=2)
                 if payload:
                     logger.debug(
-                        f"_find_matching_event successfully matched. payload: {payload}")
+                        "_find_matching_event successfully matched. payload: %s", payload)
                     return payload
                 else:
                     logger.debug(

--- a/app/listener.py
+++ b/app/listener.py
@@ -19,7 +19,7 @@ class Listener:
         self.wallet_id = wallet_id
         self.unprocessed_queue = asyncio.Queue()
         self._processed_events = []
-        
+
         # Start the listener when the object is created
         asyncio.create_task(self.start())
 

--- a/app/listener.py
+++ b/app/listener.py
@@ -16,6 +16,9 @@ class Listener:
         self.wallet_id = wallet_id
         self.unprocessed_queue = asyncio.Queue()
         self._processed_events = []
+        
+        # Start the listener when the object is created
+        asyncio.create_task(self.start())
 
     async def handle_webhook(self, data: Dict[str, Any]):
         """

--- a/app/listener.py
+++ b/app/listener.py
@@ -105,4 +105,3 @@ class Listener:
 
 class ListenerTimeout(Exception):
     """Exception raised when the Listener times out waiting for a matching event."""
-    pass

--- a/app/listener.py
+++ b/app/listener.py
@@ -82,6 +82,7 @@ class Listener:
             except asyncio.TimeoutError:
                 logger.warning(
                     "_find_matching_event has timed out in `asyncio.wait_for`")
+            finally:
                 # If the total waiting time reaches the specified timeout, raise an exception, else continue
                 if asyncio.get_event_loop().time() - start_time >= timeout:
                     self.stop()

--- a/app/listener.py
+++ b/app/listener.py
@@ -78,15 +78,15 @@ class Listener:
                     return payload
             except asyncio.TimeoutError:
                 logger.warning(
-                    "_find_matching_event has timed out in `asyncio.wait_for`")
+                    "_find_matching_event has timed out. unprocessed_queue may be very large")
             finally:
                 # If the total waiting time reaches the specified timeout, raise an exception, else continue
                 if loop.is_running and loop.time() - start_time >= timeout:
                     self.stop()
                     logger.warning(
-                        f"Waiting for a filtered event has timed out ({timeout}s), using filter_map: {filter_map}")
+                        "Waiting for a filtered event has timed out (%ss), with filter_map: %s", timeout, filter_map)
                     raise ListenerTimeout(
-                        f"Waiting for an expected event has timed out")
+                        "Waiting for an expected event has timed out")
 
     async def start(self):
         """

--- a/app/listener.py
+++ b/app/listener.py
@@ -75,13 +75,7 @@ class Listener:
                 # Use a smaller timeout value for asyncio.wait_for to repeatedly call _find_matching_event
                 payload = await asyncio.wait_for(_find_matching_event(), timeout=2)
                 if payload:
-                    logger.debug(
-                        "_find_matching_event successfully matched. payload: %s", payload)
                     return payload
-                else:
-                    logger.debug(
-                        f"_find_matching_event returned None. Sleep briefly before retry. Events already checked: {self._processed_events}")
-                    await asyncio.sleep(2)
             except asyncio.TimeoutError:
                 logger.warning(
                     "_find_matching_event has timed out in `asyncio.wait_for`")

--- a/app/listener.py
+++ b/app/listener.py
@@ -14,14 +14,15 @@ class Listener:
     def __init__(self, topic: CloudApiTopics, wallet_id: str):
         self.topic = topic
         self.wallet_id = wallet_id
-        self.queue = asyncio.Queue()
+        self.unprocessed_queue = asyncio.Queue()
+        self._processed_events = []
 
     async def handle_webhook(self, data: Dict[str, Any]):
         """
         Process a webhook event and add it to the queue if the topic and wallet_id match.
         """
         if data["topic"] == self.topic and data["wallet_id"] == self.wallet_id:
-            await self.queue.put(data)
+            await self.unprocessed_queue.put(data)
 
     async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: Optional[float] = 180):
         """
@@ -42,13 +43,15 @@ class Listener:
             Search the queue for an event that matches the specified filter_map. If a matching event
             is found, return its payload. Otherwise, return None.
             """
-            while not self.queue.empty():
-                item = await self.queue.get()
+            while not self.unprocessed_queue.empty():
+                item = await self.unprocessed_queue.get()
 
                 payload = item["payload"]
 
                 if _payload_matches_filter(payload, filter_map):
                     return payload
+                else:
+                    self._processed_events.append(item)
 
             # Return None or raise an exception if no matching payload is found
             return None

--- a/app/listener.py
+++ b/app/listener.py
@@ -34,6 +34,9 @@ class Listener:
         """
         Wait for an event that matches the specified filter_map within the given timeout period.
         """
+        logger.debug(
+            f"Listener is starting to wait for a filtered event with timeout {timeout}s")
+
         def _payload_matches_filter(payload: Dict[str, Any], filter_map: Dict[str, Any]) -> bool:
             """
             Check if the given payload matches the specified filter_map. A payload is considered a
@@ -60,7 +63,8 @@ class Listener:
                     self._processed_events.append(item)
 
             # Return None if no matching payload is found
-            logger.debug("_find_matching_event found no matching events in queue")
+            logger.debug(
+                "_find_matching_event found no matching events in queue")
             return None
 
                     raise ListenerTimeout(

--- a/app/listener.py
+++ b/app/listener.py
@@ -63,6 +63,8 @@ class Listener:
             logger.debug("_find_matching_event found no matching events in queue")
             return None
 
+                    raise ListenerTimeout(
+                        f"Waiting for a filtered event has timed out ({timeout}s), using filter_map: {filter_map}")
         try:
             payload = await asyncio.wait_for(_find_matching_event(), timeout=timeout)
             return payload
@@ -82,3 +84,8 @@ class Listener:
         """
         logger.debug("Stopping listener")
         Webhooks.unregister_callback(self.handle_webhook)
+
+
+class ListenerTimeout(Exception):
+    """Exception raised when the Listener times out waiting for a matching event."""
+    pass

--- a/app/listener.py
+++ b/app/listener.py
@@ -77,8 +77,8 @@ class Listener:
                 if payload:
                     return payload
                 else:
-                    logger.warning(
-                        "_find_matching_event returned None. Sleep before retry.")
+                    logger.debug(
+                        f"_find_matching_event returned None. Sleep briefly before retry. Events already checked: {self._processed_events}")
                     await asyncio.sleep(2)
             except asyncio.TimeoutError:
                 logger.warning(

--- a/app/listener.py
+++ b/app/listener.py
@@ -67,9 +67,10 @@ class Listener:
                 "_find_matching_event found no matching events in queue")
             return None
 
-         # Loop continuously, waiting for a matching event or until the total waiting time reaches the specified timeout
-        start_time = asyncio.get_event_loop().time()
-        while True:
+        # Loop continuously, waiting for a matching event or until the total waiting time reaches the specified timeout
+        loop = asyncio.get_event_loop()
+        start_time = loop.time()
+        while loop.is_running:
             try:
                 # Use a smaller timeout value for asyncio.wait_for to repeatedly call _find_matching_event
                 payload = await asyncio.wait_for(_find_matching_event(), timeout=5)
@@ -84,7 +85,7 @@ class Listener:
                     "_find_matching_event has timed out in `asyncio.wait_for`")
             finally:
                 # If the total waiting time reaches the specified timeout, raise an exception, else continue
-                if asyncio.get_event_loop().time() - start_time >= timeout:
+                if loop.is_running and loop.time() - start_time >= timeout:
                     self.stop()
                     raise ListenerTimeout(
                         f"Waiting for a filtered event has timed out ({timeout}s), using filter_map: {filter_map}")

--- a/app/main.py
+++ b/app/main.py
@@ -55,7 +55,7 @@ async def shutdown_event():
 
 @app.on_event("startup")
 async def startup_event():
-    await Webhooks.listen_webhooks()
+    await Webhooks.start_webhook_client()
 
 
 # add endpoints

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,15 @@
-from distutils.util import strtobool
 import io
 import logging
 import os
 import traceback
+from distutils.util import strtobool
 
+import pydantic
+import yaml
 from aiohttp import ClientResponseError
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import HTTPException
 from fastapi.responses import JSONResponse
-import pydantic
-import yaml
 
 from app.admin.tenants import tenants
 from app.error.cloud_api_error import CloudApiException

--- a/app/main.py
+++ b/app/main.py
@@ -76,11 +76,13 @@ async def client_response_error_exception_handler(
 
     if isinstance(exception, ClientResponseError):
         return JSONResponse(
-            {"detail": exception.message, **(stacktrace if debug else {})}, exception.status or 500
+            {"detail": exception.message, **
+                (stacktrace if debug else {})}, exception.status or 500
         )
     if isinstance(exception, CloudApiException):
         return JSONResponse(
-            {"detail": exception.detail, **(stacktrace if debug else {})}, exception.status_code
+            {"detail": exception.detail, **
+                (stacktrace if debug else {})}, exception.status_code
         )
     if isinstance(exception, HTTPException):
         return JSONResponse(
@@ -92,5 +94,6 @@ async def client_response_error_exception_handler(
         return JSONResponse({"detail": exception.errors()}, status_code=422)
     else:
         return JSONResponse(
-            {"detail": "Internal server error", "exception":str(exception)}, 500
+            {"detail": "Internal server error",
+                "exception": str(exception)}, 500
         )

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -11,8 +11,7 @@ import app.admin.tenants.onboarding as onboarding
 from app.admin.tenants.onboarding import acapy_ledger, acapy_wallet
 from app.error.cloud_api_error import CloudApiException
 from app.facades.acapy_wallet import Did
-from app.tests.util.webhooks import (MockConnectionListener,
-                                     MockEndorsementListener, MockListener)
+from app.listener import Listener
 from tests.fixtures import get_mock_agent_controller
 from tests.util.mock import get
 
@@ -264,3 +263,21 @@ async def test_onboard_verifier_no_recipient_keys(mock_agent_controller: AcaPyCl
         await onboarding.onboard_verifier(
             name="verifier_name", verifier_controller=mock_agent_controller
         )
+
+
+class MockListener(Listener):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
+        pass
+
+    def stop(self):
+        pass
+
+
+class MockEndorserConnectionListener(MockListener):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
+        return {"connection_id": "endorser_connection_id"}
+
+
+class MockEndorsementListener(MockListener):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
+        return {"state": "request-received", "transaction_id": "abcde"}

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -3,8 +3,7 @@ from typing import Any, Dict
 import pytest
 from aries_cloudcontroller import (AcaPyClient, ConnRecord,
                                    InvitationCreateRequest, InvitationMessage,
-                                   InvitationRecord, TransactionList,
-                                   TransactionRecord)
+                                   InvitationRecord)
 from assertpy import assert_that
 from mockito import verify, when
 

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -54,10 +54,10 @@ async def test_onboard_issuer_public_did_exists(
 
     # Mock event listeners
     when(onboarding)._create_listener(
-        topic="connections", wallet_id="issuer_wallet_id"
-    ).thenReturn(MockListener(topic="connections", wallet_id="issuer_wallet_id"))
-    when(onboarding)._create_listener(topic="connections", wallet_id="admin").thenReturn(
-        MockConnectionListener(topic="connections", wallet_id="admin")
+        topic="connections", wallet_id="admin"
+    ).thenReturn(MockListener(topic="connections", wallet_id="admin"))
+    when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(
+        MockEndorserConnectionListener(topic="endorsements", wallet_id="admin")
     )
 
     invitation_url = "https://invitation.com"
@@ -273,11 +273,11 @@ class MockListener(Listener):
         pass
 
 
-class MockEndorserConnectionListener(MockListener):
+class MockListenerEndorserConnectionId(MockListener):
     async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
         return {"connection_id": "endorser_connection_id"}
 
 
-class MockEndorsementListener(MockListener):
+class MockListenerRequestReceived(MockListener):
     async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
         return {"state": "request-received", "transaction_id": "abcde"}

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -13,6 +13,7 @@ from app.admin.tenants.onboarding import acapy_ledger, acapy_wallet
 from app.error.cloud_api_error import CloudApiException
 from app.facades.acapy_wallet import Did
 from app.listener import Listener
+from shared_models.shared_models import CloudApiTopics
 from tests.fixtures import get_mock_agent_controller
 from tests.util.mock import get
 

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -57,7 +57,7 @@ async def test_onboard_issuer_public_did_exists(
         topic="connections", wallet_id="admin"
     ).thenReturn(MockListener(topic="connections", wallet_id="admin"))
     when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(
-        MockEndorserConnectionListener(topic="endorsements", wallet_id="admin")
+        MockListenerEndorserConnectionId(topic="endorsements", wallet_id="admin")
     )
 
     invitation_url = "https://invitation.com"
@@ -125,16 +125,12 @@ async def test_onboard_issuer_no_public_did(
     )
 
     # Mock event listeners
-    when(onboarding)._create_listener(
-        topic="connections", wallet_id="issuer_wallet_id"
-    ).thenReturn(MockListener(topic="connections", wallet_id="issuer_wallet_id"))
-
     when(onboarding)._create_listener(topic="connections", wallet_id="admin").thenReturn(
-        MockConnectionListener(topic="connections", wallet_id="admin")
+        MockListenerEndorserConnectionId(topic="connections", wallet_id="admin")
     )
 
     when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(
-        MockEndorsementListener(topic="endorsements", wallet_id="admin")
+        MockListenerRequestReceived(topic="endorsements", wallet_id="admin")
     )
 
     when(endorser_controller.endorse_transaction).get_records(...).thenReturn(

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -1,10 +1,11 @@
+from typing import Any, Dict
+
 import pytest
 from aries_cloudcontroller import (AcaPyClient, ConnRecord,
                                    InvitationCreateRequest, InvitationMessage,
                                    InvitationRecord, TransactionList,
                                    TransactionRecord)
 from assertpy import assert_that
-from asynctest import CoroutineMock, MagicMock
 from mockito import verify, when
 
 import app.admin.tenants.onboarding as onboarding
@@ -57,7 +58,8 @@ async def test_onboard_issuer_public_did_exists(
         topic="connections", wallet_id="admin"
     ).thenReturn(MockListener(topic="connections", wallet_id="admin"))
     when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(
-        MockListenerEndorserConnectionId(topic="endorsements", wallet_id="admin")
+        MockListenerEndorserConnectionId(
+            topic="endorsements", wallet_id="admin")
     )
 
     invitation_url = "https://invitation.com"
@@ -126,7 +128,8 @@ async def test_onboard_issuer_no_public_did(
 
     # Mock event listeners
     when(onboarding)._create_listener(topic="connections", wallet_id="admin").thenReturn(
-        MockListenerEndorserConnectionId(topic="connections", wallet_id="admin")
+        MockListenerEndorserConnectionId(
+            topic="connections", wallet_id="admin")
     )
 
     when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -1,27 +1,20 @@
-from asynctest import MagicMock, CoroutineMock
-from aries_cloudcontroller import (
-    AcaPyClient,
-    ConnRecord,
-    InvitationCreateRequest,
-    InvitationMessage,
-    InvitationRecord,
-    TransactionList,
-    TransactionRecord,
-)
-
 import pytest
-
+from aries_cloudcontroller import (AcaPyClient, ConnRecord,
+                                   InvitationCreateRequest, InvitationMessage,
+                                   InvitationRecord, TransactionList,
+                                   TransactionRecord)
+from assertpy import assert_that
+from asynctest import CoroutineMock, MagicMock
 from mockito import verify, when
+
+import app.admin.tenants.onboarding as onboarding
+from app.admin.tenants.onboarding import acapy_ledger, acapy_wallet
 from app.error.cloud_api_error import CloudApiException
 from app.facades.acapy_wallet import Did
 from app.tests.util.webhooks import (MockConnectionListener,
                                      MockEndorsementListener, MockListener)
 from tests.fixtures import get_mock_agent_controller
-
 from tests.util.mock import get
-import app.admin.tenants.onboarding as onboarding
-from app.admin.tenants.onboarding import acapy_wallet, acapy_ledger
-from app.tests.util.webhooks import mock_start_listener
 
 
 @pytest.mark.asyncio
@@ -231,7 +224,8 @@ async def test_onboard_verifier_no_public_did(mock_agent_controller: AcaPyClient
         get(
             InvitationRecord(
                 invitation_url=invitation_url,
-                invitation=InvitationMessage(services=[{"recipientKeys": [did_key]}]),
+                invitation=InvitationMessage(
+                    services=[{"recipientKeys": [did_key]}]),
             )
         )
     )

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -55,10 +55,10 @@ async def test_onboard_issuer_public_did_exists(
     )
 
     # Mock event listeners
-    when(onboarding)._create_listener(
+    when(onboarding).create_listener(
         topic="connections", wallet_id="admin"
     ).thenReturn(MockListener(topic="connections", wallet_id="admin"))
-    when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(
+    when(onboarding).create_listener(topic="endorsements", wallet_id="admin").thenReturn(
         MockListenerEndorserConnectionId(
             topic="endorsements", wallet_id="admin")
     )
@@ -101,11 +101,11 @@ async def test_onboard_issuer_no_public_did(
     )
 
     # Mock event listeners
-    when(onboarding)._create_listener(topic="connections", wallet_id="admin").thenReturn(
+    when(onboarding).create_listener(topic="connections", wallet_id="admin").thenReturn(
         MockListenerEndorserConnectionId(
             topic="connections", wallet_id="admin")
     )
-    when(onboarding)._create_listener(topic="endorsements", wallet_id="admin").thenReturn(
+    when(onboarding).create_listener(topic="endorsements", wallet_id="admin").thenReturn(
         MockListenerRequestReceived(topic="endorsements", wallet_id="admin")
     )
 

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -244,6 +244,10 @@ async def test_onboard_verifier_no_recipient_keys(mock_agent_controller: AcaPyCl
 
 
 class MockListener(Listener):
+    def __init__(self, topic: CloudApiTopics, wallet_id: str):
+        # Override init method, to prevent asyncio tasks from being created
+        pass
+
     async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
         pass
 

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -33,24 +33,24 @@ async def test_onboard_issuer_public_did_exists(
     endorser_controller = get_mock_agent_controller()
 
     when(endorser_controller.out_of_band).create_invitation(...).thenReturn(
-        get(InvitationRecord(invitation=InvitationMessage()))
+        await get(InvitationRecord(invitation=InvitationMessage()))
     )
     when(mock_agent_controller.out_of_band).receive_invitation(...).thenReturn(
-        get(ConnRecord())
+        await get(ConnRecord())
     )
 
     when(acapy_wallet).get_public_did(controller=endorser_controller).thenReturn(
-        get(Did(did="EndorserController", verkey="EndorserVerkey"))
+        await get(Did(did="EndorserController", verkey="EndorserVerkey"))
     )
 
     when(mock_agent_controller.endorse_transaction).set_endorser_role(...).thenReturn(
-        get()
+        await get()
     )
     when(endorser_controller.endorse_transaction).set_endorser_role(...).thenReturn(
-        get()
+        await get()
     )
     when(mock_agent_controller.endorse_transaction).set_endorser_info(...).thenReturn(
-        get()
+        await get()
     )
 
     # Mock event listeners

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,45 +1,44 @@
 import pytest
 import mockito
-from app.tests.util.client_fixtures import (
-    governance_acapy_client,
-    governance_client,
-    tenant_admin_acapy_client,
-    tenant_admin_client,
-)
-from app.tests.util.member_personas import (
-    alice_acapy_client,
-    alice_bob_connect_multi,
-    alice_member_client,
-    alice_tenant,
-    bob_acapy_client,
-    bob_and_alice_connection,
-    bob_and_alice_public_did,
-    bob_member_client,
-    bob_multi_use_invitation,
-)
-from app.tests.util.ecosystem_personas import (
-    acme_acapy_client,
-    acme_and_alice_connection,
-    acme_client,
-    acme_tenant,
-    faber_acapy_client,
-    faber_and_alice_connection,
-    faber_client,
-)
+# Unused imports contain fixtures
 from app.webhooks import Webhooks
-from tests.fixtures import mock_agent_controller
+
+# In pytest, conftest.py is a special file used to share fixtures, hooks, and other configurations
+# among multiple test files. It's automatically discovered by pytest when tests are run, and the
+# fixtures and hooks defined within it can be used in any test file within the same directory or subdirectories.
+
+# Pytest fixtures are reusable components that can be shared across multiple tests.
+# They can also help set up and tear down resources needed for the tests.
+# `autouse` means that the fixture will be automatically used for all tests in the pytest session,
+# so there is no need to explicitly include it in the test functions.
 
 
 @pytest.fixture(autouse=True)
 def run_around_tests():
+    """
+    Automatically unstub all stubbed methods after each test.
+
+    The 'yield' statement is used to split the fixture function into two parts: the setup
+    part that runs before the test, and the teardown part that runs after the test. In this
+    case, there is no setup code, so the 'yield' statement directly indicates the end of
+    the setup phase and the beginning of the teardown phase.
+    """
+    # Setup phase: No setup needed in this fixture
+
     yield
 
-    # After each test, unstub all stubbed methods
+    # Teardown phase: After each test, unstub all stubbed methods
     mockito.unstub()
 
 
 @pytest.fixture(autouse=True)
 async def shutdown_webhooks_listener():
+    """
+    Automatically shut down the Webhooks listener after each test.
+    """
+    # Setup phase: No setup needed in this fixture
+
     yield
 
+    # Teardown phase: After each test, shut down the Webhooks listener
     await Webhooks.shutdown()

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,5 +1,24 @@
-import pytest
 import mockito
+import pytest
+
+from app.tests.util.client_fixtures import (governance_acapy_client,
+                                            governance_client,
+                                            tenant_admin_acapy_client,
+                                            tenant_admin_client)
+from app.tests.util.ecosystem_personas import (acme_acapy_client,
+                                               acme_and_alice_connection,
+                                               acme_client, acme_tenant,
+                                               faber_acapy_client,
+                                               faber_and_alice_connection,
+                                               faber_client)
+from app.tests.util.member_personas import (alice_acapy_client,
+                                            alice_bob_connect_multi,
+                                            alice_member_client, alice_tenant,
+                                            bob_acapy_client,
+                                            bob_and_alice_connection,
+                                            bob_and_alice_public_did,
+                                            bob_member_client,
+                                            bob_multi_use_invitation)
 # Unused imports contain fixtures
 from app.webhooks import Webhooks
 

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -19,8 +19,9 @@ from app.tests.util.member_personas import (alice_acapy_client,
                                             bob_and_alice_public_did,
                                             bob_member_client,
                                             bob_multi_use_invitation)
-# Unused imports contain fixtures
 from app.webhooks import Webhooks
+from tests.fixtures import mock_agent_controller
+# Unused imports contain fixtures
 
 # In pytest, conftest.py is a special file used to share fixtures, hooks, and other configurations
 # among multiple test files. It's automatically discovered by pytest when tests are run, and the

--- a/app/tests/e2e/conftest.py
+++ b/app/tests/e2e/conftest.py
@@ -7,7 +7,7 @@ from app.tests.e2e.test_fixtures import issue_credential_to_alice
 from app.tests.util.ledger import create_public_did, has_public_did
 
 
-@pytest.yield_fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True, scope="module")
 def event_loop(request: Any):
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop

--- a/app/tests/e2e/test_definitions.py
+++ b/app/tests/e2e/test_definitions.py
@@ -21,7 +21,7 @@ from app.tests.util.string import get_random_string
 from app.tests.util.trust_registry import register_issuer
 
 # Tests are broken if we import the event_loop...
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def event_loop(request):
     """Create an instance of the default event loop for each test case."""
     loop = asyncio.get_event_loop_policy().new_event_loop()

--- a/app/tests/e2e/test_fixtures.py
+++ b/app/tests/e2e/test_fixtures.py
@@ -129,7 +129,8 @@ async def credential_exchange_id(
 
     response = await alice_member_client.get(
         BASE_PATH,
-        params={"connection_id": faber_and_alice_connection["alice_connection_id"]},
+        params={
+            "connection_id": faber_and_alice_connection["alice_connection_id"]},
     )
     response.raise_for_status()
     records = response.json()

--- a/app/tests/e2e/test_fixtures.py
+++ b/app/tests/e2e/test_fixtures.py
@@ -1,22 +1,20 @@
 from typing import Any
+
 import pytest
 from aries_cloudcontroller import AcaPyClient
 from httpx import AsyncClient
+
 from app.dependencies import acapy_auth, acapy_auth_verified
-from app.generic.definitions import (
-    CreateCredentialDefinition,
-    CreateSchema,
-    CredentialSchema,
-    create_schema,
-    create_credential_definition,
-)
+from app.generic.definitions import (CreateCredentialDefinition, CreateSchema,
+                                     CredentialSchema,
+                                     create_credential_definition,
+                                     create_schema)
+from app.generic.issuer.issuer import router
+from app.listener import Listener
 from app.tests.util.ecosystem_personas import FaberAliceConnect
 from app.tests.util.ledger import create_public_did, has_public_did
-from app.tests.util.webhooks import check_webhook_state
-from app.generic.issuer.issuer import router
-
 from app.tests.util.trust_registry import register_issuer
-from app.webhook_listener import start_listener
+from app.tests.util.webhooks import check_webhook_state
 from shared_models.shared_models import CredentialExchange
 
 BASE_PATH = router.prefix + "/credentials"

--- a/app/tests/e2e/test_issuer.py
+++ b/app/tests/e2e/test_issuer.py
@@ -1,5 +1,6 @@
 from time import sleep
 
+import logging
 import pytest
 from assertpy import assert_that
 from httpx import AsyncClient
@@ -13,6 +14,8 @@ from app.tests.util.webhooks import (check_webhook_state,
                                      get_hooks_per_topic_per_wallet)
 
 # This import are important for tests to run!
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
@@ -487,6 +490,11 @@ async def test_revoke_credential(
     if record_as_issuer_for_alice:
         record_issuer_for_alice: CredentialExchange = record_as_issuer_for_alice[-1]
     else:
+        logger.warning(
+            f"No records matched `credential-issued` with role: issuer. List of records retreived: {records}")
+        raise Exception(
+            "No issued credential retreived.")
+
     cred_id = cred_id_no_version(record_issuer_for_alice["credential_id"])
 
     response = await faber_client.post(

--- a/app/tests/e2e/test_issuer.py
+++ b/app/tests/e2e/test_issuer.py
@@ -437,7 +437,7 @@ async def test_revoke_credential(
         "attributes": {"speed": "10"},
     }
 
-    wait_for_event, _ = await start_listener(
+    alice_credentials_listener = Listener(
         topic="credentials", wallet_id=alice_tenant["tenant_id"]
     )
 
@@ -451,7 +451,7 @@ async def test_revoke_credential(
         print(credential_exchange)
     response.raise_for_status()
 
-    payload = await wait_for_event(
+    payload = await alice_credentials_listener.wait_for_filtered_event(
         filter_map={
             "connection_id": faber_and_alice_connection["alice_connection_id"],
             "state": "offer-received",
@@ -459,18 +459,16 @@ async def test_revoke_credential(
     )
 
     alice_credential_id = payload["credential_id"]
-    wait_for_event, _ = await start_listener(
-        topic="credentials", wallet_id=alice_tenant["tenant_id"]
-    )
 
     # send credential request - holder
     response = await alice_member_client.post(
         f"/generic/issuer/credentials/{alice_credential_id}/request", json={}
     )
 
-    await wait_for_event(
+    await alice_credentials_listener.wait_for_filtered_event(
         filter_map={"credential_id": alice_credential_id, "state": "done"}
     )
+    alice_credentials_listener.stop()
 
     # Retrieve an issued credential
     records = (await faber_client.get("/generic/issuer/credentials")).json()

--- a/app/tests/e2e/test_issuer.py
+++ b/app/tests/e2e/test_issuer.py
@@ -1,16 +1,18 @@
 from time import sleep
+
 import pytest
 from assertpy import assert_that
 from httpx import AsyncClient
+
 from app.generic.definitions import CredentialSchema
 from app.generic.issuer.facades.acapy_issuer_utils import cred_id_no_version
+from app.tests.e2e.test_fixtures import *  # NOQA
+from app.tests.e2e.test_fixtures import BASE_PATH
 from app.tests.util.ecosystem_personas import FaberAliceConnect
-from app.tests.util.webhooks import get_hooks_per_topic_per_wallet, check_webhook_state
+from app.tests.util.webhooks import (check_webhook_state,
+                                     get_hooks_per_topic_per_wallet)
 
 # This import are important for tests to run!
-
-from app.tests.e2e.test_fixtures import BASE_PATH
-from app.tests.e2e.test_fixtures import *  # NOQA
 
 
 @pytest.mark.asyncio
@@ -29,7 +31,8 @@ async def test_send_credential_oob_v1(
 
     response = await alice_member_client.get(
         BASE_PATH,
-        params={"connection_id": faber_and_alice_connection["alice_connection_id"]},
+        params={
+            "connection_id": faber_and_alice_connection["alice_connection_id"]},
     )
     records = response.json()
 
@@ -162,7 +165,8 @@ async def test_send_credential(
 
     response = await alice_member_client.get(
         BASE_PATH,
-        params={"connection_id": faber_and_alice_connection["alice_connection_id"]},
+        params={
+            "connection_id": faber_and_alice_connection["alice_connection_id"]},
     )
     records = response.json()
 
@@ -205,7 +209,8 @@ async def test_send_credential(
     )
     response = await alice_member_client.get(
         BASE_PATH,
-        params={"connection_id": faber_and_alice_connection["alice_connection_id"]},
+        params={
+            "connection_id": faber_and_alice_connection["alice_connection_id"]},
     )
     records = response.json()
 
@@ -329,7 +334,8 @@ async def test_send_credential_request(
 
     response = await alice_member_client.get(
         BASE_PATH,
-        params={"connection_id": faber_and_alice_connection["alice_connection_id"]},
+        params={
+            "connection_id": faber_and_alice_connection["alice_connection_id"]},
     )
     assert check_webhook_state(
         client=alice_member_client,

--- a/app/tests/e2e/test_issuer.py
+++ b/app/tests/e2e/test_issuer.py
@@ -439,9 +439,11 @@ async def test_revoke_credential(
     credential_definition_id_revocable: str,
     faber_and_alice_connection: FaberAliceConnect,
 ):
+    faber_connection_id = faber_and_alice_connection["faber_connection_id"]
+
     credential = {
         "protocol_version": "v1",
-        "connection_id": faber_and_alice_connection["faber_connection_id"],
+        "connection_id": faber_connection_id,
         "credential_definition_id": credential_definition_id_revocable,
         "attributes": {"speed": "10"},
     }
@@ -484,14 +486,14 @@ async def test_revoke_credential(
     record_as_issuer_for_alice = [
         rec
         for rec in records
-        if (rec["role"] == "issuer" and rec["state"] == "credential-issued" and rec['connection_id'] == faber_and_alice_connection["faber_connection_id"])
+        if (rec["role"] == "issuer" and rec["state"] == "credential-issued" and rec['connection_id'] == faber_connection_id)
     ]
 
     if record_as_issuer_for_alice:
         record_issuer_for_alice: CredentialExchange = record_as_issuer_for_alice[-1]
     else:
         logger.warning(
-            f"No records matched `credential-issued` with role: issuer. List of records retreived: {records}")
+            f"No records matched state: `credential-issued` with role: `issuer`. Looking for connection_id = {faber_connection_id}. List of records retreived: {records}.\n")
         raise Exception(
             "No issued credential retreived.")
 

--- a/app/tests/e2e/test_issuer.py
+++ b/app/tests/e2e/test_issuer.py
@@ -484,7 +484,9 @@ async def test_revoke_credential(
         if (rec["role"] == "issuer" and rec["state"] == "credential-issued" and rec['connection_id'] == faber_and_alice_connection["faber_connection_id"])
     ]
 
-    record_issuer_for_alice: CredentialExchange = record_as_issuer_for_alice[-1]
+    if record_as_issuer_for_alice:
+        record_issuer_for_alice: CredentialExchange = record_as_issuer_for_alice[-1]
+    else:
     cred_id = cred_id_no_version(record_issuer_for_alice["credential_id"])
 
     response = await faber_client.post(

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -10,7 +10,7 @@ from app.facades import acapy_wallet, trust_registry
 from app.role import Role
 
 # Tests are broken if we import the event_loop...
-@pytest.yield_fixture(scope="session")
+@pytest.fixture(scope="session")
 def event_loop(request):
     """Create an instance of the default event loop for each test case."""
     loop = asyncio.get_event_loop_policy().new_event_loop()

--- a/app/tests/e2e/test_trust_registry_integration.py
+++ b/app/tests/e2e/test_trust_registry_integration.py
@@ -30,9 +30,9 @@ async def test_accept_proof_request_verifier_no_public_did(
         await issuer_client.post("/generic/connections/create-invitation")
     ).json()
 
-    wait_for_event, _ = await start_listener(
-        topic="connections", wallet_id=issuer_tenant["tenant_id"]
-    )
+    issuer_tenant_listener = Listener(topic="connections",
+                                      wallet_id=issuer_tenant["tenant_id"])
+
     invitation_response = (
         await holder_client.post(
             "/generic/connections/accept-invitation",
@@ -43,17 +43,19 @@ async def test_accept_proof_request_verifier_no_public_did(
     issuer_holder_connection_id = invitation["connection_id"]
     holder_issuer_connection_id = invitation_response["connection_id"]
 
-    await wait_for_event(
-        filter_map={"state": "completed", "connection_id": issuer_holder_connection_id}
+    await issuer_tenant_listener.wait_for_filtered_event(
+        filter_map={"state": "completed",
+                    "connection_id": issuer_holder_connection_id}
     )
+    issuer_tenant_listener.stop()
 
     # Create connection between holder and verifier
-    ## We need to use the multi-use didcomm invitation from the trust registry
+    # We need to use the multi-use didcomm invitation from the trust registry
     verifier_actor = await actor_by_id(verifier_tenant["tenant_id"])
 
     assert verifier_actor
 
-    wait_for_event, _ = await start_listener(
+    verifier_tenant_listener = Listener(
         topic="connections",
         wallet_id=verifier_tenant["tenant_id"],
     )
@@ -70,7 +72,8 @@ async def test_accept_proof_request_verifier_no_public_did(
         )
     ).json()
 
-    payload = await wait_for_event(filter_map={"state": "completed"}, timeout=100)
+    payload = await verifier_tenant_listener.wait_for_filtered_event(filter_map={"state": "completed"}, timeout=100)
+    verifier_tenant_listener.stop()
 
     holder_verifier_connection_id = invitation_response["connection_id"]
     verifier_holder_connection_id = payload["connection_id"]
@@ -104,7 +107,7 @@ async def test_accept_proof_request_verifier_no_public_did(
     credential_definition_id = credential_definition["id"]
 
     # Issue credential from issuer to holder
-    wait_for_event, _ = await start_listener(
+    holder_tenant_listener = Listener(
         topic="credentials", wallet_id=holder_tenant["tenant_id"]
     )
 
@@ -120,17 +123,18 @@ async def test_accept_proof_request_verifier_no_public_did(
         )
     ).json()
 
-    payload = await wait_for_event(
+    payload = await holder_tenant_listener.wait_for_filtered_event(
         filter_map={
             "state": "offer-received",
             "connection_id": holder_issuer_connection_id,
         },
     )
+    holder_tenant_listener.stop()
 
     issuer_credential_exchange_id = issuer_credential_exchange["credential_id"]
     holder_credential_exchange_id = payload["credential_id"]
 
-    wait_for_event, _ = await start_listener(
+    issuer_tenant_cred_listener = Listener(
         topic="credentials", wallet_id=issuer_tenant["tenant_id"]
     )
 
@@ -140,14 +144,16 @@ async def test_accept_proof_request_verifier_no_public_did(
     response.raise_for_status()
 
     # Wait for credential exchange to finish
-    await wait_for_event(
-        filter_map={"state": "done", "credential_id": issuer_credential_exchange_id},
+    await issuer_tenant_cred_listener.wait_for_filtered_event(  # <- times out
+        filter_map={"state": "done",
+                    "credential_id": issuer_credential_exchange_id},
         timeout=300,
     )
+    issuer_tenant_cred_listener.stop()
 
     # Present proof from holder to verifier
 
-    wait_for_event, _ = await start_listener(
+    holder_tenant_proofs_listener = Listener(
         topic="proofs", wallet_id=holder_tenant["tenant_id"]
     )
 
@@ -180,13 +186,14 @@ async def test_accept_proof_request_verifier_no_public_did(
     response.raise_for_status()
     verifier_proof_exchange = response.json()
 
-    payload = await wait_for_event(
+    payload = await holder_tenant_proofs_listener.wait_for_filtered_event(
         filter_map={
             "state": "request-received",
             "connection_id": holder_verifier_connection_id,
         },
         timeout=300,
     )
+    holder_tenant_proofs_listener.stop()
 
     verifier_proof_exchange_id = verifier_proof_exchange["proof_id"]
     holder_proof_exchange_id = payload["proof_id"]
@@ -199,7 +206,7 @@ async def test_accept_proof_request_verifier_no_public_did(
 
     cred_id = available_credentials[0]["cred_info"]["referent"]
 
-    wait_for_event, _ = await start_listener(
+    verifier_tenant_proofs_listener = Listener(
         topic="proofs", wallet_id=verifier_tenant["tenant_id"]
     )
 
@@ -221,7 +228,7 @@ async def test_accept_proof_request_verifier_no_public_did(
     )
     response.raise_for_status()
 
-    await wait_for_event(
+    await verifier_tenant_proofs_listener.wait_for_filtered_event(
         filter_map={
             "state": "done",
             "proof_id": verifier_proof_exchange_id,
@@ -229,6 +236,7 @@ async def test_accept_proof_request_verifier_no_public_did(
         },
         timeout=300,
     )
+    verifier_tenant_proofs_listener.stop()
 
     # Delete all tenants
     await delete_tenant(tenant_admin, issuer_tenant["tenant_id"])

--- a/app/tests/e2e/test_trust_registry_integration.py
+++ b/app/tests/e2e/test_trust_registry_integration.py
@@ -1,18 +1,12 @@
-from httpx import AsyncClient
 import pytest
+from httpx import AsyncClient
+
 from app.facades.trust_registry import actor_by_id
-from app.tests.util.client import (
-    tenant_client,
-    tenant_admin_client,
-)
+from app.listener import Listener
+from app.tests.util.client import tenant_admin_client, tenant_client
 from app.tests.util.string import base64_to_json, get_random_string
-from app.tests.util.tenants import (
-    create_issuer_tenant,
-    create_tenant,
-    create_verifier_tenant,
-    delete_tenant,
-)
-from app.webhook_listener import start_listener
+from app.tests.util.tenants import (create_issuer_tenant, create_tenant,
+                                    create_verifier_tenant, delete_tenant)
 
 
 @pytest.mark.asyncio

--- a/app/tests/e2e/test_verifier.py
+++ b/app/tests/e2e/test_verifier.py
@@ -1,20 +1,20 @@
-from aries_cloudcontroller import (
-    IndyPresSpec,
-    IndyRequestedCredsRequestedAttr,
-)
+import time
+
 import pytest
+from aries_cloudcontroller import IndyPresSpec, IndyRequestedCredsRequestedAttr
 from assertpy import assert_that
 from httpx import AsyncClient
 
+from app.generic.verifier.models import (AcceptProofRequest,
+                                         PresentProofProtocolVersion,
+                                         RejectProofRequest, SendProofRequest)
 from app.listener import Listener
 from app.tests.e2e.test_fixtures import *
 from app.tests.util.ecosystem_personas import AcmeAliceConnect
 from app.tests.util.webhooks import check_webhook_state
 from app.tests.verifier.test_verifier_utils import indy_proof_request
-from app.tests.e2e.test_fixtures import *
-from shared_models.shared_models import CredentialExchange, PresentationExchange  # NOQA
-
-import time
+from shared_models.shared_models import CredentialExchange  # NOQA
+from shared_models.shared_models import PresentationExchange
 
 BASE_PATH = "/generic/verifier"
 
@@ -196,7 +196,8 @@ async def test_accept_proof_request_oob_v1(
 
     assert check_webhook_state(
         client=bob_member_client,
-        filter_map={"state": "done", "role": "verifier", "connection_id": None},
+        filter_map={"state": "done",
+                    "role": "verifier", "connection_id": None},
         topic="proofs",
         max_duration=240,
     )
@@ -290,7 +291,8 @@ async def test_accept_proof_request_oob_v2(
 
     assert check_webhook_state(
         client=bob_member_client,
-        filter_map={"state": "done", "role": "verifier", "connection_id": None},
+        filter_map={"state": "done",
+                    "role": "verifier", "connection_id": None},
         topic="proofs",
         max_duration=240,
     )
@@ -694,7 +696,7 @@ async def test_get_credentials_for_request(
         }
     )
     alice_proofs_listener.stop()
-    
+
     proof_id = alice_exchange["proof_id"]
 
     response = await alice_member_client.get(

--- a/app/tests/e2e/test_verifier.py
+++ b/app/tests/e2e/test_verifier.py
@@ -6,12 +6,8 @@ import pytest
 from assertpy import assert_that
 from httpx import AsyncClient
 
-from app.generic.verifier.models import (
-    AcceptProofRequest,
-    PresentProofProtocolVersion,
-    RejectProofRequest,
-    SendProofRequest,
-)
+from app.listener import Listener
+from app.tests.e2e.test_fixtures import *
 from app.tests.util.ecosystem_personas import AcmeAliceConnect
 from app.tests.util.webhooks import check_webhook_state
 from app.tests.verifier.test_verifier_utils import indy_proof_request
@@ -310,7 +306,7 @@ async def test_accept_proof_request_v2(
     credential_definition_id: str,
     acme_and_alice_connection: AcmeAliceConnect,
 ):
-    wait_for_event, _ = await start_listener(
+    alice_proofs_listener = Listener(
         topic="proofs", wallet_id=alice_tenant["tenant_id"]
     )
 
@@ -338,12 +334,13 @@ async def test_accept_proof_request_v2(
     acme_exchange = response.json()
     acme_proof_id = acme_exchange["proof_id"]
 
-    payload = await wait_for_event(
+    payload = await alice_proofs_listener.wait_for_filtered_event(
         filter_map={
             "state": "request-received",
             "connection_id": acme_and_alice_connection["alice_connection_id"],
         }
     )
+    alice_proofs_listener.stop()
 
     alice_proof_id = payload["proof_id"]
 
@@ -364,7 +361,7 @@ async def test_accept_proof_request_v2(
         ),
     )
 
-    wait_for_event, _ = await start_listener(
+    acme_proofs_listener = Listener(
         topic="proofs", wallet_id=acme_tenant["tenant_id"]
     )
 
@@ -373,9 +370,11 @@ async def test_accept_proof_request_v2(
         json=proof_accept.dict(),
     )
 
-    await wait_for_event(
-        filter_map={"proof_id": acme_proof_id, "state": "done", "verified": True}
+    await acme_proofs_listener.wait_for_filtered_event(
+        filter_map={"proof_id": acme_proof_id,
+                    "state": "done", "verified": True}
     )
+    acme_proofs_listener.stop()
 
     result = response.json()
 
@@ -391,7 +390,7 @@ async def test_send_proof_request(
     acme_client: AsyncClient,
     alice_tenant: Any,
 ):
-    wait_for_event, _ = await start_listener(
+    alice_proofs_listener = Listener(
         topic="proofs", wallet_id=alice_tenant["tenant_id"]
     )
     response = await acme_client.post(
@@ -413,7 +412,7 @@ async def test_send_proof_request(
     assert result["state"]
 
     # Wait for request received
-    await wait_for_event(
+    await alice_proofs_listener.wait_for_filtered_event(
         filter_map={
             "connection_id": acme_and_alice_connection["alice_connection_id"],
             "state": "request-received",
@@ -422,9 +421,6 @@ async def test_send_proof_request(
     )
 
     # V2
-    wait_for_event, _ = await start_listener(
-        topic="proofs", wallet_id=alice_tenant["tenant_id"]
-    )
     response = await acme_client.post(
         BASE_PATH + "/send-request",
         json={
@@ -444,13 +440,14 @@ async def test_send_proof_request(
     assert result["state"]
 
     # Wait for request received
-    await wait_for_event(
+    await alice_proofs_listener.wait_for_filtered_event(
         filter_map={
             "connection_id": acme_and_alice_connection["alice_connection_id"],
             "state": "request-received",
             "protocol_version": "v2",
         }
     )
+    alice_proofs_listener.stop()
 
 
 @pytest.mark.asyncio
@@ -460,7 +457,7 @@ async def test_reject_proof_request(
     alice_tenant: Any,
     acme_client: AsyncClient,
 ):
-    wait_for_event, _ = await start_listener(
+    alice_proofs_listener = Listener(
         topic="proofs", wallet_id=alice_tenant["tenant_id"]
     )
 
@@ -476,13 +473,14 @@ async def test_reject_proof_request(
     response.raise_for_status()
 
     # Wait for request received
-    alice_exchange = await wait_for_event(
+    alice_exchange = await alice_proofs_listener.wait_for_filtered_event(
         filter_map={
             "connection_id": acme_and_alice_connection["alice_connection_id"],
             "state": "request-received",
             "protocol_version": "v1",
         }
     )
+    alice_proofs_listener.stop()
 
     reject_proof_request_v1 = RejectProofRequest(
         proof_id=alice_exchange["proof_id"], problem_report=None
@@ -641,7 +639,7 @@ async def test_get_credentials_for_request(
     alice_tenant: Any,
     alice_member_client: AsyncClient,
 ):
-    wait_for_event, _ = await start_listener(
+    alice_proofs_listener = Listener(
         topic="proofs", wallet_id=alice_tenant["tenant_id"]
     )
     # V1
@@ -655,7 +653,7 @@ async def test_get_credentials_for_request(
     )
 
     # Wait for request received
-    alice_exchange = await wait_for_event(
+    alice_exchange = await alice_proofs_listener.wait_for_filtered_event(
         filter_map={
             "connection_id": acme_and_alice_connection["alice_connection_id"],
             "state": "request-received",
@@ -678,9 +676,6 @@ async def test_get_credentials_for_request(
     ]
 
     # V2
-    wait_for_event, _ = await start_listener(
-        topic="proofs", wallet_id=alice_tenant["tenant_id"]
-    )
     await acme_client.post(
         BASE_PATH + "/send-request",
         json={
@@ -691,13 +686,15 @@ async def test_get_credentials_for_request(
     )
 
     # Wait for request received
-    alice_exchange = await wait_for_event(
+    alice_exchange = await alice_proofs_listener.wait_for_filtered_event(
         filter_map={
             "connection_id": acme_and_alice_connection["alice_connection_id"],
             "state": "request-received",
             "protocol_version": "v2",
         }
     )
+    alice_proofs_listener.stop()
+    
     proof_id = alice_exchange["proof_id"]
 
     response = await alice_member_client.get(

--- a/app/tests/util/client_fixtures.py
+++ b/app/tests/util/client_fixtures.py
@@ -10,7 +10,7 @@ from app.tests.util.client import (
 # governance
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 async def governance_acapy_client():
     client = _governance_acapy_client()
     yield client
@@ -18,7 +18,7 @@ async def governance_acapy_client():
     await client.close()
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 async def governance_client():
     async with _governance_client() as client:
         yield client
@@ -27,13 +27,13 @@ async def governance_client():
 # TENANT ADMIN
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 async def tenant_admin_client():
     async with _tenant_admin_client() as client:
         yield client
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 async def tenant_admin_acapy_client():
     client = _tenant_admin_acapy_client()
     yield client

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -34,7 +34,7 @@ async def faber_client():
         faber_async_client = tenant_client(token=tenant["access_token"])
         yield faber_async_client
 
-        faber_async_client.aclose()
+        await faber_async_client.aclose()
 
         await delete_tenant(client, tenant["tenant_id"])
 
@@ -69,7 +69,7 @@ async def acme_client(acme_tenant: Any):
     acme_async_client = tenant_client(token=acme_tenant["access_token"])
     yield acme_async_client
 
-    acme_async_client.aclose()
+    await acme_async_client.aclose()
 
 
 @pytest.fixture(scope="module")

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -31,10 +31,10 @@ async def faber_client():
         if "access_token" not in tenant:
             raise Exception("Error creating tenant", tenant)
 
-        faber_client = tenant_client(token=tenant["access_token"])
-        yield faber_client
-        
-        faber_client.aclose()
+        faber_async_client = tenant_client(token=tenant["access_token"])
+        yield faber_async_client
+
+        faber_async_client.aclose()
 
         await delete_tenant(client, tenant["tenant_id"])
 
@@ -66,10 +66,10 @@ async def acme_tenant():
 
 @pytest.fixture(scope="module")
 async def acme_client(acme_tenant: Any):
-    acme_client = tenant_client(token=acme_tenant["access_token"])
-    yield acme_client
-    
-    acme_client.aclose()
+    acme_async_client = tenant_client(token=acme_tenant["access_token"])
+    yield acme_async_client
+
+    acme_async_client.aclose()
 
 
 @pytest.fixture(scope="module")

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -2,21 +2,14 @@ from typing import Any, TypedDict
 
 import pytest
 from httpx import AsyncClient
+
 from app.facades.trust_registry import actor_by_id
-
-from app.tests.util.client import (
-    tenant_admin_client,
-    tenant_acapy_client,
-    tenant_client,
-)
+from app.listener import Listener
+from app.tests.util.client import (tenant_acapy_client, tenant_admin_client,
+                                   tenant_client)
 from app.tests.util.string import base64_to_json
-from app.webhook_listener import start_listener
-
-from app.tests.util.tenants import (
-    create_issuer_tenant,
-    create_verifier_tenant,
-    delete_tenant,
-)
+from app.tests.util.tenants import (create_issuer_tenant,
+                                    create_verifier_tenant, delete_tenant)
 from app.tests.util.webhooks import check_webhook_state
 
 

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -91,9 +91,8 @@ async def acme_and_alice_connection(
     invitation_json = base64_to_json(
         acme_actor["didcomm_invitation"].split("?oob=")[1])
 
-    wait_for_event, _ = await start_listener(
-        topic="connections", wallet_id=acme_tenant["tenant_id"]
-    )
+    listener = Listener(topic="connections",
+                        wallet_id=acme_tenant["tenant_id"])
 
     # accept invitation on alice side
     invitation_response = (
@@ -103,7 +102,8 @@ async def acme_and_alice_connection(
         )
     ).json()
 
-    payload = await wait_for_event(filter_map={"state": "completed"})
+    payload = await listener.wait_for_filtered_event(filter_map={"state": "completed"})
+    listener.stop()
 
     acme_connection_id = payload["connection_id"]
     alice_connection_id = invitation_response["connection_id"]

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -88,7 +88,8 @@ async def acme_and_alice_connection(
     assert acme_actor
     assert acme_actor["didcomm_invitation"]
 
-    invitation_json = base64_to_json(acme_actor["didcomm_invitation"].split("?oob=")[1])
+    invitation_json = base64_to_json(
+        acme_actor["didcomm_invitation"].split("?oob=")[1])
 
     wait_for_event, _ = await start_listener(
         topic="connections", wallet_id=acme_tenant["tenant_id"]
@@ -138,12 +139,14 @@ async def faber_and_alice_connection(
     assert check_webhook_state(
         alice_member_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": alice_connection_id},
+        filter_map={"state": "completed",
+                    "connection_id": alice_connection_id},
     )
     assert check_webhook_state(
         faber_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": faber_connection_id},
+        filter_map={"state": "completed",
+                    "connection_id": faber_connection_id},
     )
 
     return {

--- a/app/tests/util/ecosystem_personas.py
+++ b/app/tests/util/ecosystem_personas.py
@@ -31,7 +31,10 @@ async def faber_client():
         if "access_token" not in tenant:
             raise Exception("Error creating tenant", tenant)
 
-        yield tenant_client(token=tenant["access_token"])
+        faber_client = tenant_client(token=tenant["access_token"])
+        yield faber_client
+        
+        faber_client.aclose()
 
         await delete_tenant(client, tenant["tenant_id"])
 
@@ -63,7 +66,10 @@ async def acme_tenant():
 
 @pytest.fixture(scope="module")
 async def acme_client(acme_tenant: Any):
-    yield tenant_client(token=acme_tenant["access_token"])
+    acme_client = tenant_client(token=acme_tenant["access_token"])
+    yield acme_client
+    
+    acme_client.aclose()
 
 
 @pytest.fixture(scope="module")

--- a/app/tests/util/event_loop.py
+++ b/app/tests/util/event_loop.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Any
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def event_loop(request: Any):
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop

--- a/app/tests/util/member_personas.py
+++ b/app/tests/util/member_personas.py
@@ -36,7 +36,7 @@ async def bob_member_client():
 
         bob_client = tenant_client(token=tenant["access_token"])
         yield bob_client
-        
+
         bob_client.aclose()
 
         await delete_tenant(client, tenant["tenant_id"])
@@ -55,9 +55,9 @@ async def alice_tenant():
 @pytest.fixture(scope="module")
 async def alice_member_client(alice_tenant: Any):
     alice_client = tenant_client(token=alice_tenant["access_token"])
-    
+
     yield alice_client
-    
+
     alice_client.aclose()
 
 
@@ -65,7 +65,8 @@ async def alice_member_client(alice_tenant: Any):
 async def bob_acapy_client(bob_member_client: AsyncClient):
     # We extract the token from the x-api-key header as that's the easiest
     # method to create an AcaPyClient from an AsyncClient
-    [_, token] = bob_member_client.headers.get("x-api-key").split(".", maxsplit=1)
+    [_, token] = bob_member_client.headers.get(
+        "x-api-key").split(".", maxsplit=1)
 
     client = tenant_acapy_client(token=token)
     yield client
@@ -75,7 +76,8 @@ async def bob_acapy_client(bob_member_client: AsyncClient):
 
 @pytest.fixture(scope="module")
 async def alice_acapy_client(alice_member_client: AsyncClient):
-    [_, token] = alice_member_client.headers.get("x-api-key").split(".", maxsplit=1)
+    [_, token] = alice_member_client.headers.get(
+        "x-api-key").split(".", maxsplit=1)
 
     client = tenant_acapy_client(token=token)
     yield client

--- a/app/tests/util/member_personas.py
+++ b/app/tests/util/member_personas.py
@@ -37,7 +37,7 @@ async def bob_member_client():
         bob_client = tenant_client(token=tenant["access_token"])
         yield bob_client
 
-        bob_client.aclose()
+        await bob_client.aclose()
 
         await delete_tenant(client, tenant["tenant_id"])
 
@@ -58,7 +58,7 @@ async def alice_member_client(alice_tenant: Any):
 
     yield alice_client
 
-    alice_client.aclose()
+    await alice_client.aclose()
 
 
 @pytest.fixture(scope="module")

--- a/app/tests/util/member_personas.py
+++ b/app/tests/util/member_personas.py
@@ -34,7 +34,10 @@ async def bob_member_client():
     async with tenant_admin_client() as client:
         tenant = await create_issuer_tenant(client, "bob")
 
-        yield tenant_client(token=tenant["access_token"])
+        bob_client = tenant_client(token=tenant["access_token"])
+        yield bob_client
+        
+        bob_client.aclose()
 
         await delete_tenant(client, tenant["tenant_id"])
 
@@ -51,7 +54,11 @@ async def alice_tenant():
 
 @pytest.fixture(scope="module")
 async def alice_member_client(alice_tenant: Any):
-    yield tenant_client(token=alice_tenant["access_token"])
+    alice_client = tenant_client(token=alice_tenant["access_token"])
+    
+    yield alice_client
+    
+    alice_client.aclose()
 
 
 @pytest.fixture(scope="module")

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -1,13 +1,12 @@
 import base64
 import json
 import time
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import httpx
 from httpx import AsyncClient
 from pydantic import BaseModel
 
-from app.listener import Listener
 from app.tests.util.constants import WEBHOOKS_URL
 from shared_models import CloudApiTopics
 
@@ -85,21 +84,3 @@ def get_hooks_per_topic_per_wallet(client: AsyncClient, topic: CloudApiTopics) -
         return hooks if hooks else []
     except httpx.HTTPError as e:
         raise e from e
-
-
-class MockListener(Listener):
-    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
-        pass
-
-    def stop(self):
-        pass
-
-
-class MockConnectionListener(MockListener):
-    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
-        return {"connection_id": "endorser_connection_id"}
-
-
-class MockEndorsementListener(MockListener):
-    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
-        return {"state": "request-received", "transaction_id": "abcde"}

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -87,15 +87,19 @@ def get_hooks_per_topic_per_wallet(client: AsyncClient, topic: CloudApiTopics) -
         raise e from e
 
 
-async def mock_wait_for_event(*, filter_map: Dict[str, Any], timeout: float = 300):
-    pass
+class MockListener(Listener):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
+        pass
+
+    def stop(self):
+        pass
 
 
-def mock_stop_listener():
-    pass
+class MockConnectionListener(MockListener):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
+        return {"connection_id": "endorser_connection_id"}
 
 
-mock_start_listener = (
-    mock_wait_for_event,
-    mock_stop_listener,
-)
+class MockEndorsementListener(MockListener):
+    async def wait_for_filtered_event(self, filter_map: Dict[str, Any], timeout: float = 300):
+        return {"state": "request-received", "transaction_id": "abcde"}

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -3,12 +3,13 @@ import json
 import time
 from typing import Any, Dict, List, Optional
 
-from httpx import AsyncClient
 import httpx
+from httpx import AsyncClient
 from pydantic import BaseModel
 
-from shared_models import CloudApiTopics
+from app.listener import Listener
 from app.tests.util.constants import WEBHOOKS_URL
+from shared_models import CloudApiTopics
 
 
 class FilterMap(BaseModel):
@@ -55,7 +56,8 @@ def check_webhook_state(
         hooks_response = httpx.get(f"{WEBHOOKS_URL}/{topic}/{wallet_id}")
 
         if hooks_response.is_error:
-            raise Exception(f"Error retrieving webhooks: {hooks_response.text}")
+            raise Exception(
+                f"Error retrieving webhooks: {hooks_response.text}")
 
         hooks = hooks_response.json()
 
@@ -72,7 +74,8 @@ def check_webhook_state(
                 return True
 
         time.sleep(poll_interval)
-    raise Exception(f"Cannot satisfy webhook filter \n{filter_map}\n. Found \n{hooks}")
+    raise Exception(
+        f"Cannot satisfy webhook filter \n{filter_map}\n. Found \n{hooks}")
 
 
 def get_hooks_per_topic_per_wallet(client: AsyncClient, topic: CloudApiTopics) -> List:

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -88,8 +88,7 @@ class Webhooks:
                 f"Starting Webhooks client has timed out after {timeout}s")
             if Webhooks.client:
                 await Webhooks.client.disconnect()
-            raise WebhooksTimeout(
-                f"Starting Webhooks has timed out ({timeout}s)")
+            raise WebhooksTimeout(f"Starting Webhooks has timed out")
 
     @staticmethod
     async def _handle_webhook(data: str, topic: str):
@@ -119,8 +118,7 @@ class Webhooks:
         except asyncio.TimeoutError:
             logger.warning(
                 f"Shutting down Webhooks has timed out after {timeout}s")
-            raise WebhooksTimeout(
-                f"Webhooks shutdown timed out ({timeout}s)")
+            raise WebhooksTimeout(f"Webhooks shutdown timed out")
 
 
 class WebhooksTimeout(Exception):

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -36,6 +36,8 @@ class Webhooks:
         """
         if not Webhooks.client:
             await Webhooks.start_webhook_client()
+            
+        logger.debug("Registering a callback")
         Webhooks._callbacks.append(callback)
 
     @staticmethod
@@ -51,6 +53,8 @@ class Webhooks:
         """
         Unregister a listener function so that it will no longer be called when a webhook event is received.
         """
+        logger.debug("Unregistering a callback")
+        
         try:
             Webhooks._callbacks.remove(callback)
         except ValueError:
@@ -62,6 +66,8 @@ class Webhooks:
         """
         Start listening for webhook events on a WebSocket connection with a specified timeout.
         """
+        logger.debug("Starting Webhooks client")
+
         async def ensure_connection_ready():
             """
             Ensure the connection is established before proceeding
@@ -78,6 +84,8 @@ class Webhooks:
         try:
             await asyncio.wait_for(ensure_connection_ready(), timeout=timeout)
         except asyncio.TimeoutError:
+            logger.warning(
+                f"Starting Webhooks client has timed out after {timeout}s")
             if Webhooks.client:
                 await Webhooks.client.disconnect()
             raise WebhooksTimeout(
@@ -88,6 +96,8 @@ class Webhooks:
         """
         Internal callback function for handling received webhook events.
         """
+        logger.debug(f"Handling webhook for topic: {topic} - emit {data}")
+        
         await Webhooks.emit(json.loads(data))
 
     @staticmethod
@@ -95,6 +105,8 @@ class Webhooks:
         """
         Shutdown the Webhooks client and clear the listeners with a specified timeout.
         """
+        logger.debug("Shutting down Webhooks client")
+        
         async def wait_for_shutdown():
             if Webhooks.client:
                 await Webhooks.client.disconnect()
@@ -105,6 +117,8 @@ class Webhooks:
         try:
             await asyncio.wait_for(wait_for_shutdown(), timeout=timeout)
         except asyncio.TimeoutError:
+            logger.warning(
+                f"Shutting down Webhooks has timed out after {timeout}s")
             raise WebhooksTimeout(
                 f"Webhooks shutdown timed out ({timeout}s)")
 

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -132,4 +132,3 @@ class Webhooks:
 
 class WebhooksTimeout(Exception):
     """Exception raised when Webhooks functions time out."""
-    pass

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -73,7 +73,7 @@ class Webhooks:
             Ensure the connection is established before proceeding
             """
             Webhooks.client = PubSubClient(
-                [WEBHOOK_TOPIC_ALL], callback=Webhooks._on_webhook
+                [WEBHOOK_TOPIC_ALL], callback=Webhooks._handle_webhook
             )
 
             ws_url = convert_url_to_ws(WEBHOOKS_URL)
@@ -92,7 +92,7 @@ class Webhooks:
                 f"Starting Webhooks has timed out ({timeout}s)")
 
     @staticmethod
-    async def _on_webhook(data: str, topic: str):
+    async def _handle_webhook(data: str, topic: str):
         """
         Internal callback function for handling received webhook events.
         """

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -96,7 +96,6 @@ class Webhooks:
     @staticmethod
     async def wait_until_client_ready():
         if Webhooks.client:
-            logger.debug("wait_until_client_ready")
             await Webhooks.client.wait_until_ready()
             Webhooks._ready.set()
 

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -86,12 +86,12 @@ class Webhooks:
                 await asyncio.wait_for(ensure_connection_ready(), timeout=timeout)
             except asyncio.TimeoutError:
                 logger.warning(
-                    f"Starting Webhooks client has timed out after {timeout}s")
+                    "Starting Webhooks client has timed out after %ss", timeout)
                 await Webhooks.shutdown()
-                raise WebhooksTimeout(f"Starting Webhooks has timed out")
+                raise WebhooksTimeout("Starting Webhooks has timed out")
         else:
             logger.debug(
-                f"Tried to start Webhook client when it's already started. Ignoring.")
+                "Requested to start Webhook client when it's already started. Ignoring.")
 
     @staticmethod
     async def wait_until_client_ready():
@@ -104,8 +104,7 @@ class Webhooks:
         """
         Internal callback function for handling received webhook events.
         """
-        logger.debug(f"Handling webhook for topic: {topic} - emit {data}")
-        #todo: topic isn't used. should only emit to relevant topic/callback pairs
+        # todo: topic isn't used. should only emit to relevant topic/callback pairs
         await Webhooks.emit(json.loads(data))
 
     @staticmethod
@@ -118,7 +117,7 @@ class Webhooks:
         async def wait_for_shutdown():
             if Webhooks.client and await Webhooks._ready.wait():
                 await Webhooks.client.disconnect()
-            
+
             Webhooks.client = None
             Webhooks._ready = asyncio.Event()
             Webhooks._callbacks = []
@@ -127,8 +126,8 @@ class Webhooks:
             await asyncio.wait_for(wait_for_shutdown(), timeout=timeout)
         except asyncio.TimeoutError:
             logger.warning(
-                f"Shutting down Webhooks has timed out after {timeout}s")
-            raise WebhooksTimeout(f"Webhooks shutdown timed out")
+                "Shutting down Webhooks has timed out after %ss", timeout)
+            raise WebhooksTimeout("Webhooks shutdown timed out")
 
 
 class WebhooksTimeout(Exception):

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -36,7 +36,7 @@ class Webhooks:
         """
         if not Webhooks.client:
             await Webhooks.start_webhook_client()
-            
+
         logger.debug("Registering a callback")
         Webhooks._callbacks.append(callback)
 
@@ -54,7 +54,7 @@ class Webhooks:
         Unregister a listener function so that it will no longer be called when a webhook event is received.
         """
         logger.debug("Unregistering a callback")
-        
+
         try:
             Webhooks._callbacks.remove(callback)
         except ValueError:
@@ -97,7 +97,7 @@ class Webhooks:
         Internal callback function for handling received webhook events.
         """
         logger.debug(f"Handling webhook for topic: {topic} - emit {data}")
-        
+
         await Webhooks.emit(json.loads(data))
 
     @staticmethod
@@ -106,7 +106,7 @@ class Webhooks:
         Shutdown the Webhooks client and clear the listeners with a specified timeout.
         """
         logger.debug("Shutting down Webhooks client")
-        
+
         async def wait_for_shutdown():
             if Webhooks.client:
                 await Webhooks.client.disconnect()

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -43,7 +43,7 @@ class Webhooks:
         """
         Emit a webhook event by calling all registered listener functions with the event data.
         """
-        for callback in Webhooks._callbacks:
+        for callback in Webhooks._callbacks:  # todo: surely we don't need to submit data to every single callbacks
             await callback(data)
 
     @staticmethod

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -105,7 +105,7 @@ class Webhooks:
         Internal callback function for handling received webhook events.
         """
         logger.debug(f"Handling webhook for topic: {topic} - emit {data}")
-
+        #todo: topic isn't used. should only emit to relevant topic/callback pairs
         await Webhooks.emit(json.loads(data))
 
     @staticmethod
@@ -118,8 +118,9 @@ class Webhooks:
         async def wait_for_shutdown():
             if Webhooks.client and await Webhooks._ready.wait():
                 await Webhooks.client.disconnect()
-                Webhooks.client = None
-                Webhooks._ready = asyncio.Event()
+            
+            Webhooks.client = None
+            Webhooks._ready = asyncio.Event()
             Webhooks._callbacks = []
 
         try:

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -84,11 +84,11 @@ class Webhooks:
             try:
                 logger.debug("Starting Webhooks client")
                 await asyncio.wait_for(ensure_connection_ready(), timeout=timeout)
-            except asyncio.TimeoutError:
+            except asyncio.TimeoutError as e:
                 logger.warning(
                     "Starting Webhooks client has timed out after %ss", timeout)
                 await Webhooks.shutdown()
-                raise WebhooksTimeout("Starting Webhooks has timed out")
+                raise WebhooksTimeout("Starting Webhooks has timed out") from e
         else:
             logger.debug(
                 "Requested to start Webhook client when it's already started. Ignoring.")
@@ -124,10 +124,10 @@ class Webhooks:
 
         try:
             await asyncio.wait_for(wait_for_shutdown(), timeout=timeout)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             logger.warning(
                 "Shutting down Webhooks has timed out after %ss", timeout)
-            raise WebhooksTimeout("Webhooks shutdown timed out")
+            raise WebhooksTimeout("Webhooks shutdown timed out") from e
 
 
 class WebhooksTimeout(Exception):

--- a/app/webhooks.py
+++ b/app/webhooks.py
@@ -37,7 +37,6 @@ class Webhooks:
         if not Webhooks.client:
             await Webhooks.start_webhook_client()
 
-        logger.debug("Registering a callback")
         Webhooks._callbacks.append(callback)
 
     @staticmethod
@@ -45,7 +44,7 @@ class Webhooks:
         """
         Emit a webhook event by calling all registered listener functions with the event data.
         """
-        for callback in Webhooks._callbacks:  # todo: surely we don't need to submit data to every single callbacks
+        for callback in Webhooks._callbacks:  # todo: surely we don't need to submit data to every single callback
             await callback(data)
 
     @staticmethod
@@ -87,8 +86,7 @@ class Webhooks:
             except asyncio.TimeoutError:
                 logger.warning(
                     f"Starting Webhooks client has timed out after {timeout}s")
-                if Webhooks.client:
-                    await Webhooks.client.disconnect()
+                await Webhooks.shutdown()
                 raise WebhooksTimeout(f"Starting Webhooks has timed out")
         else:
             logger.debug(


### PR DESCRIPTION
The webhooks + listener implementation (`app/webhook_listener.py`) is laden with code smells:
- poor function names (`on`/`off`; `on_webhook` in listeners and `_on_webhook` in Webhooks class; `_listeners` is the name for the list of callback functions) with no docstring descriptions
- `sys.exit()` being called on timeout errors
- listener is implemented as an `async def start_listener()` which returns two async functions when called: `return wait_for_event_with_timeout, stop_listener`. This should be moved to its own class, providing instance specific access to these methods.
- `while True` to read from an async queue. By default, `get()` from an async queue will wait indefinitely if it's empty. There is also a duplicate method to introduce timeout to this loop
- the match payload to filter_map method:
  ```python
              match = all(
                  payload.get(filter_key, None) == filter_value
                  for filter_key, filter_value in filter_map.items()
              )
  ```
  will always return true when the key in filter_map doesn't exist in payload and if filter_map value is searching for None.
- and some more minor code smells.

This PR refactors `webhook_listener.py` into `webhooks.py` and `listener.py` for better maintainability, fixing code smells, and updating usage of these instances to work as prior.

Further notes:
- Webhooks is currently implemented as a static class with static methods and class-level variables. Therefore, it does not manage any instance specific state, and will have a shared set of listeners with a single Webhooks instance for the entire application. Currently the Webhooks instance manages a single PubSubClient with topics set to `'ALL_WEBHOOKS'`. I'll need some feedback about how to improve this, but creating instance specific webhooks may yield better maintainability + scalability.
- It may be worth adding an auth mechanism to listeners, as noted here: https://github.com/didx-xyz/aries-cloudapi-python/issues/259
- Test mocking in `test_onboarding.py` for `test_onboard_issuer_public_did_exists` seems to have been done incorrectly. Mock event listeners were created, but there's a mismatch in parameter values. Adding to fix list