### PR TITLE
Fix accept proof OOB tests and fix delete wallet requests

### DIFF
--- a/app/admin/tenants/tenants.py
+++ b/app/admin/tenants/tenants.py
@@ -137,7 +137,7 @@ async def create_tenant(
                     "Stray wallet was created for unregistered actor; deleting wallet"
                 )
                 await admin_controller.multitenancy.delete_wallet(
-                    wallet_response.wallet_id
+                    wallet_id=wallet_response.wallet_id
                 )
                 bound_logger.info("Wallet deleted.")
             raise
@@ -148,7 +148,7 @@ async def create_tenant(
                     "Could not register actor, but wallet was created; deleting wallet"
                 )
                 await admin_controller.multitenancy.delete_wallet(
-                    wallet_response.wallet_id
+                    wallet_id=wallet_response.wallet_id
                 )
                 bound_logger.info("Wallet deleted.")
             raise
@@ -195,9 +195,7 @@ async def delete_tenant_by_id(
             await remove_actor_by_id(wallet.wallet_id)
 
         bound_logger.debug("Deleting wallet")
-        await admin_controller.multitenancy.delete_wallet(
-            wallet_id=tenant_id, body=RemoveWalletRequest()
-        )
+        await admin_controller.multitenancy.delete_wallet(wallet_id=tenant_id)
         bound_logger.info("Successfully deleted tenant.")
 
 

--- a/app/tests/e2e/test_verifier.py
+++ b/app/tests/e2e/test_verifier.py
@@ -116,7 +116,6 @@ async def test_accept_proof_request_v1(
     assert response.status_code == 200
 
 
-@pytest.mark.skip(reason="Broken in 0.8.1 - to be fixed")
 @pytest.mark.anyio
 async def test_accept_proof_request_oob_v1(
     issue_credential_to_alice: CredentialExchange,
@@ -210,7 +209,6 @@ async def test_accept_proof_request_oob_v1(
     assert bob_presentation_received["role"] == "verifier"
 
 
-@pytest.mark.skip(reason="Broken in 0.8.1 - to be fixed")
 @pytest.mark.anyio
 async def test_accept_proof_request_oob_v2(
     issue_credential_to_alice: CredentialExchange,


### PR DESCRIPTION
Some `delete_wallet` operations were missing named arguments, which is required.

Additionally, we can now unskip the tests that were previously broken with the 0.8.1 upgrade: in e2e/test_verifier:
- test_accept_proof_request_oob_v1
- test_accept_proof_request_oob_v2

These tests now pass again, so something was fixed in the 0.8.1 -> 0.8.2 updates to resolve the verkey routing issue.