### PR TITLE
Feat/retry logic for endorser connection

### DIFF
--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -1,7 +1,5 @@
-import asyncio
 from typing import List, Optional
 
-from aiohttp.web import HTTPForbidden
 from aries_cloudcontroller import AcaPyClient, InvitationCreateRequest, InvitationRecord
 from aries_cloudcontroller.model.create_wallet_token_request import (
     CreateWalletTokenRequest,
@@ -272,24 +270,6 @@ async def onboard_issuer_no_public_did(
             endorser_did=endorser_did.did,
         )
         bound_logger.debug("Successfully set endorser info.")
-
-    async def configure_endorsement_with_retry(connection_record, endorser_did):
-        max_attempts = 3
-        retry_delay = 1.0  # delay in seconds
-
-        for attempt in range(max_attempts):
-            try:
-                await configure_endorsement(connection_record, endorser_did)
-                break
-            except HTTPForbidden as e:
-                if attempt + 1 == max_attempts:
-                    bound_logger.error("Maximum number of retries exceeded. Failing.")
-                    raise e  # Re-raise the exception if max attempts exceeded
-
-                bound_logger.warning(
-                    f"Failed to set roles (attempt {attempt + 1}). Retrying in {retry_delay} seconds..."
-                )
-                await asyncio.sleep(retry_delay)
 
     async def register_issuer_did():
         bound_logger.info("Creating DID for issuer")

--- a/app/util/retry_method.py
+++ b/app/util/retry_method.py
@@ -5,7 +5,7 @@ from loguru import Logger
 
 
 async def coroutine_with_retry(
-    coroutine: Awaitable, logger: Logger, max_attempts=5, retry_delay=0.5
+    coroutine: Awaitable, logger: Logger, max_attempts=5, retry_delay=1
 ):
     for attempt in range(max_attempts):
         try:

--- a/app/util/retry_method.py
+++ b/app/util/retry_method.py
@@ -1,0 +1,22 @@
+import asyncio
+from typing import Awaitable
+
+from loguru import Logger
+
+
+async def coroutine_with_retry(
+    coroutine: Awaitable, logger: Logger, max_attempts=5, retry_delay=0.5
+):
+    for attempt in range(max_attempts):
+        try:
+            await coroutine
+            break
+        except Exception as e:
+            if attempt + 1 == max_attempts:
+                logger.error("Maximum number of retries exceeded. Failing.")
+                raise e  # Re-raise the exception if max attempts exceeded
+
+            logger.warning(
+                f"Failed to run coroutine (attempt {attempt + 1}). Retrying in {retry_delay} seconds..."
+            )
+            await asyncio.sleep(retry_delay)

--- a/app/util/retry_method.py
+++ b/app/util/retry_method.py
@@ -1,7 +1,6 @@
 import asyncio
+from logging import Logger
 from typing import Awaitable
-
-from loguru import Logger
 
 
 async def coroutine_with_retry(


### PR DESCRIPTION
When onboarding an issuer, in creating a connection with the endorser, `set_endorser_roles` and `configure_endorsement` can fail spuriously. This PR implements retry logic, to attempt 5 times, with 1 second delay, before raising an exception.