### PR TITLE
Add retry logic for onboarding an issuer with no public DID

### DIFF
--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -153,8 +153,13 @@ async def onboard_issuer(
         bound_logger.debug("Obtained public DID for the to-be issuer")
     except CloudApiException:
         bound_logger.debug("No public DID for the to-be issuer")
-        issuer_did = await onboard_issuer_no_public_did(
-            name, endorser_controller, issuer_controller, issuer_wallet_id
+        # Onboarding an issuer with no public DID can fail when creating a connection with
+        # the endorser. If something goes wrong, the whole coroutine should be re-attempted
+        issuer_did: acapy_wallet.Did = await coroutine_with_retry(
+            onboard_issuer_no_public_did,
+            (name, endorser_controller, issuer_controller, issuer_wallet_id),
+            bound_logger,
+            max_attempts=3,
         )
 
     bound_logger.debug("Creating OOB invitation on behalf of issuer")

--- a/app/admin/tenants/onboarding.py
+++ b/app/admin/tenants/onboarding.py
@@ -324,12 +324,8 @@ async def onboard_issuer_no_public_did(
         endorser_connection, connection_record = await wait_for_connection_completion(
             invitation
         )
-        await coroutine_with_retry(
-            set_endorser_roles, (endorser_connection, connection_record), bound_logger
-        )
-        await coroutine_with_retry(
-            configure_endorsement, (connection_record, endorser_did), bound_logger
-        )
+        await set_endorser_roles(endorser_connection, connection_record)
+        await configure_endorsement(connection_record, endorser_did)
 
     try:
         logger.debug("Getting public DID for endorser")

--- a/app/util/retry_method.py
+++ b/app/util/retry_method.py
@@ -5,10 +5,10 @@ from typing import Callable, Tuple
 
 async def coroutine_with_retry(
     coroutine_func: Callable, args: Tuple, logger: Logger, max_attempts=5, retry_delay=1
-):
+    result = None
     for attempt in range(max_attempts):
         try:
-            await coroutine_func(*args)
+            result = await coroutine_func(*args)
             break
         except Exception as e:
             if attempt + 1 == max_attempts:
@@ -19,3 +19,4 @@ async def coroutine_with_retry(
                 f"Failed to run coroutine (attempt {attempt + 1}). Retrying in {retry_delay} seconds..."
             )
             await asyncio.sleep(retry_delay)
+    return result

--- a/app/util/retry_method.py
+++ b/app/util/retry_method.py
@@ -1,10 +1,11 @@
 import asyncio
 from logging import Logger
-from typing import Callable, Tuple
+from typing import Any, Callable, Tuple
 
 
 async def coroutine_with_retry(
     coroutine_func: Callable, args: Tuple, logger: Logger, max_attempts=5, retry_delay=1
+) -> Any:
     result = None
     for attempt in range(max_attempts):
         try:


### PR DESCRIPTION
Onboarding an issuer with no public DID can fail (approx 1% chance) when creating a connection with the endorser. If something goes wrong (e.g. configuring the endorsement or registering did), the whole process should be re-attempted.