### PR TITLE
Fix: make `bob_member` test fixture a regular tenant

### DIFF
--- a/app/tests/util/ecosystem_connections.py
+++ b/app/tests/util/ecosystem_connections.py
@@ -44,10 +44,6 @@ async def bob_and_alice_connection(
         )
     ).json()
 
-    assert await check_webhook_state(
-        alice_member_client, topic="connections", filter_map={"state": "completed"}
-    )
-
     bob_connection_id = invitation["connection_id"]
     alice_connection_id = invitation_response["connection_id"]
 

--- a/app/tests/util/ecosystem_connections.py
+++ b/app/tests/util/ecosystem_connections.py
@@ -59,11 +59,6 @@ async def bob_and_alice_connection(
         topic="connections",
         filter_map={"state": "completed"},
     )
-    assert await check_webhook_state(
-        bob_member_client,
-        topic="endorsements",
-        filter_map={"state": "transaction-acked"},
-    )
 
     return BobAliceConnect(
         alice_connection_id=alice_connection_id, bob_connection_id=bob_connection_id

--- a/app/tests/util/member_wallets.py
+++ b/app/tests/util/member_wallets.py
@@ -25,7 +25,7 @@ async def alice_tenant() -> Generator[CreateTenantResponse, Any, None]:
 @pytest.fixture(scope="function")
 async def bob_tenant() -> Generator[CreateTenantResponse, Any, None]:
     async with get_tenant_admin_client() as admin_client:
-        tenant = await create_issuer_tenant(admin_client, "bob")
+        tenant = await create_tenant(admin_client, "bob")
 
         yield tenant
 


### PR DESCRIPTION
Made Bob a tenant, no longer a issuer.

Remove webhook check state for endorsments