### PR TITLE
Fix todos and address some security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ bug and credit the discoverer.
 
 Security bugs can be reported via email. The process is as follows:
 
-(email) Subject: Security Issue: [repo-name] - [Type of bug]
+(email) Subject: Security Issue: \[repo-name\] - \[Type of bug\]
 
 (email) Content: Description of the bug + how to reproduce the bug
 

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -12,15 +12,11 @@ class CreateWalletRequestWithGroups(CreateWalletRequest):
 
 
 class WalletRecordWithGroups(WalletRecord):
-    group_id: Optional[str] = None
+    group_id: Optional[str] = Field(None, example="SomeGroupId")
 
 
 class WalletListWithGroups(BaseModel):
     results: Optional[List[WalletRecordWithGroups]] = None
-
-
-class WalletRecordWithGroups(WalletRecord):
-    group_id: Optional[str] = Field(None, example="SomeGroupId")
 
 
 class TenantRequestBase(BaseModel):

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from aries_cloudcontroller import CreateWalletRequest
 from aries_cloudcontroller.model.wallet_record import WalletRecord
 from pydantic import BaseModel, Field, HttpUrl
+from pydantic.networks import AnyHttpUrl
 
 from app.services.trust_registry import TrustRegistryRole
 

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -57,6 +57,11 @@ class CreateTenantResponse(Tenant, TenantAuth):
     pass
 
 
+class OnboardResult(BaseModel):
+    did: str
+    didcomm_invitation: Optional[AnyHttpUrl]
+
+
 def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
     label: str = wallet_record.settings["default_label"]
     image_url: Optional[str] = wallet_record.settings.get("image_url")

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -142,6 +142,6 @@ async def delete_connection_by_id(
 
     async with client_from_auth(auth) as aries_controller:
         await aries_controller.connection.delete_connection(conn_id=connection_id)
-        
+
     bound_logger.info("Successfully deleted connection by ID.")
     return {}

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -142,6 +142,6 @@ async def delete_connection_by_id(
 
     async with client_from_auth(auth) as aries_controller:
         await aries_controller.connection.delete_connection(conn_id=connection_id)
-    # TODO what if id not found?
+        
     bound_logger.info("Successfully deleted connection by ID.")
     return {}

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -284,6 +284,8 @@ async def accept_proof_request(
                     prover=prover,
                     presentation=presentation,
                 )
+            else:
+                bound_logger.warning("No connection associated with proof, OOB?")
 
             bound_logger.debug("Accepting proof record")
             result = await prover.accept_proof_request(

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -47,11 +47,11 @@ async def get_credentials_for_request(
     bound_logger = logger.bind(body={"proof_id": proof_id})
     bound_logger.info("GET request received: Get credentials for a proof request")
     try:
-        prover = get_verifier_by_version(version_candidate=proof_id)
+        verifier = get_verifier_by_version(version_candidate=proof_id)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Fetching credentials for request")
-            result = await prover.get_credentials_for_request(
+            result = await verifier.get_credentials_for_request(
                 controller=aries_controller, proof_id=proof_id
             )
     except Exception as e:
@@ -117,11 +117,11 @@ async def get_proof_record(
     bound_logger = logger.bind(body={"proof_id": proof_id})
     bound_logger.info("GET request received: Get proof record by id")
     try:
-        prover = get_verifier_by_version(version_candidate=proof_id)
+        verifier = get_verifier_by_version(version_candidate=proof_id)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Fetching proof record")
-            result = await prover.get_proof_record(
+            result = await verifier.get_proof_record(
                 controller=aries_controller, proof_id=proof_id
             )
     except Exception as e:
@@ -155,10 +155,11 @@ async def delete_proof(
     bound_logger = logger.bind(body={"proof_id": proof_id})
     bound_logger.info("DELETE request received: Delete proof record by id")
     try:
-        prover = get_verifier_by_version(version_candidate=proof_id)
+        verifier = get_verifier_by_version(version_candidate=proof_id)
+
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Deleting proof record")
-            await prover.delete_proof(controller=aries_controller, proof_id=proof_id)
+            await verifier.delete_proof(controller=aries_controller, proof_id=proof_id)
     except Exception as e:
         bound_logger.exception("Failed to delete proof record.")
         raise e from e
@@ -186,7 +187,7 @@ async def send_proof_request(
     bound_logger = logger.bind(body=proof_request)
     bound_logger.info("POST request received: Send proof request")
     try:
-        prover = get_verifier_by_version(proof_request.protocol_version)
+        verifier = get_verifier_by_version(proof_request.protocol_version)
 
         async with client_from_auth(auth) as aries_controller:
             if proof_request.connection_id:
@@ -195,7 +196,7 @@ async def send_proof_request(
                 )
 
             bound_logger.debug("Sending proof request")
-            result = await prover.send_proof_request(
+            result = await verifier.send_proof_request(
                 controller=aries_controller, proof_request=proof_request
             )
     except Exception as e:
@@ -230,11 +231,11 @@ async def create_proof_request(
     bound_logger = logger.bind(body=proof_request)
     bound_logger.info("POST request received: Create proof request")
     try:
-        prover = get_verifier_by_version(proof_request.protocol_version)
+        verifier = get_verifier_by_version(proof_request.protocol_version)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Creating proof request")
-            result = await prover.create_proof_request(
+            result = await verifier.create_proof_request(
                 controller=aries_controller, proof_request=proof_request
             )
     except Exception as e:
@@ -269,11 +270,11 @@ async def accept_proof_request(
     bound_logger = logger.bind(body=presentation)
     bound_logger.info("POST request received: Accept proof request")
     try:
-        prover = get_verifier_by_version(presentation.proof_id)
+        verifier = get_verifier_by_version(presentation.proof_id)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Get proof record")
-            proof_record = await prover.get_proof_record(
+            proof_record = await verifier.get_proof_record(
                 controller=aries_controller, proof_id=presentation.proof_id
             )
 
@@ -281,14 +282,14 @@ async def accept_proof_request(
             if proof_record.connection_id:
                 await assert_valid_prover(
                     aries_controller=aries_controller,
-                    prover=prover,
+                    verifier=verifier,
                     presentation=presentation,
                 )
             else:
                 bound_logger.warning("No connection associated with proof, OOB?")
 
             bound_logger.debug("Accepting proof record")
-            result = await prover.accept_proof_request(
+            result = await verifier.accept_proof_request(
                 controller=aries_controller, proof_request=presentation
             )
     except Exception as e:
@@ -322,11 +323,11 @@ async def reject_proof_request(
     bound_logger = logger.bind(body=proof_request)
     bound_logger.info("POST request received: Reject proof request")
     try:
-        prover = get_verifier_by_version(proof_request.proof_id)
+        verifier = get_verifier_by_version(proof_request.proof_id)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Getting proof record")
-            proof_record = await prover.get_proof_record(
+            proof_record = await verifier.get_proof_record(
                 controller=aries_controller, proof_id=proof_request.proof_id
             )
 
@@ -341,7 +342,7 @@ async def reject_proof_request(
                 )
 
             bound_logger.debug("Rejecting proof request")
-            await prover.reject_proof_request(
+            await verifier.reject_proof_request(
                 controller=aries_controller, proof_request=proof_request
             )
     except Exception as e:

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -286,7 +286,9 @@ async def accept_proof_request(
                     presentation=presentation,
                 )
             else:
-                bound_logger.warning("No connection associated with proof, OOB?")
+                bound_logger.warning(
+                    "No connection associated with proof. Skip validating prover"
+                )
 
             bound_logger.debug("Accepting proof record")
             result = await verifier.accept_proof_request(

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -12,7 +12,7 @@ from app.dependencies.acapy_clients import (
 )
 from app.event_handling.sse_listener import SseListener
 from app.exceptions.cloud_api_error import CloudApiException
-from app.models.tenants import UpdateTenantRequest, OnboardResult
+from app.models.tenants import OnboardResult, UpdateTenantRequest
 from app.services import acapy_ledger, acapy_wallet
 from app.services.trust_registry import TrustRegistryRole, actor_by_id, update_actor
 from app.util.did import qualified_did_sov

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -5,8 +5,6 @@ from aries_cloudcontroller.model.create_wallet_token_request import (
     CreateWalletTokenRequest,
 )
 from fastapi.exceptions import HTTPException
-from pydantic import BaseModel
-from pydantic.networks import AnyHttpUrl
 
 from app.dependencies.acapy_clients import (
     get_governance_controller,

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -12,7 +12,7 @@ from app.dependencies.acapy_clients import (
 )
 from app.event_handling.sse_listener import SseListener
 from app.exceptions.cloud_api_error import CloudApiException
-from app.models.tenants import UpdateTenantRequest
+from app.models.tenants import UpdateTenantRequest, OnboardResult
 from app.services import acapy_ledger, acapy_wallet
 from app.services.trust_registry import TrustRegistryRole, actor_by_id, update_actor
 from app.util.did import qualified_did_sov

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -25,11 +25,6 @@ from shared.log_config import get_logger
 logger = get_logger(__name__)
 
 
-class OnboardResult(BaseModel):
-    did: str
-    didcomm_invitation: Optional[AnyHttpUrl]
-
-
 def create_sse_listener(wallet_id: str, topic: str) -> SseListener:
     # Helper method for passing MockListener to class
     return SseListener(topic=topic, wallet_id=wallet_id)

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -340,9 +340,6 @@ async def revoke_credential(
             bound_logger.exception("Exception caught when revoking credential.")
             raise e
 
-        # FIXME: Using create_transaction_for_endorser nothing is returned from aca-py
-        # This is unexpected and throws and error in the controller validating the pydantic model.
-        # It still creates the transaction record though that can be endorsed below.
         await endorser_revoke()
 
     bound_logger.info("Successfully revoked credential.")

--- a/app/tests/e2e/test_jsonld.py
+++ b/app/tests/e2e/test_jsonld.py
@@ -40,10 +40,12 @@ signed_doc = {
         },
         "proof": {
             "type": "Ed25519Signature2018",
-            "verificationMethod": "did:key:did:key:z6Mkq8pevWDaxgsD2DZC11JUnnjGdrLmHSh9P7waX3HR4Zwz#did:key:z6Mkq8pevWDaxgsD2DZC11JUnnjGdrLmHSh9P7waX3HR4Zwz",
+            "verificationMethod": "did:key:did:key:z6Mkq8pevWDaxgsD2DZC11JUnnjGdrLmHSh9P7waX3HR4Zwz"
+            "#did:key:z6Mkq8pevWDaxgsD2DZC11JUnnjGdrLmHSh9P7waX3HR4Zwz",
             "proofPurpose": "assertionMethod",
             "created": "2022-11-24T08:20:11Z",
-            "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..Rdpq5uOCJInEMD-5G7mXalu0NiJHSgIfE5ISE7Ed451wJmkpFHR50K9Sb3nEo0P8wpXzrUQRCETqImTvqsZNDA",
+            "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..Rdpq5uOCJInEMD-"
+            "5G7mXalu0NiJHSgIfE5ISE7Ed451wJmkpFHR50K9Sb3nEo0P8wpXzrUQRCETqImTvqsZNDA",
         },
     },
     "verkey": "BgZcLFy9d9NjuiiVKSLdwhBGpH4usZSnh72egmKQ9MAc",

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -24,8 +24,10 @@ cred_def_id = "VagGATdBsVdBeFKeoYPe7H:3:CL:141:5d211963-3478-4de4-b8b6-9072759a7
 cred_ex_id = "5mJRavkcQFrqgKqKKZua3z:3:CL:30:tag"
 cred_id = "c7c909f4-f670-49bd-9d81-53fba6bb23b8"
 max_cred_num = 32767
-revocation_registry_id = "VagGATdBsVdBeFKeoYPe7H:4:VagGATdBsVdBeFKeoYPe7H:3:CL:141:"\
+revocation_registry_id = (
+    "VagGATdBsVdBeFKeoYPe7H:4:VagGATdBsVdBeFKeoYPe7H:3:CL:141:"
     "QIOPN:CL_ACCUM:5d211963-3478-4de4-b8b6-9072759a71c8"
+)
 conn_id = "12345"
 transaction_id = "1234"
 

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -117,35 +117,35 @@ async def test_get_active_revocation_registry_for_credential(
 
 @pytest.mark.anyio
 async def test_get_credential_revocation_status(mock_agent_controller: AcaPyClient):
-    cred_ex_id = "db9d7025-b276-4c32-ae38-fbad41864112"
+    cred_ex_id_b = "db9d7025-b276-4c32-ae38-fbad41864112"
     # Success
     when(mock_agent_controller.revocation).get_revocation_status(
-        cred_ex_id=cred_ex_id
+        cred_ex_id=cred_ex_id_b
     ).thenReturn(
         to_async(
             CredRevRecordResult(
                 result=IssuerCredRevRecord(
-                    cred_ex_id=cred_ex_id, cred_def_id=cred_def_id
+                    cred_ex_id=cred_ex_id_b, cred_def_id=cred_def_id
                 )
             )
         )
     )
     get_credential_revocation_status_result = await rg.get_credential_revocation_status(
-        controller=mock_agent_controller, credential_exchange_id=cred_ex_id
+        controller=mock_agent_controller, credential_exchange_id=cred_ex_id_b
     )
     assert isinstance(get_credential_revocation_status_result, IssuerCredRevRecord)
     assert get_credential_revocation_status_result.cred_def_id == cred_def_id
-    assert get_credential_revocation_status_result.cred_ex_id == cred_ex_id
+    assert get_credential_revocation_status_result.cred_ex_id == cred_ex_id_b
 
     # Fail
     with pytest.raises(
         CloudApiException, match="Error retrieving revocation status"
     ) as exc:
         when(mock_agent_controller.revocation).get_revocation_status(
-            cred_ex_id=cred_ex_id
+            cred_ex_id=cred_ex_id_b
         ).thenReturn(to_async(None))
         await rg.get_credential_revocation_status(
-            controller=mock_agent_controller, credential_exchange_id=cred_ex_id
+            controller=mock_agent_controller, credential_exchange_id=cred_ex_id_b
         )
         assert exc.value.status_code == 500
 

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -24,7 +24,8 @@ cred_def_id = "VagGATdBsVdBeFKeoYPe7H:3:CL:141:5d211963-3478-4de4-b8b6-9072759a7
 cred_ex_id = "5mJRavkcQFrqgKqKKZua3z:3:CL:30:tag"
 cred_id = "c7c909f4-f670-49bd-9d81-53fba6bb23b8"
 max_cred_num = 32767
-revocation_registry_id = "VagGATdBsVdBeFKeoYPe7H:4:VagGATdBsVdBeFKeoYPe7H:3:CL:141:QIOPN:CL_ACCUM:5d211963-3478-4de4-b8b6-9072759a71c8"
+revocation_registry_id = "VagGATdBsVdBeFKeoYPe7H:4:VagGATdBsVdBeFKeoYPe7H:3:CL:141:"\
+    "QIOPN:CL_ACCUM:5d211963-3478-4de4-b8b6-9072759a71c8"
 conn_id = "12345"
 transaction_id = "1234"
 

--- a/app/tests/verifier/utils.py
+++ b/app/tests/verifier/utils.py
@@ -342,9 +342,9 @@ async def test_assert_valid_prover_invitation_key(mock_agent_controller: AcaPyCl
         },
     )
 
-    prover = mock(Verifier)
+    verifier = mock(Verifier)
 
-    when(prover).get_proof_record(
+    when(verifier).get_proof_record(
         controller=mock_agent_controller, proof_id=pres_exchange.proof_id
     ).thenReturn(to_async(pres_exchange))
     when(mock_agent_controller.connection).get_connection(
@@ -366,7 +366,7 @@ async def test_assert_valid_prover_invitation_key(mock_agent_controller: AcaPyCl
             presentation=AcceptProofRequest(
                 proof_id=pres_exchange.proof_id, presentation_spec=presentation
             ),
-            prover=prover,
+            verifier=verifier,
         )
 
 
@@ -405,9 +405,9 @@ async def test_assert_valid_prover_public_did(mock_agent_controller: AcaPyClient
         },
     )
 
-    prover = mock(Verifier)
+    verifier = mock(Verifier)
 
-    when(prover).get_proof_record(
+    when(verifier).get_proof_record(
         controller=mock_agent_controller, proof_id=pres_exchange.proof_id
     ).thenReturn(to_async(pres_exchange))
     when(mock_agent_controller.connection).get_connection(
@@ -429,7 +429,7 @@ async def test_assert_valid_prover_public_did(mock_agent_controller: AcaPyClient
             presentation=AcceptProofRequest(
                 proof_id=pres_exchange.proof_id, presentation_spec=presentation
             ),
-            prover=prover,
+            verifier=verifier,
         )
 
 
@@ -451,9 +451,9 @@ async def test_assert_valid_prover_x_no_public_did_no_invitation_key(
     )
     conn_record = ConnRecord(connection_id=pres_exchange.connection_id)
 
-    prover = mock(Verifier)
+    verifier = mock(Verifier)
 
-    when(prover).get_proof_record(
+    when(verifier).get_proof_record(
         controller=mock_agent_controller, proof_id=pres_exchange.proof_id
     ).thenReturn(to_async(pres_exchange))
     when(mock_agent_controller.connection).get_connection(
@@ -468,7 +468,7 @@ async def test_assert_valid_prover_x_no_public_did_no_invitation_key(
             presentation=AcceptProofRequest(
                 proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
             ),
-            prover=prover,
+            verifier=verifier,
         )
 
 
@@ -500,9 +500,9 @@ async def test_assert_valid_prover_x_actor_invalid_role(
         connection_id=pres_exchange.connection_id, their_public_did="xxx"
     )
 
-    prover = mock(Verifier)
+    verifier = mock(Verifier)
 
-    when(prover).get_proof_record(
+    when(verifier).get_proof_record(
         controller=mock_agent_controller, proof_id=pres_exchange.proof_id
     ).thenReturn(to_async(pres_exchange))
     when(mock_agent_controller.connection).get_connection(
@@ -519,7 +519,7 @@ async def test_assert_valid_prover_x_actor_invalid_role(
                 presentation=AcceptProofRequest(
                     proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
                 ),
-                prover=prover,
+                verifier=verifier,
             )
 
 
@@ -543,9 +543,9 @@ async def test_assert_valid_prover_x_invalid_schemas(
         connection_id=pres_exchange.connection_id, their_public_did="xxx"
     )
 
-    prover = mock(Verifier)
+    verifier = mock(Verifier)
 
-    when(prover).get_proof_record(
+    when(verifier).get_proof_record(
         controller=mock_agent_controller, proof_id=pres_exchange.proof_id
     ).thenReturn(to_async(pres_exchange))
     when(mock_agent_controller.connection).get_connection(
@@ -570,7 +570,7 @@ async def test_assert_valid_prover_x_invalid_schemas(
                 presentation=AcceptProofRequest(
                     proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
                 ),
-                prover=prover,
+                verifier=verifier,
             )
 
 
@@ -590,9 +590,9 @@ async def test_assert_valid_prover_x_no_connection_id(
         verified="false",
     )
 
-    prover = mock(Verifier)
+    verifier = mock(Verifier)
 
-    when(prover).get_proof_record(
+    when(verifier).get_proof_record(
         controller=mock_agent_controller, proof_id=pres_exchange.proof_id
     ).thenReturn(to_async(pres_exchange))
 
@@ -604,7 +604,7 @@ async def test_assert_valid_prover_x_no_connection_id(
             presentation=AcceptProofRequest(
                 proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
             ),
-            prover=prover,
+            verifier=verifier,
         )
 
 

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -38,7 +38,7 @@ def get_verifier_by_version(
 
 
 async def assert_valid_prover(
-    aries_controller: AcaPyClient, presentation: AcceptProofRequest, prover: Verifier
+    aries_controller: AcaPyClient, presentation: AcceptProofRequest, verifier: Verifier
 ) -> None:
     """Check transaction requirements against trust registry for prover"""
     # get connection record
@@ -49,7 +49,7 @@ async def assert_valid_prover(
 
     bound_logger.debug("Getting connection from proof")
     connection_id = await get_connection_from_proof(
-        aries_controller=aries_controller, proof_id=proof_id, prover=prover
+        aries_controller=aries_controller, proof_id=proof_id, verifier=verifier
     )
 
     if not connection_id:
@@ -200,9 +200,9 @@ async def get_schema_ids(
 
 
 async def get_connection_from_proof(
-    aries_controller: AcaPyClient, prover: Verifier, proof_id: str
+    aries_controller: AcaPyClient, verifier: Verifier, proof_id: str
 ) -> Optional[str]:
-    proof_record = await prover.get_proof_record(
+    proof_record = await verifier.get_proof_record(
         controller=aries_controller, proof_id=proof_id
     )
     return proof_record.connection_id

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -53,8 +53,6 @@ async def assert_valid_prover(
         aries_controller=aries_controller, proof_id=proof_id, prover=prover
     )
 
-    # TODO: (In other PR) handle case where no connection id exists
-    # instead of simply rejecting the request
     if not connection_id:
         raise CloudApiException(
             "No connection id associated with proof request. Can not verify proof request.",

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -29,9 +29,8 @@ def get_verifier_by_version(
         isinstance(version_candidate, str) and version_candidate.startswith("v1-")
     ):
         return VerifierFacade.v1.value
-    elif (
-        version_candidate == PresentProofProtocolVersion.v2
-        or version_candidate.startswith("v2-")
+    elif version_candidate == PresentProofProtocolVersion.v2 or (
+        isinstance(version_candidate, str) and version_candidate.startswith("v2-")
     ):
         return VerifierFacade.v2.value
     else:

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -67,7 +67,6 @@ async def assert_valid_prover(
     if not connection_record.connection_id:
         raise CloudApiException("Cannot proceed. No connection id.", 404)
 
-    invitation_key = connection_record.invitation_key
     # Case 1: connection made with public DID
     if connection_record.their_public_did:
         public_did = f"did:sov:{connection_record.their_public_did}"

--- a/scripts/ngrok-wait.sh
+++ b/scripts/ngrok-wait.sh
@@ -8,7 +8,7 @@ AGENT_ENDPOINT=null
 while [ -z "$AGENT_ENDPOINT" ] || [ "$AGENT_ENDPOINT" = "null" ]
 do
     echo "Fetching end point from ngrok service"
-    AGENT_ENDPOINT=$(curl --silent $NGROK_NAME:4040/api/tunnels | ./jq -r '.tunnels[0].public_url')
+    AGENT_ENDPOINT=$(curl --silent "$NGROK_NAME":4040/api/tunnels | ./jq -r '.tunnels[0].public_url')
     echo "ngrok end point [$AGENT_ENDPOINT]"
     if [ -z "$AGENT_ENDPOINT" ] || [ "$AGENT_ENDPOINT" = "null" ]; then
         echo "ngrok not ready, sleeping 5 seconds...."

--- a/scripts/ngrok-wait.sh
+++ b/scripts/ngrok-wait.sh
@@ -5,8 +5,7 @@ NGROK_NAME=${NGROK_NAME:-ngrok}
 echo "ngrok end point [$NGROK_NAME]"
 
 AGENT_ENDPOINT=null
-while [ -z "$AGENT_ENDPOINT" ] || [ "$AGENT_ENDPOINT" = "null" ]
-do
+while [ -z "$AGENT_ENDPOINT" ] || [ "$AGENT_ENDPOINT" = "null" ]; do
     echo "Fetching end point from ngrok service"
     AGENT_ENDPOINT=$(curl --silent "$NGROK_NAME":4040/api/tunnels | ./jq -r '.tunnels[0].public_url')
     echo "ngrok end point [$AGENT_ENDPOINT]"

--- a/webhooks/clients.example.py
+++ b/webhooks/clients.example.py
@@ -18,9 +18,6 @@ async def on_events(data, topic):
 
 
 async def main():
-    # Create a client and subscribe to topics
-    client = PubSubClient(["ALL_WEBHOOKS"], callback=on_events)
-
     """
     # You can also register it using the commented code below
     async def on_data(data, topic):
@@ -28,6 +25,8 @@ async def main():
 
     [client.subscribe(topic, on_data) for topic in topics]
     """
+    # Create a client and subscribe to topics
+    client = PubSubClient(["ALL_WEBHOOKS"], callback=on_events)
 
     client.start_client(f"ws://{URL}:{PORT}/pubsub")
     print("Started")


### PR DESCRIPTION
- Made long strings multi line
- escaped some brackets in SECURITY.md
- Logging a warning in `accept_proof_request` if `assert_valid_prover`  is not called. Looks like if proof request does not have a `connection_id` it is treated as a `oob` connection
- Removed a duplicate class `WalletRecordWithGroups` in `app/models/tenants.py` 
- Renamed locally scoped variable `cred_ex_id` to `cred_ex_id_b` not to confuse it with global `cred_ex_id` in `test_revocation_registry.py`

- Move `OnboardResults` class to `models/tenants.py`
- renamed instances of the Verifier V1/V2 interface from `prover` to `verifier`