### PR TITLE
Refactor verifier models, service and routes to support jsonld

### DIFF
--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -28,7 +28,7 @@ class CredentialBase(BaseModel):
     def check_indy_credential_detail(cls, value, values):
         if values.get("type") == CredentialType.INDY and value is None:
             raise ValueError(
-                "indy_credential_detail must be populated if CredentialType.INDY is selected"
+                "indy_credential_detail must be populated if `indy` credential type is selected"
             )
         return value
 
@@ -37,7 +37,7 @@ class CredentialBase(BaseModel):
     def check_ld_credential_detail(cls, value, values):
         if values.get("type") == CredentialType.LD_PROOF and value is None:
             raise ValueError(
-                "ld_credential_detail must be populated if CredentialType.LD_PROOF is selected"
+                "ld_credential_detail must be populated if `ld_proof` credential type is selected"
             )
         return value
 

--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -7,10 +7,10 @@ from pydantic import BaseModel, validator
 from shared.models.protocol import IssueCredentialProtocolVersion
 
 
-class CredentialType(Enum):
-    INDY = "indy"
-    JWT = "jwt"
-    LD_PROOF = "ld_proof"
+class CredentialType(str, Enum):
+    INDY: str = "indy"
+    JWT: str = "jwt"
+    LD_PROOF: str = "ld_proof"
 
 
 class IndyCredential(BaseModel):

--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -47,7 +47,7 @@ class CredentialWithConnection(CredentialBase):
 
 
 class CredentialWithProtocol(CredentialBase):
-    protocol_version: IssueCredentialProtocolVersion
+    protocol_version: IssueCredentialProtocolVersion = IssueCredentialProtocolVersion.v2
 
 
 class SendCredential(CredentialWithProtocol, CredentialWithConnection):

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -60,17 +60,3 @@ class CreateTenantResponse(Tenant, TenantAuth):
 class OnboardResult(BaseModel):
     did: str
     didcomm_invitation: Optional[AnyHttpUrl]
-
-
-def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
-    label: str = wallet_record.settings["default_label"]
-    image_url: Optional[str] = wallet_record.settings.get("image_url")
-
-    return Tenant(
-        tenant_id=wallet_record.wallet_id,
-        tenant_name=label,
-        image_url=image_url,
-        created_at=wallet_record.created_at,
-        updated_at=wallet_record.updated_at,
-        group_id=wallet_record.group_id if hasattr(wallet_record, "group_id") else None,
-    )

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -6,21 +6,16 @@ from pydantic import BaseModel
 from shared.models.protocol import PresentProofProtocolVersion
 
 
-class SendProofRequest(BaseModel):
-    connection_id: str
-    proof_request: IndyProofRequest
-    auto_verify: Optional[bool] = None
-    comment: Optional[str] = None
-    trace: Optional[bool] = None
-    protocol_version: PresentProofProtocolVersion
-
-
 class CreateProofRequest(BaseModel):
     proof_request: IndyProofRequest
     auto_verify: Optional[bool] = None
     comment: Optional[str] = None
     trace: Optional[bool] = None
     protocol_version: PresentProofProtocolVersion
+
+
+class SendProofRequest(CreateProofRequest):
+    connection_id: str
 
 
 class AcceptProofRequest(BaseModel):

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -12,10 +12,10 @@ from pydantic import BaseModel, validator
 from shared.models.protocol import PresentProofProtocolVersion
 
 
-class ProofRequestType(Enum):
-    INDY = "indy"
-    JWT = "jwt"
-    LD_PROOF = "ld_proof"
+class ProofRequestType(str, Enum):
+    INDY: str = "indy"
+    JWT: str = "jwt"
+    LD_PROOF: str = "ld_proof"
 
 
 class ProofRequestBase(BaseModel):

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -1,7 +1,12 @@
 from enum import Enum
 from typing import Optional
 
-from aries_cloudcontroller import DIFProofRequest, IndyPresSpec, IndyProofRequest
+from aries_cloudcontroller import (
+    DIFPresSpec,
+    DIFProofRequest,
+    IndyPresSpec,
+    IndyProofRequest,
+)
 from pydantic import BaseModel, validator
 
 from shared.models.protocol import PresentProofProtocolVersion
@@ -57,7 +62,27 @@ class ProofId(BaseModel):
 
 
 class AcceptProofRequest(ProofRequestBase, ProofId):
-    pass
+    type: ProofRequestType = ProofRequestType.INDY
+    indy_presentation_spec: Optional[IndyPresSpec]
+    dif_presentation_spec: Optional[DIFPresSpec]
+
+    @validator("indy_presentation_spec", pre=True, always=True)
+    @classmethod
+    def check_indy_presentation_spec(cls, value, values):
+        if values.get("type") == ProofRequestType.INDY and value is None:
+            raise ValueError(
+                "indy_presentation_spec must be populated if `indy` type is selected"
+            )
+        return value
+
+    @validator("dif_presentation_spec", pre=True, always=True)
+    @classmethod
+    def check_dif_presentation_spec(cls, value, values):
+        if values.get("type") == ProofRequestType.LD_PROOF and value is None:
+            raise ValueError(
+                "dif_presentation_spec must be populated if `ld_proof` type is selected"
+            )
+        return value
 
 
 class RejectProofRequest(ProofId):

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -43,7 +43,7 @@ class ProofRequestBase(BaseModel):
 
 
 class ProofRequestMetadata(BaseModel):
-    protocol_version: PresentProofProtocolVersion
+    protocol_version: PresentProofProtocolVersion = PresentProofProtocolVersion.v2
     auto_verify: Optional[bool] = None
     comment: Optional[str] = None
     trace: Optional[bool] = None

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -61,7 +61,7 @@ class ProofId(BaseModel):
     proof_id: str
 
 
-class AcceptProofRequest(ProofRequestBase, ProofId):
+class AcceptProofRequest(ProofId):
     type: ProofRequestType = ProofRequestType.INDY
     indy_presentation_spec: Optional[IndyPresSpec]
     dif_presentation_spec: Optional[DIFPresSpec]

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -1,17 +1,33 @@
+from enum import Enum
 from typing import Optional
 
-from aries_cloudcontroller import IndyPresSpec, IndyProofRequest
+from aries_cloudcontroller import DIFProofRequest, IndyPresSpec, IndyProofRequest
 from pydantic import BaseModel
 
 from shared.models.protocol import PresentProofProtocolVersion
 
 
-class CreateProofRequest(BaseModel):
-    proof_request: IndyProofRequest
+class ProofRequestType(Enum):
+    INDY = "indy"
+    JWT = "jwt"
+    LD_PROOF = "ld_proof"
+
+
+class ProofRequestBase(BaseModel):
+    type: ProofRequestType = ProofRequestType.INDY
+    indy_proof_request: Optional[IndyProofRequest]
+    ld_proof_request: Optional[DIFProofRequest]
+
+
+class ProofRequestMetadata(BaseModel):
+    protocol_version: PresentProofProtocolVersion
     auto_verify: Optional[bool] = None
     comment: Optional[str] = None
     trace: Optional[bool] = None
-    protocol_version: PresentProofProtocolVersion
+
+
+class CreateProofRequest(ProofRequestBase, ProofRequestMetadata):
+    pass
 
 
 class SendProofRequest(CreateProofRequest):

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -21,7 +21,7 @@ class ProofRequestType(Enum):
 class ProofRequestBase(BaseModel):
     type: ProofRequestType = ProofRequestType.INDY
     indy_proof_request: Optional[IndyProofRequest]
-    ld_proof_request: Optional[DIFProofRequest]
+    dif_proof_request: Optional[DIFProofRequest]
 
     @validator("indy_proof_request", pre=True, always=True)
     @classmethod
@@ -32,12 +32,12 @@ class ProofRequestBase(BaseModel):
             )
         return value
 
-    @validator("ld_proof_request", pre=True, always=True)
+    @validator("dif_proof_request", pre=True, always=True)
     @classmethod
-    def check_ld_proof_request(cls, value, values):
+    def check_dif_proof_request(cls, value, values):
         if values.get("type") == ProofRequestType.LD_PROOF and value is None:
             raise ValueError(
-                "ld_proof_request must be populated if `ld_proof` type is selected"
+                "dif_proof_request must be populated if `ld_proof` type is selected"
             )
         return value
 

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -23,7 +23,7 @@ class ProofRequestBase(BaseModel):
     def check_indy_proof_request(cls, value, values):
         if values.get("type") == ProofRequestType.INDY and value is None:
             raise ValueError(
-                "indy_proof_request must be populated if ProofRequestType.INDY is selected"
+                "indy_proof_request must be populated if `indy` type is selected"
             )
         return value
 
@@ -32,7 +32,7 @@ class ProofRequestBase(BaseModel):
     def check_ld_proof_request(cls, value, values):
         if values.get("type") == ProofRequestType.LD_PROOF and value is None:
             raise ValueError(
-                "ld_proof_request must be populated if ProofRequestType.LD_PROOF is selected"
+                "ld_proof_request must be populated if `ld_proof` type is selected"
             )
         return value
 

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -18,11 +18,13 @@ class SendProofRequest(CreateProofRequest):
     connection_id: str
 
 
-class AcceptProofRequest(BaseModel):
+class ProofId(BaseModel):
     proof_id: str
-    presentation_spec: IndyPresSpec
 
 
-class RejectProofRequest(BaseModel):
-    proof_id: str
+class AcceptProofRequest(ProofId):
+    indy_presentation_spec: Optional[IndyPresSpec]
+
+
+class RejectProofRequest(ProofId):
     problem_report: Optional[str] = None

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from aries_cloudcontroller import DIFProofRequest, IndyPresSpec, IndyProofRequest
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from shared.models.protocol import PresentProofProtocolVersion
 
@@ -17,6 +17,24 @@ class ProofRequestBase(BaseModel):
     type: ProofRequestType = ProofRequestType.INDY
     indy_proof_request: Optional[IndyProofRequest]
     ld_proof_request: Optional[DIFProofRequest]
+
+    @validator("indy_proof_request", pre=True, always=True)
+    @classmethod
+    def check_indy_proof_request(cls, value, values):
+        if values.get("type") == ProofRequestType.INDY and value is None:
+            raise ValueError(
+                "indy_proof_request must be populated if ProofRequestType.INDY is selected"
+            )
+        return value
+
+    @validator("ld_proof_request", pre=True, always=True)
+    @classmethod
+    def check_ld_proof_request(cls, value, values):
+        if values.get("type") == ProofRequestType.LD_PROOF and value is None:
+            raise ValueError(
+                "ld_proof_request must be populated if ProofRequestType.LD_PROOF is selected"
+            )
+        return value
 
 
 class ProofRequestMetadata(BaseModel):

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -38,8 +38,8 @@ class ProofId(BaseModel):
     proof_id: str
 
 
-class AcceptProofRequest(ProofId):
-    indy_presentation_spec: Optional[IndyPresSpec]
+class AcceptProofRequest(ProofRequestBase, ProofId):
+    pass
 
 
 class RejectProofRequest(ProofId):

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -24,7 +24,6 @@ from app.models.tenants import (
     TenantAuth,
     UpdateTenantRequest,
     WalletListWithGroups,
-    tenant_from_wallet_record,
 )
 from app.services.onboarding import handle_tenant_update, onboard_tenant
 from app.services.trust_registry import (
@@ -35,6 +34,7 @@ from app.services.trust_registry import (
     register_actor,
     remove_actor_by_id,
 )
+from app.util.tenants import tenant_from_wallet_record
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -28,7 +28,7 @@ router = APIRouter(prefix="/generic/verifier", tags=["verifier"])
 
 @router.post("/create-request", response_model=PresentationExchange)
 async def create_proof_request(
-    proof_request: CreateProofRequest,
+    create_proof_request: CreateProofRequest,
     auth: AcaPyAuth = Depends(acapy_auth),
 ) -> PresentationExchange:
     """
@@ -36,7 +36,7 @@ async def create_proof_request(
 
     Parameters:
     -----------
-    proof_request: CreateProofRequest
+    create_proof_request: CreateProofRequest
         The proof request object
 
     Returns:
@@ -44,15 +44,15 @@ async def create_proof_request(
     presentation_exchange: PresentationExchange
         The presentation exchange record
     """
-    bound_logger = logger.bind(body=proof_request)
+    bound_logger = logger.bind(body=create_proof_request)
     bound_logger.info("POST request received: Create proof request")
     try:
-        verifier = get_verifier_by_version(proof_request.protocol_version)
+        verifier = get_verifier_by_version(create_proof_request.protocol_version)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Creating proof request")
             result = await verifier.create_proof_request(
-                controller=aries_controller, create_proof_request=proof_request
+                controller=aries_controller, create_proof_request=create_proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to create presentation record.")
@@ -67,7 +67,7 @@ async def create_proof_request(
 
 @router.post("/send-request", response_model=PresentationExchange)
 async def send_proof_request(
-    proof_request: SendProofRequest,
+    send_proof_request: SendProofRequest,
     auth: AcaPyAuth = Depends(acapy_auth),
 ) -> PresentationExchange:
     """
@@ -75,7 +75,7 @@ async def send_proof_request(
 
     Parameters:
     -----------
-    proof_request: SendProofRequest
+    send_proof_request: SendProofRequest
         The proof request object
 
     Returns:
@@ -83,20 +83,20 @@ async def send_proof_request(
     presentation_exchange: PresentationExchange
         The presentation exchange record
     """
-    bound_logger = logger.bind(body=proof_request)
+    bound_logger = logger.bind(body=send_proof_request)
     bound_logger.info("POST request received: Send proof request")
     try:
-        verifier = get_verifier_by_version(proof_request.protocol_version)
+        verifier = get_verifier_by_version(send_proof_request.protocol_version)
 
         async with client_from_auth(auth) as aries_controller:
-            if proof_request.connection_id:
+            if send_proof_request.connection_id:
                 await assert_valid_verifier(
-                    aries_controller=aries_controller, proof_request=proof_request
+                    aries_controller=aries_controller, proof_request=send_proof_request
                 )
 
             bound_logger.debug("Sending proof request")
             result = await verifier.send_proof_request(
-                controller=aries_controller, send_proof_request=proof_request
+                controller=aries_controller, send_proof_request=send_proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to send proof request.")
@@ -111,7 +111,7 @@ async def send_proof_request(
 
 @router.post("/accept-request", response_model=PresentationExchange)
 async def accept_proof_request(
-    presentation: AcceptProofRequest,
+    accept_proof_request: AcceptProofRequest,
     auth: AcaPyAuth = Depends(acapy_auth),
 ) -> PresentationExchange:
     """
@@ -119,7 +119,7 @@ async def accept_proof_request(
 
     Parameters:
     -----------
-    proof_request: AcceptProofRequest
+    accept_proof_request: AcceptProofRequest
         The proof request object
 
     Returns:
@@ -127,15 +127,15 @@ async def accept_proof_request(
     presentation_exchange: PresentationExchange
         The presentation exchange record
     """
-    bound_logger = logger.bind(body=presentation)
+    bound_logger = logger.bind(body=accept_proof_request)
     bound_logger.info("POST request received: Accept proof request")
     try:
-        verifier = get_verifier_by_version(presentation.proof_id)
+        verifier = get_verifier_by_version(accept_proof_request.proof_id)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Get proof record")
             proof_record = await verifier.get_proof_record(
-                controller=aries_controller, proof_id=presentation.proof_id
+                controller=aries_controller, proof_id=accept_proof_request.proof_id
             )
 
             # If there is a connection id the proof is not connectionless
@@ -143,7 +143,7 @@ async def accept_proof_request(
                 await assert_valid_prover(
                     aries_controller=aries_controller,
                     verifier=verifier,
-                    presentation=presentation,
+                    presentation=accept_proof_request,
                 )
             else:
                 bound_logger.warning(
@@ -152,7 +152,7 @@ async def accept_proof_request(
 
             bound_logger.debug("Accepting proof record")
             result = await verifier.accept_proof_request(
-                controller=aries_controller, accept_proof_request=presentation
+                controller=aries_controller, accept_proof_request=accept_proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to accept proof request.")
@@ -167,7 +167,7 @@ async def accept_proof_request(
 
 @router.post("/reject-request", status_code=204)
 async def reject_proof_request(
-    proof_request: RejectProofRequest,
+    reject_proof_request: RejectProofRequest,
     auth: AcaPyAuth = Depends(acapy_auth),
 ) -> None:
     """
@@ -175,22 +175,22 @@ async def reject_proof_request(
 
     Parameters:
     -----------
-    proof_request: RejectProofRequest
+    reject_proof_request: RejectProofRequest
         The proof request object
 
     Returns:
     --------
     None
     """
-    bound_logger = logger.bind(body=proof_request)
+    bound_logger = logger.bind(body=reject_proof_request)
     bound_logger.info("POST request received: Reject proof request")
     try:
-        verifier = get_verifier_by_version(proof_request.proof_id)
+        verifier = get_verifier_by_version(reject_proof_request.proof_id)
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Getting proof record")
             proof_record = await verifier.get_proof_record(
-                controller=aries_controller, proof_id=proof_request.proof_id
+                controller=aries_controller, proof_id=reject_proof_request.proof_id
             )
 
             if proof_record.state != "request-received":
@@ -205,7 +205,7 @@ async def reject_proof_request(
 
             bound_logger.debug("Rejecting proof request")
             await verifier.reject_proof_request(
-                controller=aries_controller, reject_proof_request=proof_request
+                controller=aries_controller, reject_proof_request=reject_proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to reject request.")

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -26,146 +26,6 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/generic/verifier", tags=["verifier"])
 
 
-@router.get("/proofs", response_model=List[PresentationExchange])
-async def get_proof_records(
-    auth: AcaPyAuth = Depends(acapy_auth),
-) -> List[PresentationExchange]:
-    """
-    Get all proof records
-
-    Returns:
-    --------
-    presentation_exchange_list: [PresentationExchange]
-        The list of presentation exchange records
-    """
-    logger.info("GET request received: Get all proof records")
-    try:
-        async with client_from_auth(auth) as aries_controller:
-            logger.debug("Fetching v1 proof records")
-            v1_records = await VerifierFacade.v1.value.get_proof_records(
-                controller=aries_controller
-            )
-            logger.debug("Fetching v2 proof records")
-            v2_records = await VerifierFacade.v2.value.get_proof_records(
-                controller=aries_controller
-            )
-    except Exception as e:
-        logger.exception("Failed to get proof records.")
-        raise e from e
-
-    result = v1_records + v2_records
-    if result:
-        logger.info("Successfully fetched v1 and v2 records.")
-    else:
-        logger.info("No v1 or v2 records returned.")
-    return result
-
-
-@router.get("/proofs/{proof_id}", response_model=PresentationExchange)
-async def get_proof_record(
-    proof_id: str,
-    auth: AcaPyAuth = Depends(acapy_auth),
-) -> PresentationExchange:
-    """
-    Get a specific proof record
-
-    Parameters:
-    ----------
-    proof_id: str
-        The proof ID
-
-    Returns:
-    --------
-    presentation_exchange_record: PresentationExchange
-        The of presentation exchange record for the proof ID
-    """
-    bound_logger = logger.bind(body={"proof_id": proof_id})
-    bound_logger.info("GET request received: Get proof record by id")
-    try:
-        verifier = get_verifier_by_version(version_candidate=proof_id)
-
-        async with client_from_auth(auth) as aries_controller:
-            bound_logger.debug("Fetching proof record")
-            result = await verifier.get_proof_record(
-                controller=aries_controller, proof_id=proof_id
-            )
-    except Exception as e:
-        bound_logger.exception("Failed to get proof record.")
-        raise e from e
-
-    if result:
-        bound_logger.info("Successfully fetched proof record.")
-    else:
-        bound_logger.info("No record returned.")
-    return result
-
-
-@router.get("/proofs/{proof_id}/credentials", response_model=List[IndyCredPrecis])
-async def get_credentials_by_proof_id(
-    proof_id: str,
-    auth: AcaPyAuth = Depends(acapy_auth),
-) -> List[IndyCredPrecis]:
-    """
-    Get matching credentials for presentation exchange
-
-    Parameters:
-    ----------
-    proof_id: str
-         The proof ID
-
-    Returns:
-    --------
-    presentation_exchange_list: [IndyCredPrecis]
-        The list of Indy presentation credentials
-    """
-    bound_logger = logger.bind(body={"proof_id": proof_id})
-    bound_logger.info("GET request received: Get credentials for a proof request")
-    try:
-        verifier = get_verifier_by_version(version_candidate=proof_id)
-
-        async with client_from_auth(auth) as aries_controller:
-            bound_logger.debug("Fetching credentials for request")
-            result = await verifier.get_credentials_by_proof_id(
-                controller=aries_controller, proof_id=proof_id
-            )
-    except Exception as e:
-        bound_logger.exception("Failed to get matching credentials.")
-        raise e from e
-    bound_logger.info("Successfully fetched credentials for proof request.")
-    return result
-
-
-@router.delete("/proofs/{proof_id}", status_code=204)
-async def delete_proof(
-    proof_id: str,
-    auth: AcaPyAuth = Depends(acapy_auth),
-) -> None:
-    """
-    Delete proofs record for proof_id (pres_ex_id including prepending version hint 'v1-' or 'v2-')
-
-    Parameters:
-    ----------
-    proof_id: str
-        The proof ID - starting with v1- or v2-
-
-    Returns:
-    --------
-    None
-    """
-    bound_logger = logger.bind(body={"proof_id": proof_id})
-    bound_logger.info("DELETE request received: Delete proof record by id")
-    try:
-        verifier = get_verifier_by_version(version_candidate=proof_id)
-
-        async with client_from_auth(auth) as aries_controller:
-            bound_logger.debug("Deleting proof record")
-            await verifier.delete_proof(controller=aries_controller, proof_id=proof_id)
-    except Exception as e:
-        bound_logger.exception("Failed to delete proof record.")
-        raise e from e
-    bound_logger.info("Successfully deleted proof record.")
-
-
 @router.post("/create-request", response_model=PresentationExchange)
 async def create_proof_request(
     proof_request: CreateProofRequest,
@@ -352,3 +212,143 @@ async def reject_proof_request(
         raise e from e
 
     bound_logger.info("Successfully rejected proof request.")
+
+
+@router.get("/proofs", response_model=List[PresentationExchange])
+async def get_proof_records(
+    auth: AcaPyAuth = Depends(acapy_auth),
+) -> List[PresentationExchange]:
+    """
+    Get all proof records
+
+    Returns:
+    --------
+    presentation_exchange_list: [PresentationExchange]
+        The list of presentation exchange records
+    """
+    logger.info("GET request received: Get all proof records")
+    try:
+        async with client_from_auth(auth) as aries_controller:
+            logger.debug("Fetching v1 proof records")
+            v1_records = await VerifierFacade.v1.value.get_proof_records(
+                controller=aries_controller
+            )
+            logger.debug("Fetching v2 proof records")
+            v2_records = await VerifierFacade.v2.value.get_proof_records(
+                controller=aries_controller
+            )
+    except Exception as e:
+        logger.exception("Failed to get proof records.")
+        raise e from e
+
+    result = v1_records + v2_records
+    if result:
+        logger.info("Successfully fetched v1 and v2 records.")
+    else:
+        logger.info("No v1 or v2 records returned.")
+    return result
+
+
+@router.get("/proofs/{proof_id}", response_model=PresentationExchange)
+async def get_proof_record(
+    proof_id: str,
+    auth: AcaPyAuth = Depends(acapy_auth),
+) -> PresentationExchange:
+    """
+    Get a specific proof record
+
+    Parameters:
+    ----------
+    proof_id: str
+        The proof ID
+
+    Returns:
+    --------
+    presentation_exchange_record: PresentationExchange
+        The of presentation exchange record for the proof ID
+    """
+    bound_logger = logger.bind(body={"proof_id": proof_id})
+    bound_logger.info("GET request received: Get proof record by id")
+    try:
+        verifier = get_verifier_by_version(version_candidate=proof_id)
+
+        async with client_from_auth(auth) as aries_controller:
+            bound_logger.debug("Fetching proof record")
+            result = await verifier.get_proof_record(
+                controller=aries_controller, proof_id=proof_id
+            )
+    except Exception as e:
+        bound_logger.exception("Failed to get proof record.")
+        raise e from e
+
+    if result:
+        bound_logger.info("Successfully fetched proof record.")
+    else:
+        bound_logger.info("No record returned.")
+    return result
+
+
+@router.delete("/proofs/{proof_id}", status_code=204)
+async def delete_proof(
+    proof_id: str,
+    auth: AcaPyAuth = Depends(acapy_auth),
+) -> None:
+    """
+    Delete proofs record for proof_id (pres_ex_id including prepending version hint 'v1-' or 'v2-')
+
+    Parameters:
+    ----------
+    proof_id: str
+        The proof ID - starting with v1- or v2-
+
+    Returns:
+    --------
+    None
+    """
+    bound_logger = logger.bind(body={"proof_id": proof_id})
+    bound_logger.info("DELETE request received: Delete proof record by id")
+    try:
+        verifier = get_verifier_by_version(version_candidate=proof_id)
+
+        async with client_from_auth(auth) as aries_controller:
+            bound_logger.debug("Deleting proof record")
+            await verifier.delete_proof(controller=aries_controller, proof_id=proof_id)
+    except Exception as e:
+        bound_logger.exception("Failed to delete proof record.")
+        raise e from e
+    bound_logger.info("Successfully deleted proof record.")
+
+
+@router.get("/proofs/{proof_id}/credentials", response_model=List[IndyCredPrecis])
+async def get_credentials_by_proof_id(
+    proof_id: str,
+    auth: AcaPyAuth = Depends(acapy_auth),
+) -> List[IndyCredPrecis]:
+    """
+    Get matching credentials for presentation exchange
+
+    Parameters:
+    ----------
+    proof_id: str
+         The proof ID
+
+    Returns:
+    --------
+    presentation_exchange_list: [IndyCredPrecis]
+        The list of Indy presentation credentials
+    """
+    bound_logger = logger.bind(body={"proof_id": proof_id})
+    bound_logger.info("GET request received: Get credentials for a proof request")
+    try:
+        verifier = get_verifier_by_version(version_candidate=proof_id)
+
+        async with client_from_auth(auth) as aries_controller:
+            bound_logger.debug("Fetching credentials for request")
+            result = await verifier.get_credentials_by_proof_id(
+                controller=aries_controller, proof_id=proof_id
+            )
+    except Exception as e:
+        bound_logger.exception("Failed to get matching credentials.")
+        raise e from e
+    bound_logger.info("Successfully fetched credentials for proof request.")
+    return result

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -46,6 +46,7 @@ async def create_proof_request(
     """
     bound_logger = logger.bind(body=create_proof_request)
     bound_logger.info("POST request received: Create proof request")
+
     try:
         verifier = get_verifier_by_version(create_proof_request.protocol_version)
 
@@ -85,6 +86,7 @@ async def send_proof_request(
     """
     bound_logger = logger.bind(body=send_proof_request)
     bound_logger.info("POST request received: Send proof request")
+
     try:
         verifier = get_verifier_by_version(send_proof_request.protocol_version)
 
@@ -129,6 +131,7 @@ async def accept_proof_request(
     """
     bound_logger = logger.bind(body=accept_proof_request)
     bound_logger.info("POST request received: Accept proof request")
+
     try:
         verifier = get_verifier_by_version(accept_proof_request.proof_id)
 
@@ -184,6 +187,7 @@ async def reject_proof_request(
     """
     bound_logger = logger.bind(body=reject_proof_request)
     bound_logger.info("POST request received: Reject proof request")
+
     try:
         verifier = get_verifier_by_version(reject_proof_request.proof_id)
 
@@ -227,6 +231,7 @@ async def get_proof_records(
         The list of presentation exchange records
     """
     logger.info("GET request received: Get all proof records")
+
     try:
         async with client_from_auth(auth) as aries_controller:
             logger.debug("Fetching v1 proof records")
@@ -269,6 +274,7 @@ async def get_proof_record(
     """
     bound_logger = logger.bind(body={"proof_id": proof_id})
     bound_logger.info("GET request received: Get proof record by id")
+
     try:
         verifier = get_verifier_by_version(version_candidate=proof_id)
 
@@ -307,6 +313,7 @@ async def delete_proof(
     """
     bound_logger = logger.bind(body={"proof_id": proof_id})
     bound_logger.info("DELETE request received: Delete proof record by id")
+
     try:
         verifier = get_verifier_by_version(version_candidate=proof_id)
 
@@ -339,6 +346,7 @@ async def get_credentials_by_proof_id(
     """
     bound_logger = logger.bind(body={"proof_id": proof_id})
     bound_logger.info("GET request received: Get credentials for a proof request")
+
     try:
         verifier = get_verifier_by_version(version_candidate=proof_id)
 

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -192,7 +192,7 @@ async def create_proof_request(
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Creating proof request")
             result = await verifier.create_proof_request(
-                controller=aries_controller, proof_request=proof_request
+                controller=aries_controller, create_proof_request=proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to create presentation record.")
@@ -236,7 +236,7 @@ async def send_proof_request(
 
             bound_logger.debug("Sending proof request")
             result = await verifier.send_proof_request(
-                controller=aries_controller, proof_request=proof_request
+                controller=aries_controller, send_proof_request=proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to send proof request.")
@@ -292,7 +292,7 @@ async def accept_proof_request(
 
             bound_logger.debug("Accepting proof record")
             result = await verifier.accept_proof_request(
-                controller=aries_controller, proof_request=presentation
+                controller=aries_controller, accept_proof_request=presentation
             )
     except Exception as e:
         bound_logger.exception("Failed to accept proof request.")
@@ -345,7 +345,7 @@ async def reject_proof_request(
 
             bound_logger.debug("Rejecting proof request")
             await verifier.reject_proof_request(
-                controller=aries_controller, proof_request=proof_request
+                controller=aries_controller, reject_proof_request=proof_request
             )
     except Exception as e:
         bound_logger.exception("Failed to reject request.")

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -101,7 +101,7 @@ async def get_proof_record(
 
 
 @router.get("/proofs/{proof_id}/credentials", response_model=List[IndyCredPrecis])
-async def get_credentials_for_request(
+async def get_credentials_by_proof_id(
     proof_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
 ) -> List[IndyCredPrecis]:
@@ -125,7 +125,7 @@ async def get_credentials_for_request(
 
         async with client_from_auth(auth) as aries_controller:
             bound_logger.debug("Fetching credentials for request")
-            result = await verifier.get_credentials_for_request(
+            result = await verifier.get_credentials_by_proof_id(
                 controller=aries_controller, proof_id=proof_id
             )
     except Exception as e:

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -12,7 +12,8 @@ from aries_cloudcontroller.model.v10_credential_store_request import (
     V10CredentialStoreRequest,
 )
 
-from app.models.issuer import CredentialBase, CredentialWithConnection
+from app.exceptions.cloud_api_error import CloudApiException
+from app.models.issuer import CredentialBase, CredentialType, CredentialWithConnection
 from app.services.issuer.acapy_issuer import Issuer
 from app.util.credentials import cred_id_no_version
 from shared.log_config import get_logger
@@ -27,6 +28,12 @@ class IssuerV1(Issuer):
     async def send_credential(
         cls, controller: AcaPyClient, credential: CredentialWithConnection
     ):
+        if credential.type != CredentialType.INDY:
+            raise CloudApiException(
+                f"Only Indy credential types are supported in v1. Requested type: {credential.type}",
+                status_code=400,
+            )
+
         bound_logger = logger.bind(body=credential)
         bound_logger.debug("Getting credential preview from attributes")
         credential_preview = cls.__preview_from_attributes(
@@ -47,6 +54,12 @@ class IssuerV1(Issuer):
 
     @classmethod
     async def create_offer(cls, controller: AcaPyClient, credential: CredentialBase):
+        if credential.type != CredentialType.INDY:
+            raise CloudApiException(
+                f"Only Indy credential types are supported in v1. Requested type: {credential.type}",
+                status_code=400,
+            )
+
         bound_logger = logger.bind(body=credential)
         bound_logger.debug("Getting credential preview from attributes")
         credential_preview = cls.__preview_from_attributes(

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -30,11 +30,11 @@ class IssuerV2(Issuer):
         cls, controller: AcaPyClient, credential: CredentialWithConnection
     ):
         bound_logger = logger.bind(body=credential)
-        bound_logger.debug("Getting credential preview from attributes")
 
         credential_preview = None
         # Determine the appropriate filter based on the type
         if credential.type == CredentialType.INDY:
+            bound_logger.debug("Getting credential preview from attributes")
             credential_preview = cls.__preview_from_attributes(
                 attributes=credential.indy_credential_detail.attributes
             )
@@ -65,11 +65,11 @@ class IssuerV2(Issuer):
     @classmethod
     async def create_offer(cls, controller: AcaPyClient, credential: CredentialBase):
         bound_logger = logger.bind(body=credential)
-        bound_logger.debug("Getting credential preview from attributes")
 
         credential_preview = None
         # Determine the appropriate filter based on the type
         if credential.type == CredentialType.INDY:
+            bound_logger.debug("Getting credential preview from attributes")
             credential_preview = cls.__preview_from_attributes(
                 attributes=credential.indy_credential_detail.attributes
             )

--- a/app/services/verifier/acapy_verifier.py
+++ b/app/services/verifier/acapy_verifier.py
@@ -164,7 +164,7 @@ class Verifier(ABC):
 
     @classmethod
     @abstractmethod
-    async def get_credentials_for_request(
+    async def get_credentials_by_proof_id(
         cls, controller: AcaPyClient, proof_id: str
     ) -> List[IndyCredPrecis]:
         """

--- a/app/services/verifier/acapy_verifier.py
+++ b/app/services/verifier/acapy_verifier.py
@@ -17,29 +17,6 @@ class Verifier(ABC):
 
     @classmethod
     @abstractmethod
-    async def send_proof_request(
-        cls,
-        controller: AcaPyClient,
-        proof_request: SendProofRequest,
-    ) -> PresentationExchange:
-        """
-        Request proof from a connection ID.
-
-        Parameters:
-        -----------
-        controller: AcaPyClient
-            The aries_cloudcontroller object
-        proof_request: SendProofRequest
-            The proof request object
-
-        Returns:
-        --------
-        exchange_record: PresentationExchange
-            The proof exchange record
-        """
-
-    @classmethod
-    @abstractmethod
     async def create_proof_request(
         cls,
         controller: AcaPyClient,
@@ -53,6 +30,29 @@ class Verifier(ABC):
         controller: AcaPyClient
             The aries_cloudcontroller object
         proof_request: CreateProofRequest
+            The proof request object
+
+        Returns:
+        --------
+        exchange_record: PresentationExchange
+            The proof exchange record
+        """
+
+    @classmethod
+    @abstractmethod
+    async def send_proof_request(
+        cls,
+        controller: AcaPyClient,
+        proof_request: SendProofRequest,
+    ) -> PresentationExchange:
+        """
+        Request proof from a connection ID.
+
+        Parameters:
+        -----------
+        controller: AcaPyClient
+            The aries_cloudcontroller object
+        proof_request: SendProofRequest
             The proof request object
 
         Returns:
@@ -105,25 +105,6 @@ class Verifier(ABC):
 
     @classmethod
     @abstractmethod
-    async def delete_proof(cls, controller: AcaPyClient, proof_id: str) -> None:
-        """
-        Delete proof request
-
-        Parameters:
-        -----------
-        controller: AcaPyClient
-            The aries_cloudcontroller object
-        proof_id: str
-            The proof record exchange id
-
-        Returns:
-        --------
-        None
-            Returns None on successful record deletion.
-        """
-
-    @classmethod
-    @abstractmethod
     async def get_proof_records(
         cls, controller: AcaPyClient
     ) -> List[PresentationExchange]:
@@ -160,6 +141,25 @@ class Verifier(ABC):
         --------
         PresentationExchange
             A presentation exchange records
+        """
+
+    @classmethod
+    @abstractmethod
+    async def delete_proof(cls, controller: AcaPyClient, proof_id: str) -> None:
+        """
+        Delete proof request
+
+        Parameters:
+        -----------
+        controller: AcaPyClient
+            The aries_cloudcontroller object
+        proof_id: str
+            The proof record exchange id
+
+        Returns:
+        --------
+        None
+            Returns None on successful record deletion.
         """
 
     @classmethod

--- a/app/services/verifier/acapy_verifier.py
+++ b/app/services/verifier/acapy_verifier.py
@@ -20,7 +20,7 @@ class Verifier(ABC):
     async def create_proof_request(
         cls,
         controller: AcaPyClient,
-        proof_request: CreateProofRequest,
+        create_proof_request: CreateProofRequest,
     ) -> PresentationExchange:
         """
         Create proof request
@@ -29,7 +29,7 @@ class Verifier(ABC):
         -----------
         controller: AcaPyClient
             The aries_cloudcontroller object
-        proof_request: CreateProofRequest
+        create_proof_request: CreateProofRequest
             The proof request object
 
         Returns:
@@ -43,7 +43,7 @@ class Verifier(ABC):
     async def send_proof_request(
         cls,
         controller: AcaPyClient,
-        proof_request: SendProofRequest,
+        send_proof_request: SendProofRequest,
     ) -> PresentationExchange:
         """
         Request proof from a connection ID.
@@ -52,7 +52,7 @@ class Verifier(ABC):
         -----------
         controller: AcaPyClient
             The aries_cloudcontroller object
-        proof_request: SendProofRequest
+        send_proof_request: SendProofRequest
             The proof request object
 
         Returns:
@@ -64,7 +64,7 @@ class Verifier(ABC):
     @classmethod
     @abstractmethod
     async def accept_proof_request(
-        cls, controller: AcaPyClient, proof_request: AcceptProofRequest
+        cls, controller: AcaPyClient, accept_proof_request: AcceptProofRequest
     ) -> PresentationExchange:
         """
         Accept proof request
@@ -73,7 +73,7 @@ class Verifier(ABC):
         -----------
         controller: AcaPyClient
             The aries_cloudcontroller object
-        proof_request: AcceptProofRequest
+        accept_proof_request: AcceptProofRequest
             The proof request object
 
         Returns:
@@ -85,7 +85,7 @@ class Verifier(ABC):
     @classmethod
     @abstractmethod
     async def reject_proof_request(
-        cls, controller: AcaPyClient, proof_request: RejectProofRequest
+        cls, controller: AcaPyClient, reject_proof_request: RejectProofRequest
     ) -> None:
         """
         Reject proof request
@@ -94,7 +94,7 @@ class Verifier(ABC):
         -----------
         controller: AcaPyClient
             The aries_cloudcontroller object
-        proof_request: RejectProofRequest
+        reject_proof_request: RejectProofRequest
             The proof request object
 
         Returns:

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -26,19 +26,19 @@ class VerifierV1(Verifier):
     async def create_proof_request(
         cls,
         controller: AcaPyClient,
-        proof_request: CreateProofRequest,
+        create_proof_request: CreateProofRequest,
     ) -> PresentationExchange:
-        bound_logger = logger.bind(body=proof_request)
+        bound_logger = logger.bind(body=create_proof_request)
         bound_logger.debug("Creating v1 proof request")
 
         try:
             presentation_exchange = (
                 await controller.present_proof_v1_0.create_proof_request(
                     body=V10PresentationCreateRequestRequest(
-                        proof_request=proof_request.proof_request,
-                        auto_verify=proof_request.auto_verify,
-                        comment=proof_request.comment,
-                        trace=proof_request.trace,
+                        proof_request=create_proof_request.proof_request,
+                        auto_verify=create_proof_request.auto_verify,
+                        comment=create_proof_request.comment,
+                        trace=create_proof_request.trace,
                     )
                 )
             )
@@ -54,19 +54,19 @@ class VerifierV1(Verifier):
     async def send_proof_request(
         cls,
         controller: AcaPyClient,
-        proof_request: SendProofRequest,
+        send_proof_request: SendProofRequest,
     ) -> PresentationExchange:
-        bound_logger = logger.bind(body=proof_request)
+        bound_logger = logger.bind(body=send_proof_request)
         try:
             bound_logger.debug("Send free v1 presentation request")
             presentation_exchange = (
                 await controller.present_proof_v1_0.send_request_free(
                     body=V10PresentationSendRequestRequest(
-                        connection_id=proof_request.connection_id,
-                        proof_request=proof_request.proof_request,
-                        auto_verify=proof_request.auto_verify,
-                        comment=proof_request.comment,
-                        trace=proof_request.trace,
+                        connection_id=send_proof_request.connection_id,
+                        proof_request=send_proof_request.proof_request,
+                        auto_verify=send_proof_request.auto_verify,
+                        comment=send_proof_request.comment,
+                        trace=send_proof_request.trace,
                     )
                 )
             )
@@ -85,15 +85,15 @@ class VerifierV1(Verifier):
 
     @classmethod
     async def accept_proof_request(
-        cls, controller: AcaPyClient, proof_request: AcceptProofRequest
+        cls, controller: AcaPyClient, accept_proof_request: AcceptProofRequest
     ) -> PresentationExchange:
-        bound_logger = logger.bind(body=proof_request)
-        proof_id = pres_id_no_version(proof_id=proof_request.proof_id)
+        bound_logger = logger.bind(body=accept_proof_request)
+        proof_id = pres_id_no_version(proof_id=accept_proof_request.proof_id)
 
         try:
             bound_logger.debug("Send v1 proof presentation")
             presentation_record = await controller.present_proof_v1_0.send_presentation(
-                pres_ex_id=proof_id, body=proof_request.presentation_spec
+                pres_ex_id=proof_id, body=accept_proof_request.presentation_spec
             )
             result = record_to_model(presentation_record)
         except Exception as e:
@@ -110,20 +110,20 @@ class VerifierV1(Verifier):
 
     @classmethod
     async def reject_proof_request(
-        cls, controller: AcaPyClient, proof_request: RejectProofRequest
+        cls, controller: AcaPyClient, reject_proof_request: RejectProofRequest
     ) -> None:
-        bound_logger = logger.bind(body=proof_request)
+        bound_logger = logger.bind(body=reject_proof_request)
         bound_logger.info("Request to reject v1 presentation exchange record")
-        proof_id = pres_id_no_version(proof_id=proof_request.proof_id)
+        proof_id = pres_id_no_version(proof_id=reject_proof_request.proof_id)
 
         # Report problem if desired
-        if proof_request.problem_report:
+        if reject_proof_request.problem_report:
             try:
                 bound_logger.debug("Submitting v1 problem report")
                 await controller.present_proof_v1_0.report_problem(
                     pres_ex_id=proof_id,
                     body=V10PresentationProblemReportRequest(
-                        description=proof_request.problem_report
+                        description=reject_proof_request.problem_report
                     ),
                 )
             except Exception as e:

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -30,18 +30,25 @@ class VerifierV1(Verifier):
     ) -> PresentationExchange:
         bound_logger = logger.bind(body=proof_request)
         bound_logger.debug("Creating v1 proof request")
-        presentation_exchange = (
-            await controller.present_proof_v1_0.create_proof_request(
-                body=V10PresentationCreateRequestRequest(
-                    proof_request=proof_request.proof_request,
-                    auto_verify=proof_request.auto_verify,
-                    comment=proof_request.comment,
-                    trace=proof_request.trace,
+
+        try:
+            presentation_exchange = (
+                await controller.present_proof_v1_0.create_proof_request(
+                    body=V10PresentationCreateRequestRequest(
+                        proof_request=proof_request.proof_request,
+                        auto_verify=proof_request.auto_verify,
+                        comment=proof_request.comment,
+                        trace=proof_request.trace,
+                    )
                 )
             )
-        )
-        bound_logger.debug("Returning v1 PresentationExchange.")
-        return record_to_model(presentation_exchange)
+            bound_logger.debug("Returning v1 PresentationExchange.")
+            return record_to_model(presentation_exchange)
+        except Exception as e:
+            bound_logger.exception(
+                "An unexpected error occurred while creating presentation request."
+            )
+            raise CloudApiException("Failed to create presentation request.") from e
 
     @classmethod
     async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -174,7 +174,9 @@ class VerifierV1(Verifier):
             result = record_to_model(presentation_exchange)
         except Exception as e:
             bound_logger.exception("An unexpected error occurred while getting record.")
-            raise CloudApiException("Failed to get proof record.") from e
+            raise CloudApiException(
+                f"Failed to get proof record with proof id `{proof_id}`."
+            ) from e
 
         if result:
             bound_logger.debug("Successfully got v1 present-proof record.")
@@ -194,7 +196,9 @@ class VerifierV1(Verifier):
             bound_logger.exception(
                 "An unexpected error occurred while deleting record."
             )
-            raise CloudApiException("Failed to delete record.") from e
+            raise CloudApiException(
+                f"Failed to delete record with proof id `{proof_id}`."
+            ) from e
 
         bound_logger.debug("Successfully deleted v1 present-proof record.")
 
@@ -212,7 +216,9 @@ class VerifierV1(Verifier):
             bound_logger.exception(
                 "An unexpected error occurred while getting matching credentials."
             )
-            raise CloudApiException("Failed to get credentials for request.") from e
+            raise CloudApiException(
+                f"Failed to get credentials with proof id `{proof_id}`."
+            ) from e
 
         if result:
             bound_logger.debug("Successfully got matching v1 credentials.")

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -9,6 +9,7 @@ from app.exceptions.cloud_api_error import CloudApiException
 from app.models.verifier import (
     AcceptProofRequest,
     CreateProofRequest,
+    ProofRequestType,
     RejectProofRequest,
     SendProofRequest,
 )
@@ -28,6 +29,12 @@ class VerifierV1(Verifier):
         controller: AcaPyClient,
         create_proof_request: CreateProofRequest,
     ) -> PresentationExchange:
+        if create_proof_request.type != ProofRequestType.INDY:
+            raise CloudApiException(
+                f"Only Indy credential types are supported in v1. Requested type: {create_proof_request.type}",
+                status_code=400,
+            )
+
         bound_logger = logger.bind(body=create_proof_request)
         bound_logger.debug("Creating v1 proof request")
 
@@ -56,6 +63,12 @@ class VerifierV1(Verifier):
         controller: AcaPyClient,
         send_proof_request: SendProofRequest,
     ) -> PresentationExchange:
+        if send_proof_request.type != ProofRequestType.INDY:
+            raise CloudApiException(
+                f"Only Indy credential types are supported in v1. Requested type: {send_proof_request.type}",
+                status_code=400,
+            )
+
         bound_logger = logger.bind(body=send_proof_request)
         try:
             bound_logger.debug("Send free v1 presentation request")
@@ -87,6 +100,12 @@ class VerifierV1(Verifier):
     async def accept_proof_request(
         cls, controller: AcaPyClient, accept_proof_request: AcceptProofRequest
     ) -> PresentationExchange:
+        if accept_proof_request.type != ProofRequestType.INDY:
+            raise CloudApiException(
+                f"Only Indy credential types are supported in v1. Requested type: {accept_proof_request.type}",
+                status_code=400,
+            )
+
         bound_logger = logger.bind(body=accept_proof_request)
         proof_id = pres_id_no_version(proof_id=accept_proof_request.proof_id)
 

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -51,83 +51,6 @@ class VerifierV1(Verifier):
             raise CloudApiException("Failed to create presentation request.") from e
 
     @classmethod
-    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
-        bound_logger = logger.bind(body={"proof_id": proof_id})
-        pres_ex_id = pres_id_no_version(proof_id=proof_id)
-
-        try:
-            bound_logger.debug("Getting v1 matching credentials from proof id")
-            result = await controller.present_proof_v1_0.get_matching_credentials(
-                pres_ex_id=pres_ex_id
-            )
-        except Exception as e:
-            bound_logger.exception(
-                "An unexpected error occurred while getting matching credentials."
-            )
-            raise CloudApiException("Failed to get credentials for request.") from e
-
-        if result:
-            bound_logger.debug("Successfully got matching v1 credentials.")
-        else:
-            bound_logger.debug("No matching v1 credentials obtained.")
-        return result
-
-    @classmethod
-    async def get_proof_records(cls, controller: AcaPyClient):
-        try:
-            logger.debug("Fetching v1 present-proof exchange records")
-            presentation_exchange = await controller.present_proof_v1_0.get_records()
-            result = [
-                record_to_model(rec) for rec in presentation_exchange.results or []
-            ]
-        except Exception as e:
-            logger.exception("An unexpected error occurred while getting records.")
-            raise CloudApiException("Failed to get proof records.") from e
-
-        if result:
-            logger.debug("Successfully got v1 present-proof records.")
-        else:
-            logger.info("No v1 present-proof records obtained.")
-        return result
-
-    @classmethod
-    async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
-        bound_logger = logger.bind(body={"proof_id": proof_id})
-        pres_ex_id = pres_id_no_version(proof_id)
-
-        try:
-            bound_logger.debug("Fetching single v1 present-proof exchange record")
-            presentation_exchange = await controller.present_proof_v1_0.get_record(
-                pres_ex_id=pres_ex_id
-            )
-            result = record_to_model(presentation_exchange)
-        except Exception as e:
-            bound_logger.exception("An unexpected error occurred while getting record.")
-            raise CloudApiException("Failed to get proof record.") from e
-
-        if result:
-            bound_logger.debug("Successfully got v1 present-proof record.")
-        else:
-            bound_logger.info("No v1 present-proof record obtained.")
-        return result
-
-    @classmethod
-    async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
-        bound_logger = logger.bind(body={"proof_id": proof_id})
-        pres_ex_id = pres_id_no_version(proof_id=proof_id)
-
-        try:
-            bound_logger.debug("Deleting v1 present-proof exchange record")
-            await controller.present_proof_v1_0.delete_record(pres_ex_id=pres_ex_id)
-        except Exception as e:
-            bound_logger.exception(
-                "An unexpected error occurred while deleting record."
-            )
-            raise CloudApiException("Failed to delete record.") from e
-
-        bound_logger.debug("Successfully deleted v1 present-proof record.")
-
-    @classmethod
     async def send_proof_request(
         cls,
         controller: AcaPyClient,
@@ -219,3 +142,80 @@ class VerifierV1(Verifier):
             raise CloudApiException("Failed to delete record.") from e
 
         bound_logger.info("Successfully rejected v1 presentation exchange record.")
+
+    @classmethod
+    async def get_proof_records(cls, controller: AcaPyClient):
+        try:
+            logger.debug("Fetching v1 present-proof exchange records")
+            presentation_exchange = await controller.present_proof_v1_0.get_records()
+            result = [
+                record_to_model(rec) for rec in presentation_exchange.results or []
+            ]
+        except Exception as e:
+            logger.exception("An unexpected error occurred while getting records.")
+            raise CloudApiException("Failed to get proof records.") from e
+
+        if result:
+            logger.debug("Successfully got v1 present-proof records.")
+        else:
+            logger.info("No v1 present-proof records obtained.")
+        return result
+
+    @classmethod
+    async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
+        bound_logger = logger.bind(body={"proof_id": proof_id})
+        pres_ex_id = pres_id_no_version(proof_id)
+
+        try:
+            bound_logger.debug("Fetching single v1 present-proof exchange record")
+            presentation_exchange = await controller.present_proof_v1_0.get_record(
+                pres_ex_id=pres_ex_id
+            )
+            result = record_to_model(presentation_exchange)
+        except Exception as e:
+            bound_logger.exception("An unexpected error occurred while getting record.")
+            raise CloudApiException("Failed to get proof record.") from e
+
+        if result:
+            bound_logger.debug("Successfully got v1 present-proof record.")
+        else:
+            bound_logger.info("No v1 present-proof record obtained.")
+        return result
+
+    @classmethod
+    async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
+        bound_logger = logger.bind(body={"proof_id": proof_id})
+        pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
+        try:
+            bound_logger.debug("Deleting v1 present-proof exchange record")
+            await controller.present_proof_v1_0.delete_record(pres_ex_id=pres_ex_id)
+        except Exception as e:
+            bound_logger.exception(
+                "An unexpected error occurred while deleting record."
+            )
+            raise CloudApiException("Failed to delete record.") from e
+
+        bound_logger.debug("Successfully deleted v1 present-proof record.")
+
+    @classmethod
+    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
+        bound_logger = logger.bind(body={"proof_id": proof_id})
+        pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
+        try:
+            bound_logger.debug("Getting v1 matching credentials from proof id")
+            result = await controller.present_proof_v1_0.get_matching_credentials(
+                pres_ex_id=pres_ex_id
+            )
+        except Exception as e:
+            bound_logger.exception(
+                "An unexpected error occurred while getting matching credentials."
+            )
+            raise CloudApiException("Failed to get credentials for request.") from e
+
+        if result:
+            bound_logger.debug("Successfully got matching v1 credentials.")
+        else:
+            bound_logger.debug("No matching v1 credentials obtained.")
+        return result

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -94,6 +94,7 @@ class VerifierV1(Verifier):
     async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id)
+
         try:
             bound_logger.debug("Fetching single v1 present-proof exchange record")
             presentation_exchange = await controller.present_proof_v1_0.get_record(
@@ -114,6 +115,7 @@ class VerifierV1(Verifier):
     async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
         try:
             bound_logger.debug("Deleting v1 present-proof exchange record")
             await controller.present_proof_v1_0.delete_record(pres_ex_id=pres_ex_id)
@@ -164,6 +166,7 @@ class VerifierV1(Verifier):
     ) -> PresentationExchange:
         bound_logger = logger.bind(body=proof_request)
         proof_id = pres_id_no_version(proof_id=proof_request.proof_id)
+
         try:
             bound_logger.debug("Send v1 proof presentation")
             presentation_record = await controller.present_proof_v1_0.send_presentation(
@@ -189,6 +192,7 @@ class VerifierV1(Verifier):
         bound_logger = logger.bind(body=proof_request)
         bound_logger.info("Request to reject v1 presentation exchange record")
         proof_id = pres_id_no_version(proof_id=proof_request.proof_id)
+
         # Report problem if desired
         if proof_request.problem_report:
             try:

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -44,7 +44,7 @@ class VerifierV1(Verifier):
         return record_to_model(presentation_exchange)
 
     @classmethod
-    async def get_credentials_for_request(cls, controller: AcaPyClient, proof_id: str):
+    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
 

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -35,7 +35,7 @@ class VerifierV1(Verifier):
             presentation_exchange = (
                 await controller.present_proof_v1_0.create_proof_request(
                     body=V10PresentationCreateRequestRequest(
-                        proof_request=create_proof_request.proof_request,
+                        proof_request=create_proof_request.indy_proof_request,
                         auto_verify=create_proof_request.auto_verify,
                         comment=create_proof_request.comment,
                         trace=create_proof_request.trace,
@@ -63,7 +63,7 @@ class VerifierV1(Verifier):
                 await controller.present_proof_v1_0.send_request_free(
                     body=V10PresentationSendRequestRequest(
                         connection_id=send_proof_request.connection_id,
-                        proof_request=send_proof_request.proof_request,
+                        proof_request=send_proof_request.indy_proof_request,
                         auto_verify=send_proof_request.auto_verify,
                         comment=send_proof_request.comment,
                         trace=send_proof_request.trace,
@@ -93,7 +93,7 @@ class VerifierV1(Verifier):
         try:
             bound_logger.debug("Send v1 proof presentation")
             presentation_record = await controller.present_proof_v1_0.send_presentation(
-                pres_ex_id=proof_id, body=accept_proof_request.presentation_spec
+                pres_ex_id=proof_id, body=accept_proof_request.indy_presentation_spec
             )
             result = record_to_model(presentation_record)
         except Exception as e:

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -37,7 +37,7 @@ class VerifierV2(Verifier):
             )
         elif create_proof_request.type == ProofRequestType.LD_PROOF:
             presentation_request = V20PresRequestByFormat(
-                dif=create_proof_request.ld_proof_request
+                dif=create_proof_request.dif_proof_request
             )
         else:
             raise CloudApiException(
@@ -77,7 +77,7 @@ class VerifierV2(Verifier):
             )
         elif send_proof_request.type == ProofRequestType.LD_PROOF:
             presentation_request = V20PresRequestByFormat(
-                dif=send_proof_request.ld_proof_request
+                dif=send_proof_request.dif_proof_request
             )
         else:
             raise CloudApiException(
@@ -119,11 +119,11 @@ class VerifierV2(Verifier):
     ) -> PresentationExchange:
         if accept_proof_request.type == ProofRequestType.INDY:
             presentation_spec = V20PresSpecByFormatRequest(
-                indy=accept_proof_request.indy_proof_request
+                indy=accept_proof_request.indy_presentation_spec
             )
         elif accept_proof_request.type == ProofRequestType.LD_PROOF:
             presentation_spec = V20PresSpecByFormatRequest(
-                dif=accept_proof_request.ld_proof_request
+                dif=accept_proof_request.dif_presentation_spec
             )
         else:
             raise CloudApiException(

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -53,83 +53,6 @@ class VerifierV2(Verifier):
             raise CloudApiException("Failed to create presentation request.") from e
 
     @classmethod
-    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
-        bound_logger = logger.bind(body={"proof_id": proof_id})
-        pres_ex_id = pres_id_no_version(proof_id=proof_id)
-
-        try:
-            bound_logger.debug("Getting v2 matching credentials from proof id")
-            result = await controller.present_proof_v2_0.get_matching_credentials(
-                pres_ex_id=pres_ex_id
-            )
-        except Exception as e:
-            bound_logger.exception(
-                "An unexpected error occurred while getting matching credentials."
-            )
-            raise CloudApiException("Failed to get credentials for request.") from e
-
-        if result:
-            bound_logger.debug("Successfully got matching v2 credentials.")
-        else:
-            bound_logger.debug("No matching v2 credentials obtained.")
-        return result
-
-    @classmethod
-    async def get_proof_records(cls, controller: AcaPyClient):
-        try:
-            logger.debug("Fetching v2 present-proof exchange records")
-            presentation_exchange = await controller.present_proof_v2_0.get_records()
-            result = [
-                record_to_model(rec) for rec in presentation_exchange.results or []
-            ]
-        except Exception as e:
-            logger.exception("An unexpected error occurred while getting records.")
-            raise CloudApiException("Failed to get proof records.") from e
-
-        if result:
-            logger.debug("Successfully got v2 present-proof records.")
-        else:
-            logger.info("No v2 present-proof records obtained.")
-        return result
-
-    @classmethod
-    async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
-        bound_logger = logger.bind(body={"proof_id": proof_id})
-        pres_ex_id = pres_id_no_version(proof_id)
-
-        try:
-            bound_logger.debug("Fetching single v2 present-proof exchange record")
-            presentation_exchange = await controller.present_proof_v2_0.get_record(
-                pres_ex_id=pres_ex_id
-            )
-            result = record_to_model(presentation_exchange)
-        except Exception as e:
-            bound_logger.exception("An unexpected error occurred while getting record.")
-            raise CloudApiException("Failed to get proof record.") from e
-
-        if result:
-            bound_logger.debug("Successfully got v2 present-proof record.")
-        else:
-            bound_logger.info("No v2 present-proof record obtained.")
-        return result
-
-    @classmethod
-    async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
-        bound_logger = logger.bind(body={"proof_id": proof_id})
-        pres_ex_id = pres_id_no_version(proof_id=proof_id)
-
-        try:
-            bound_logger.debug("Deleting v2 present-proof exchange record")
-            await controller.present_proof_v2_0.delete_record(pres_ex_id=pres_ex_id)
-        except Exception as e:
-            bound_logger.exception(
-                "An unexpected error occurred while deleting record."
-            )
-            raise CloudApiException("Failed to delete record.") from e
-
-        bound_logger.debug("Successfully deleted v2 present-proof record.")
-
-    @classmethod
     async def send_proof_request(
         cls,
         controller: AcaPyClient,
@@ -224,3 +147,80 @@ class VerifierV2(Verifier):
             raise CloudApiException("Failed to delete record.") from e
 
         bound_logger.info("Successfully rejected v2 presentation exchange record.")
+
+    @classmethod
+    async def get_proof_records(cls, controller: AcaPyClient):
+        try:
+            logger.debug("Fetching v2 present-proof exchange records")
+            presentation_exchange = await controller.present_proof_v2_0.get_records()
+            result = [
+                record_to_model(rec) for rec in presentation_exchange.results or []
+            ]
+        except Exception as e:
+            logger.exception("An unexpected error occurred while getting records.")
+            raise CloudApiException("Failed to get proof records.") from e
+
+        if result:
+            logger.debug("Successfully got v2 present-proof records.")
+        else:
+            logger.info("No v2 present-proof records obtained.")
+        return result
+
+    @classmethod
+    async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
+        bound_logger = logger.bind(body={"proof_id": proof_id})
+        pres_ex_id = pres_id_no_version(proof_id)
+
+        try:
+            bound_logger.debug("Fetching single v2 present-proof exchange record")
+            presentation_exchange = await controller.present_proof_v2_0.get_record(
+                pres_ex_id=pres_ex_id
+            )
+            result = record_to_model(presentation_exchange)
+        except Exception as e:
+            bound_logger.exception("An unexpected error occurred while getting record.")
+            raise CloudApiException("Failed to get proof record.") from e
+
+        if result:
+            bound_logger.debug("Successfully got v2 present-proof record.")
+        else:
+            bound_logger.info("No v2 present-proof record obtained.")
+        return result
+
+    @classmethod
+    async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
+        bound_logger = logger.bind(body={"proof_id": proof_id})
+        pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
+        try:
+            bound_logger.debug("Deleting v2 present-proof exchange record")
+            await controller.present_proof_v2_0.delete_record(pres_ex_id=pres_ex_id)
+        except Exception as e:
+            bound_logger.exception(
+                "An unexpected error occurred while deleting record."
+            )
+            raise CloudApiException("Failed to delete record.") from e
+
+        bound_logger.debug("Successfully deleted v2 present-proof record.")
+
+    @classmethod
+    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
+        bound_logger = logger.bind(body={"proof_id": proof_id})
+        pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
+        try:
+            bound_logger.debug("Getting v2 matching credentials from proof id")
+            result = await controller.present_proof_v2_0.get_matching_credentials(
+                pres_ex_id=pres_ex_id
+            )
+        except Exception as e:
+            bound_logger.exception(
+                "An unexpected error occurred while getting matching credentials."
+            )
+            raise CloudApiException("Failed to get credentials for request.") from e
+
+        if result:
+            bound_logger.debug("Successfully got matching v2 credentials.")
+        else:
+            bound_logger.debug("No matching v2 credentials obtained.")
+        return result

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -181,7 +181,9 @@ class VerifierV2(Verifier):
             result = record_to_model(presentation_exchange)
         except Exception as e:
             bound_logger.exception("An unexpected error occurred while getting record.")
-            raise CloudApiException("Failed to get proof record.") from e
+            raise CloudApiException(
+                f"Failed to get proof record with proof id `{proof_id}`."
+            ) from e
 
         if result:
             bound_logger.debug("Successfully got v2 present-proof record.")
@@ -201,7 +203,9 @@ class VerifierV2(Verifier):
             bound_logger.exception(
                 "An unexpected error occurred while deleting record."
             )
-            raise CloudApiException("Failed to delete record.") from e
+            raise CloudApiException(
+                f"Failed to delete record with proof id `{proof_id}`."
+            ) from e
 
         bound_logger.debug("Successfully deleted v2 present-proof record.")
 
@@ -219,7 +223,9 @@ class VerifierV2(Verifier):
             bound_logger.exception(
                 "An unexpected error occurred while getting matching credentials."
             )
-            raise CloudApiException("Failed to get credentials for request.") from e
+            raise CloudApiException(
+                f"Failed to get credentials with proof id `{proof_id}`."
+            ) from e
 
         if result:
             bound_logger.debug("Successfully got matching v2 credentials.")

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -32,6 +32,7 @@ class VerifierV2(Verifier):
     ) -> PresentationExchange:
         bound_logger = logger.bind(body=proof_request)
         bound_logger.debug("Creating v2 proof request")
+
         try:
             proof_record = await controller.present_proof_v2_0.create_proof_request(
                 body=V20PresCreateRequestRequest(
@@ -55,6 +56,7 @@ class VerifierV2(Verifier):
     async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
         try:
             bound_logger.debug("Getting v2 matching credentials from proof id")
             result = await controller.present_proof_v2_0.get_matching_credentials(
@@ -94,6 +96,7 @@ class VerifierV2(Verifier):
     async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id)
+
         try:
             bound_logger.debug("Fetching single v2 present-proof exchange record")
             presentation_exchange = await controller.present_proof_v2_0.get_record(
@@ -114,6 +117,7 @@ class VerifierV2(Verifier):
     async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
+
         try:
             bound_logger.debug("Deleting v2 present-proof exchange record")
             await controller.present_proof_v2_0.delete_record(pres_ex_id=pres_ex_id)
@@ -166,6 +170,7 @@ class VerifierV2(Verifier):
     ) -> PresentationExchange:
         bound_logger = logger.bind(body=proof_request)
         pres_ex_id = pres_id_no_version(proof_id=proof_request.proof_id)
+
         try:
             bound_logger.debug("Send v2 proof presentation")
             presentation_record = await controller.present_proof_v2_0.send_presentation(
@@ -192,6 +197,7 @@ class VerifierV2(Verifier):
         bound_logger = logger.bind(body=proof_request)
         bound_logger.info("Request to reject v2 presentation exchange record")
         pres_ex_id = pres_id_no_version(proof_id=proof_request.proof_id)
+
         # Report problem if desired
         if proof_request.problem_report:
             try:

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -52,7 +52,7 @@ class VerifierV2(Verifier):
             raise CloudApiException("Failed to create presentation request.") from e
 
     @classmethod
-    async def get_credentials_for_request(cls, controller: AcaPyClient, proof_id: str):
+    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
         try:

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -28,20 +28,20 @@ class VerifierV2(Verifier):
     async def create_proof_request(
         cls,
         controller: AcaPyClient,
-        proof_request: CreateProofRequest,
+        create_proof_request: CreateProofRequest,
     ) -> PresentationExchange:
-        bound_logger = logger.bind(body=proof_request)
+        bound_logger = logger.bind(body=create_proof_request)
         bound_logger.debug("Creating v2 proof request")
 
         try:
             proof_record = await controller.present_proof_v2_0.create_proof_request(
                 body=V20PresCreateRequestRequest(
                     presentation_request=V20PresRequestByFormat(
-                        indy=proof_request.proof_request
+                        indy=create_proof_request.proof_request
                     ),
-                    auto_verify=proof_request.auto_verify,
-                    comment=proof_request.comment,
-                    trace=proof_request.trace,
+                    auto_verify=create_proof_request.auto_verify,
+                    comment=create_proof_request.comment,
+                    trace=create_proof_request.trace,
                 )
             )
             bound_logger.debug("Returning v2 PresentationExchange.")
@@ -56,21 +56,21 @@ class VerifierV2(Verifier):
     async def send_proof_request(
         cls,
         controller: AcaPyClient,
-        proof_request: SendProofRequest,
+        send_proof_request: SendProofRequest,
     ) -> PresentationExchange:
-        bound_logger = logger.bind(body=proof_request)
+        bound_logger = logger.bind(body=send_proof_request)
         try:
             bound_logger.debug("Send free v2 presentation request")
             presentation_exchange = (
                 await controller.present_proof_v2_0.send_request_free(
                     body=V20PresSendRequestRequest(
-                        connection_id=proof_request.connection_id,
+                        connection_id=send_proof_request.connection_id,
                         presentation_request=V20PresRequestByFormat(
-                            dif=None, indy=proof_request.proof_request
+                            dif=None, indy=send_proof_request.proof_request
                         ),
-                        auto_verify=proof_request.auto_verify,
-                        comment=proof_request.comment,
-                        trace=proof_request.trace,
+                        auto_verify=send_proof_request.auto_verify,
+                        comment=send_proof_request.comment,
+                        trace=send_proof_request.trace,
                     )
                 )
             )
@@ -89,16 +89,18 @@ class VerifierV2(Verifier):
 
     @classmethod
     async def accept_proof_request(
-        cls, controller: AcaPyClient, proof_request: AcceptProofRequest
+        cls, controller: AcaPyClient, accept_proof_request: AcceptProofRequest
     ) -> PresentationExchange:
-        bound_logger = logger.bind(body=proof_request)
-        pres_ex_id = pres_id_no_version(proof_id=proof_request.proof_id)
+        bound_logger = logger.bind(body=accept_proof_request)
+        pres_ex_id = pres_id_no_version(proof_id=accept_proof_request.proof_id)
 
         try:
             bound_logger.debug("Send v2 proof presentation")
             presentation_record = await controller.present_proof_v2_0.send_presentation(
                 pres_ex_id=pres_ex_id,
-                body=V20PresSpecByFormatRequest(indy=proof_request.presentation_spec),
+                body=V20PresSpecByFormatRequest(
+                    indy=accept_proof_request.presentation_spec
+                ),
             )
             result = record_to_model(presentation_record)
         except Exception as e:
@@ -115,20 +117,20 @@ class VerifierV2(Verifier):
 
     @classmethod
     async def reject_proof_request(
-        cls, controller: AcaPyClient, proof_request: RejectProofRequest
+        cls, controller: AcaPyClient, reject_proof_request: RejectProofRequest
     ) -> None:
-        bound_logger = logger.bind(body=proof_request)
+        bound_logger = logger.bind(body=reject_proof_request)
         bound_logger.info("Request to reject v2 presentation exchange record")
-        pres_ex_id = pres_id_no_version(proof_id=proof_request.proof_id)
+        pres_ex_id = pres_id_no_version(proof_id=reject_proof_request.proof_id)
 
         # Report problem if desired
-        if proof_request.problem_report:
+        if reject_proof_request.problem_report:
             try:
                 bound_logger.debug("Submitting v2 problem report")
                 await controller.present_proof_v2_0.report_problem(
                     pres_ex_id=pres_ex_id,
                     body=V20PresProblemReportRequest(
-                        description=proof_request.problem_report
+                        description=reject_proof_request.problem_report
                     ),
                 )
             except Exception as e:

--- a/app/tests/e2e/test_trust_registry_integration.py
+++ b/app/tests/e2e/test_trust_registry_integration.py
@@ -165,7 +165,7 @@ async def test_accept_proof_request_verifier_no_public_did(
         json={
             "protocol_version": "v1",
             "connection_id": verifier_holder_connection_id,
-            "proof_request": {
+            "indy_proof_request": {
                 "name": "Age Check",
                 "version": "1.0",
                 "requested_attributes": {
@@ -213,7 +213,7 @@ async def test_accept_proof_request_verifier_no_public_did(
         VERIFIER_BASE_PATH + "/accept-request",
         json={
             "proof_id": holder_proof_exchange_id,
-            "presentation_spec": {
+            "indy_presentation_spec": {
                 "requested_attributes": {
                     "name": {
                         "cred_id": cred_id,

--- a/app/tests/e2e/test_verifier.py
+++ b/app/tests/e2e/test_verifier.py
@@ -36,7 +36,7 @@ def create_send_request(
     return SendProofRequest(
         protocol_version=protocol_version.value,
         connection_id=connection_id,
-        proof_request=indy_proof_request,
+        indy_proof_request=indy_proof_request,
     )
 
 
@@ -52,7 +52,7 @@ async def test_accept_proof_request_v1(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
     acme_exchange = response.json()
@@ -85,7 +85,7 @@ async def test_accept_proof_request_v1(
 
     proof_accept = AcceptProofRequest(
         proof_id=alice_proof_id,
-        presentation_spec=IndyPresSpec(
+        indy_presentation_spec=IndyPresSpec(
             requested_attributes={"0_speed_uuid": indy_request_attrs},
             requested_predicates={},
             self_attested_attributes={},
@@ -132,7 +132,7 @@ async def test_accept_proof_request_oob_v1(
 
     # Create the proof request against aca-py
     create_proof_request = CreateProofRequest(
-        proof_request=indy_proof_request,
+        indy_proof_request=indy_proof_request,
         auto_verify=True,
         comment="some comment",
         protocol_version=PresentProofProtocolVersion.v1.value,
@@ -183,7 +183,7 @@ async def test_accept_proof_request_oob_v1(
     )
     proof_accept = AcceptProofRequest(
         proof_id=alice_proof_id,
-        presentation_spec=IndyPresSpec(
+        indy_presentation_spec=IndyPresSpec(
             requested_attributes={"0_speed_uuid": indy_request_attrs},
             requested_predicates={},
             self_attested_attributes={},
@@ -229,7 +229,7 @@ async def test_accept_proof_request_oob_v2(
         json={
             "comment": "some comment",
             "protocol_version": "v2",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
     bob_exchange = response.json()
@@ -274,7 +274,7 @@ async def test_accept_proof_request_oob_v2(
     )
     proof_accept = AcceptProofRequest(
         proof_id=alice_proof_id,
-        presentation_spec=IndyPresSpec(
+        indy_presentation_spec=IndyPresSpec(
             requested_attributes={"0_speed_uuid": indy_request_attrs},
             requested_predicates={},
             self_attested_attributes={},
@@ -322,7 +322,7 @@ async def test_accept_proof_request_v2(
             "protocol_version": "v2",
             # Custom proof request because v2 doesn't support proof request without restrictions
             # see: https://github.com/hyperledger/aries-cloudagent-python/issues/1755
-            "proof_request": {
+            "indy_proof_request": {
                 "name": "Proof Request",
                 "version": "1.0.0",
                 "requested_attributes": {
@@ -356,7 +356,7 @@ async def test_accept_proof_request_v2(
     )
     proof_accept = AcceptProofRequest(
         proof_id=alice_proof_id,
-        presentation_spec=IndyPresSpec(
+        indy_presentation_spec=IndyPresSpec(
             requested_attributes={"0_speed_uuid": indy_request_attrs},
             requested_predicates={},
             self_attested_attributes={},
@@ -400,7 +400,7 @@ async def test_send_proof_request(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -429,7 +429,7 @@ async def test_send_proof_request(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v2",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -471,7 +471,7 @@ async def test_reject_proof_request(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -506,7 +506,7 @@ async def test_get_proof_single(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -527,7 +527,7 @@ async def test_get_proof_single(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v2",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -556,7 +556,7 @@ async def test_get_proofs_multi(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -578,7 +578,7 @@ async def test_get_proofs_multi(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v2",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -605,7 +605,7 @@ async def test_delete_proof(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -622,7 +622,7 @@ async def test_delete_proof(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v2",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -651,7 +651,7 @@ async def test_get_credentials_for_request(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v1",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 
@@ -686,7 +686,7 @@ async def test_get_credentials_for_request(
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
             "protocol_version": "v2",
-            "proof_request": indy_proof_request.dict(),
+            "indy_proof_request": indy_proof_request.dict(),
         },
     )
 

--- a/app/tests/services/verifier/test_acapy_verifier_v1.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v1.py
@@ -26,7 +26,7 @@ async def test_create_proof_request(mock_agent_controller: AcaPyClient):
 
     created_proof_request = await VerifierV1.create_proof_request(
         controller=mock_agent_controller,
-        proof_request=CreateProofRequest(
+        create_proof_request=CreateProofRequest(
             proof_request=indy_proof_request,
             comment=None,
             protocol_version=PresentProofProtocolVersion.v1,
@@ -56,7 +56,7 @@ async def test_send_proof_request(mock_agent_controller: AcaPyClient):
 
     created_proof_send_proposal = await VerifierV1.send_proof_request(
         controller=mock_agent_controller,
-        proof_request=SendProofRequest(
+        send_proof_request=SendProofRequest(
             connection_id="abcde",
             proof_request=indy_proof_request,
             protocol_version=PresentProofProtocolVersion.v1,
@@ -74,7 +74,7 @@ async def test_accept_proof_request(mock_agent_controller: AcaPyClient):
 
     accepted_proof_request = await VerifierV1.accept_proof_request(
         mock_agent_controller,
-        proof_request=AcceptProofRequest(
+        accept_proof_request=AcceptProofRequest(
             proof_id="v1-123",
             presentation_spec=IndyPresSpec(
                 requested_attributes={},
@@ -101,7 +101,7 @@ async def test_reject_proof_reject(mock_agent_controller: AcaPyClient):
 
     deleted_proof_request = await VerifierV1.reject_proof_request(
         controller=mock_agent_controller,
-        proof_request=RejectProofRequest(proof_id="v1-abc"),
+        reject_proof_request=RejectProofRequest(proof_id="v1-abc"),
     )
 
     assert deleted_proof_request is None
@@ -118,5 +118,5 @@ async def test_reject_proof_reject(mock_agent_controller: AcaPyClient):
     with pytest.raises(AttributeError):
         deleted_proof_request = await VerifierV1.reject_proof_request(
             controller=mock_agent_controller,
-            proof_request="v1-abc",
+            reject_proof_request="v1-abc",
         )

--- a/app/tests/services/verifier/test_acapy_verifier_v1.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v1.py
@@ -27,7 +27,7 @@ async def test_create_proof_request(mock_agent_controller: AcaPyClient):
     created_proof_request = await VerifierV1.create_proof_request(
         controller=mock_agent_controller,
         create_proof_request=CreateProofRequest(
-            proof_request=indy_proof_request,
+            indy_proof_request=indy_proof_request,
             comment=None,
             protocol_version=PresentProofProtocolVersion.v1,
         ),
@@ -58,7 +58,7 @@ async def test_send_proof_request(mock_agent_controller: AcaPyClient):
         controller=mock_agent_controller,
         send_proof_request=SendProofRequest(
             connection_id="abcde",
-            proof_request=indy_proof_request,
+            indy_proof_request=indy_proof_request,
             protocol_version=PresentProofProtocolVersion.v1,
         ),
     )
@@ -76,7 +76,7 @@ async def test_accept_proof_request(mock_agent_controller: AcaPyClient):
         mock_agent_controller,
         accept_proof_request=AcceptProofRequest(
             proof_id="v1-123",
-            presentation_spec=IndyPresSpec(
+            indy_presentation_spec=IndyPresSpec(
                 requested_attributes={},
                 requested_predicates={},
                 self_attested_attributes={},

--- a/app/tests/services/verifier/test_acapy_verifier_v2.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v2.py
@@ -27,7 +27,7 @@ async def test_create_proof_request(mock_agent_controller: AcaPyClient):
 
     created_proof_request = await VerifierV2.create_proof_request(
         controller=mock_agent_controller,
-        proof_request=CreateProofRequest(
+        create_proof_request=CreateProofRequest(
             protocol_version="v2", proof_request=indy_proof_request
         ),
     )
@@ -52,7 +52,7 @@ async def test_send_proof_request(mock_agent_controller: AcaPyClient):
 
     created_proof_send_request = await VerifierV2.send_proof_request(
         controller=mock_agent_controller,
-        proof_request=SendProofRequest(
+        send_proof_request=SendProofRequest(
             protocol_version="v2",
             connection_id="abcde",
             proof_request=indy_proof_request,
@@ -63,7 +63,7 @@ async def test_send_proof_request(mock_agent_controller: AcaPyClient):
 
     with pytest.raises(CloudApiException):
         await VerifierV2.send_proof_request(
-            mock_agent_controller, proof_request="I am invalid"
+            mock_agent_controller, send_proof_request="I am invalid"
         )
 
 
@@ -75,7 +75,7 @@ async def test_accept_proof_request(mock_agent_controller: AcaPyClient):
 
     accepted_proof_request = await VerifierV2.accept_proof_request(
         mock_agent_controller,
-        proof_request=AcceptProofRequest(
+        accept_proof_request=AcceptProofRequest(
             protocol_version="v2",
             proof_id="v2-abcd",
             presentation_spec=IndyPresSpec(
@@ -103,7 +103,7 @@ async def test_reject_proof_reject(mock_agent_controller: AcaPyClient):
 
     deleted_proof_request = await VerifierV2.reject_proof_request(
         controller=mock_agent_controller,
-        proof_request=RejectProofRequest(
+        reject_proof_request=RejectProofRequest(
             protocol_version="v2", proof_id="v2-abc", problem_report=None
         ),
     )
@@ -121,5 +121,5 @@ async def test_reject_proof_reject(mock_agent_controller: AcaPyClient):
 
     with pytest.raises(AttributeError):
         deleted_proof_request = await VerifierV2.reject_proof_request(
-            controller=mock_agent_controller, proof_request="abc"
+            controller=mock_agent_controller, reject_proof_request="abc"
         )

--- a/app/tests/services/verifier/test_acapy_verifier_v2.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v2.py
@@ -28,7 +28,7 @@ async def test_create_proof_request(mock_agent_controller: AcaPyClient):
     created_proof_request = await VerifierV2.create_proof_request(
         controller=mock_agent_controller,
         create_proof_request=CreateProofRequest(
-            protocol_version="v2", proof_request=indy_proof_request
+            protocol_version="v2", indy_proof_request=indy_proof_request
         ),
     )
 
@@ -55,7 +55,7 @@ async def test_send_proof_request(mock_agent_controller: AcaPyClient):
         send_proof_request=SendProofRequest(
             protocol_version="v2",
             connection_id="abcde",
-            proof_request=indy_proof_request,
+            indy_proof_request=indy_proof_request,
         ),
     )
 
@@ -78,7 +78,7 @@ async def test_accept_proof_request(mock_agent_controller: AcaPyClient):
         accept_proof_request=AcceptProofRequest(
             protocol_version="v2",
             proof_id="v2-abcd",
-            presentation_spec=IndyPresSpec(
+            indy_presentation_spec=IndyPresSpec(
                 requested_predicates={},
                 requested_attributes={},
                 self_attested_attributes={},

--- a/app/tests/services/verifier/test_acapy_verifier_v2.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v2.py
@@ -2,8 +2,8 @@ import pytest
 from aries_cloudcontroller import AcaPyClient
 from aries_cloudcontroller.model.indy_pres_spec import IndyPresSpec
 from mockito import when
+from pydantic import ValidationError
 
-from app.exceptions.cloud_api_error import CloudApiException
 from app.routes.verifier import (
     AcceptProofRequest,
     CreateProofRequest,
@@ -61,9 +61,10 @@ async def test_send_proof_request(mock_agent_controller: AcaPyClient):
 
     assert isinstance(created_proof_send_request, PresentationExchange)
 
-    with pytest.raises(CloudApiException):
+    with pytest.raises(ValidationError):
         await VerifierV2.send_proof_request(
-            mock_agent_controller, send_proof_request="I am invalid"
+            mock_agent_controller,
+            send_proof_request=SendProofRequest(indy_proof_request="I am invalid"),
         )
 
 

--- a/app/tests/verifier/test_verifier.py
+++ b/app/tests/verifier/test_verifier.py
@@ -93,7 +93,7 @@ async def test_send_proof_request_v1(
 
     assert result is presentation_exchange_record_1
     verify(VerifierV1).send_proof_request(
-        controller=mock_agent_controller, proof_request=send_proof_request
+        controller=mock_agent_controller, send_proof_request=send_proof_request
     )
 
 
@@ -136,7 +136,7 @@ async def test_send_proof_request_v2(
 
     assert result is presentation_exchange_record_2
     verify(VerifierV2).send_proof_request(
-        controller=mock_agent_controller, proof_request=send_proof_request
+        controller=mock_agent_controller, send_proof_request=send_proof_request
     )
 
 
@@ -264,7 +264,7 @@ async def test_reject_proof_request(
     )
 
     when(VerifierV1).reject_proof_request(
-        controller=mock_agent_controller, proof_request=proof_request_v1
+        controller=mock_agent_controller, reject_proof_request=proof_request_v1
     ).thenReturn(to_async(None))
     presentation_exchange_record_1.state = "request-received"
     when(VerifierV1).get_proof_record(
@@ -278,7 +278,7 @@ async def test_reject_proof_request(
 
     assert result is None
     verify(VerifierV1).reject_proof_request(
-        controller=mock_agent_controller, proof_request=proof_request_v1
+        controller=mock_agent_controller, reject_proof_request=proof_request_v1
     )
     verify(VerifierV1).get_proof_record(
         controller=mock_agent_controller, proof_id=proof_request_v1.proof_id
@@ -288,7 +288,7 @@ async def test_reject_proof_request(
 
     # V2
     when(VerifierV2).reject_proof_request(
-        controller=mock_agent_controller, proof_request=proof_request_v2
+        controller=mock_agent_controller, reject_proof_request=proof_request_v2
     ).thenReturn(to_async(None))
     presentation_exchange_record_2.state = "request-received"
     when(VerifierV2).get_proof_record(
@@ -302,7 +302,7 @@ async def test_reject_proof_request(
 
     assert result is None
     verify(VerifierV2).reject_proof_request(
-        controller=mock_agent_controller, proof_request=proof_request_v2
+        controller=mock_agent_controller, reject_proof_request=proof_request_v2
     )
     verify(VerifierV2).get_proof_record(
         controller=mock_agent_controller, proof_id=proof_request_v2.proof_id

--- a/app/tests/verifier/test_verifier.py
+++ b/app/tests/verifier/test_verifier.py
@@ -443,7 +443,7 @@ async def test_get_credentials_for_request(
         controller=mock_agent_controller, proof_id="v1-abcd"
     ).thenReturn(to_async([cred_precis]))
 
-    result = await test_module.get_credentials_for_request(
+    result = await test_module.get_credentials_by_proof_id(
         proof_id="v1-abcd",
         auth=mock_tenant_auth,
     )
@@ -458,7 +458,7 @@ async def test_get_credentials_for_request(
         controller=mock_agent_controller, proof_id="v2-abcd"
     ).thenReturn(to_async([cred_precis]))
 
-    result = await test_module.get_credentials_for_request(
+    result = await test_module.get_credentials_by_proof_id(
         proof_id="v2-abcd",
         auth=mock_tenant_auth,
     )

--- a/app/tests/verifier/test_verifier.py
+++ b/app/tests/verifier/test_verifier.py
@@ -76,7 +76,7 @@ async def test_send_proof_request_v1(
 
     send_proof_request = test_module.SendProofRequest(
         connection_id="abcde",
-        proof_request=indy_proof_request,
+        indy_proof_request=indy_proof_request,
         protocol_version="v1",
     )
 
@@ -119,7 +119,7 @@ async def test_send_proof_request_v2(
 
     send_proof_request = test_module.SendProofRequest(
         connection_id="abcde",
-        proof_request=indy_proof_request,
+        indy_proof_request=indy_proof_request,
         protocol_version="v2",
     )
 
@@ -149,7 +149,7 @@ async def test_create_proof_request(mock_tenant_auth: AcaPyAuth):
     result = await test_module.create_proof_request(
         create_proof_request=test_module.CreateProofRequest(
             protocol_version="v1",
-            proof_request=indy_proof_request,
+            indy_proof_request=indy_proof_request,
             connection_id="abcde",
         ),
         auth=mock_tenant_auth,
@@ -163,7 +163,7 @@ async def test_create_proof_request(mock_tenant_auth: AcaPyAuth):
     result = await test_module.create_proof_request(
         create_proof_request=test_module.CreateProofRequest(
             protocol_version="v2",
-            proof_request=indy_proof_request,
+            indy_proof_request=indy_proof_request,
             connection_id="abcde",
         ),
         auth=mock_tenant_auth,
@@ -187,7 +187,7 @@ async def test_accept_proof_request_v1(
     )
 
     presentation = test_module.AcceptProofRequest(
-        proof_id="v1-1234", presentation_spec=indy_pres_spec
+        proof_id="v1-1234", indy_presentation_spec=indy_pres_spec
     )
 
     mocker.patch.object(
@@ -225,7 +225,7 @@ async def test_accept_proof_request_v2(
     )
 
     presentation = test_module.AcceptProofRequest(
-        proof_id="v2-1234", presentation_spec=indy_pres_spec
+        proof_id="v2-1234", indy_presentation_spec=indy_pres_spec
     )
 
     mocker.patch.object(

--- a/app/tests/verifier/test_verifier.py
+++ b/app/tests/verifier/test_verifier.py
@@ -424,7 +424,7 @@ async def test_get_proof_records(
 
 
 @pytest.mark.anyio
-async def test_get_credentials_for_request(
+async def test_get_credentials_by_proof_id(
     mock_agent_controller: AcaPyClient,
     mock_context_managed_controller: MockContextManagedController,
     mock_tenant_auth: AcaPyAuth,
@@ -439,7 +439,7 @@ async def test_get_credentials_for_request(
         cred_info=IndyCredInfo(cred_def_id="WgWxqztrNooG92RXvxSTWv:3:CL:20:tag")
     )
     # V1
-    when(VerifierV1).get_credentials_for_request(
+    when(VerifierV1).get_credentials_by_proof_id(
         controller=mock_agent_controller, proof_id="v1-abcd"
     ).thenReturn(to_async([cred_precis]))
 
@@ -449,12 +449,12 @@ async def test_get_credentials_for_request(
     )
 
     assert result == [cred_precis]
-    verify(VerifierV1).get_credentials_for_request(
+    verify(VerifierV1).get_credentials_by_proof_id(
         controller=mock_agent_controller, proof_id="v1-abcd"
     )
 
     # V2
-    when(VerifierV2).get_credentials_for_request(
+    when(VerifierV2).get_credentials_by_proof_id(
         controller=mock_agent_controller, proof_id="v2-abcd"
     ).thenReturn(to_async([cred_precis]))
 
@@ -464,6 +464,6 @@ async def test_get_credentials_for_request(
     )
 
     assert result == [cred_precis]
-    verify(VerifierV2).get_credentials_for_request(
+    verify(VerifierV2).get_credentials_by_proof_id(
         controller=mock_agent_controller, proof_id="v2-abcd"
     )

--- a/app/tests/verifier/test_verifier.py
+++ b/app/tests/verifier/test_verifier.py
@@ -87,7 +87,7 @@ async def test_send_proof_request_v1(
     )
 
     result = await test_module.send_proof_request(
-        proof_request=send_proof_request,
+        send_proof_request=send_proof_request,
         auth=mock_tenant_auth,
     )
 
@@ -130,7 +130,7 @@ async def test_send_proof_request_v2(
     )
 
     result = await test_module.send_proof_request(
-        proof_request=send_proof_request,
+        send_proof_request=send_proof_request,
         auth=mock_tenant_auth,
     )
 
@@ -147,7 +147,7 @@ async def test_create_proof_request(mock_tenant_auth: AcaPyAuth):
         to_async(presentation_exchange_record_1)
     )
     result = await test_module.create_proof_request(
-        proof_request=test_module.CreateProofRequest(
+        create_proof_request=test_module.CreateProofRequest(
             protocol_version="v1",
             proof_request=indy_proof_request,
             connection_id="abcde",
@@ -161,7 +161,7 @@ async def test_create_proof_request(mock_tenant_auth: AcaPyAuth):
         to_async(presentation_exchange_record_2)
     )
     result = await test_module.create_proof_request(
-        proof_request=test_module.CreateProofRequest(
+        create_proof_request=test_module.CreateProofRequest(
             protocol_version="v2",
             proof_request=indy_proof_request,
             connection_id="abcde",
@@ -201,7 +201,7 @@ async def test_accept_proof_request_v1(
     )
 
     result = await test_module.accept_proof_request(
-        presentation=presentation,
+        accept_proof_request=presentation,
         auth=mock_tenant_auth,
     )
 
@@ -239,7 +239,7 @@ async def test_accept_proof_request_v2(
     )
 
     result = await test_module.accept_proof_request(
-        presentation=presentation,
+        accept_proof_request=presentation,
         auth=mock_tenant_auth,
     )
 
@@ -272,7 +272,7 @@ async def test_reject_proof_request(
     ).thenReturn(to_async(presentation_exchange_record_1))
 
     result = await test_module.reject_proof_request(
-        proof_request=test_module.RejectProofRequest(proof_id="v1-1234"),
+        reject_proof_request=test_module.RejectProofRequest(proof_id="v1-1234"),
         auth=mock_tenant_auth,
     )
 
@@ -296,7 +296,7 @@ async def test_reject_proof_request(
     ).thenReturn(to_async(presentation_exchange_record_2))
 
     result = await test_module.reject_proof_request(
-        proof_request=test_module.RejectProofRequest(proof_id="v2-1234"),
+        reject_proof_request=test_module.RejectProofRequest(proof_id="v2-1234"),
         auth=mock_tenant_auth,
     )
 

--- a/app/tests/verifier/test_verifier.py
+++ b/app/tests/verifier/test_verifier.py
@@ -87,7 +87,7 @@ async def test_send_proof_request_v1(
     )
 
     result = await test_module.send_proof_request(
-        send_proof_request=send_proof_request,
+        body=send_proof_request,
         auth=mock_tenant_auth,
     )
 
@@ -130,7 +130,7 @@ async def test_send_proof_request_v2(
     )
 
     result = await test_module.send_proof_request(
-        send_proof_request=send_proof_request,
+        body=send_proof_request,
         auth=mock_tenant_auth,
     )
 
@@ -147,7 +147,7 @@ async def test_create_proof_request(mock_tenant_auth: AcaPyAuth):
         to_async(presentation_exchange_record_1)
     )
     result = await test_module.create_proof_request(
-        create_proof_request=test_module.CreateProofRequest(
+        body=test_module.CreateProofRequest(
             protocol_version="v1",
             indy_proof_request=indy_proof_request,
             connection_id="abcde",
@@ -161,7 +161,7 @@ async def test_create_proof_request(mock_tenant_auth: AcaPyAuth):
         to_async(presentation_exchange_record_2)
     )
     result = await test_module.create_proof_request(
-        create_proof_request=test_module.CreateProofRequest(
+        body=test_module.CreateProofRequest(
             protocol_version="v2",
             indy_proof_request=indy_proof_request,
             connection_id="abcde",
@@ -201,7 +201,7 @@ async def test_accept_proof_request_v1(
     )
 
     result = await test_module.accept_proof_request(
-        accept_proof_request=presentation,
+        body=presentation,
         auth=mock_tenant_auth,
     )
 
@@ -239,7 +239,7 @@ async def test_accept_proof_request_v2(
     )
 
     result = await test_module.accept_proof_request(
-        accept_proof_request=presentation,
+        body=presentation,
         auth=mock_tenant_auth,
     )
 
@@ -272,7 +272,7 @@ async def test_reject_proof_request(
     ).thenReturn(to_async(presentation_exchange_record_1))
 
     result = await test_module.reject_proof_request(
-        reject_proof_request=test_module.RejectProofRequest(proof_id="v1-1234"),
+        body=test_module.RejectProofRequest(proof_id="v1-1234"),
         auth=mock_tenant_auth,
     )
 
@@ -296,7 +296,7 @@ async def test_reject_proof_request(
     ).thenReturn(to_async(presentation_exchange_record_2))
 
     result = await test_module.reject_proof_request(
-        reject_proof_request=test_module.RejectProofRequest(proof_id="v2-1234"),
+        body=test_module.RejectProofRequest(proof_id="v2-1234"),
         auth=mock_tenant_auth,
     )
 

--- a/app/tests/verifier/utils.py
+++ b/app/tests/verifier/utils.py
@@ -364,7 +364,7 @@ async def test_assert_valid_prover_invitation_key(mock_agent_controller: AcaPyCl
         await assert_valid_prover(
             aries_controller=mock_agent_controller,
             presentation=AcceptProofRequest(
-                proof_id=pres_exchange.proof_id, presentation_spec=presentation
+                proof_id=pres_exchange.proof_id, indy_presentation_spec=presentation
             ),
             verifier=verifier,
         )
@@ -427,7 +427,7 @@ async def test_assert_valid_prover_public_did(mock_agent_controller: AcaPyClient
         await assert_valid_prover(
             aries_controller=mock_agent_controller,
             presentation=AcceptProofRequest(
-                proof_id=pres_exchange.proof_id, presentation_spec=presentation
+                proof_id=pres_exchange.proof_id, indy_presentation_spec=presentation
             ),
             verifier=verifier,
         )
@@ -466,7 +466,7 @@ async def test_assert_valid_prover_x_no_public_did_no_invitation_key(
         await assert_valid_prover(
             aries_controller=mock_agent_controller,
             presentation=AcceptProofRequest(
-                proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
+                proof_id=pres_exchange.proof_id, indy_presentation_spec=indy_pres_spec
             ),
             verifier=verifier,
         )
@@ -517,7 +517,8 @@ async def test_assert_valid_prover_x_actor_invalid_role(
             await assert_valid_prover(
                 aries_controller=mock_agent_controller,
                 presentation=AcceptProofRequest(
-                    proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
+                    proof_id=pres_exchange.proof_id,
+                    indy_presentation_spec=indy_pres_spec,
                 ),
                 verifier=verifier,
             )
@@ -568,7 +569,8 @@ async def test_assert_valid_prover_x_invalid_schemas(
             await assert_valid_prover(
                 aries_controller=mock_agent_controller,
                 presentation=AcceptProofRequest(
-                    proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
+                    proof_id=pres_exchange.proof_id,
+                    indy_presentation_spec=indy_pres_spec,
                 ),
                 verifier=verifier,
             )
@@ -602,7 +604,7 @@ async def test_assert_valid_prover_x_no_connection_id(
         assert await assert_valid_prover(
             aries_controller=mock_agent_controller,
             presentation=AcceptProofRequest(
-                proof_id=pres_exchange.proof_id, presentation_spec=indy_pres_spec
+                proof_id=pres_exchange.proof_id, indy_presentation_spec=indy_pres_spec
             ),
             verifier=verifier,
         )
@@ -631,7 +633,7 @@ async def test_assert_valid_verifier_invitation_key(mock_agent_controller: AcaPy
             proof_request=SendProofRequest(
                 protocol_version=PresentProofProtocolVersion.v1,
                 connection_id="a-connection-id",
-                proof_request=indy_proof_request,
+                indy_proof_request=indy_proof_request,
             ),
         )
 
@@ -650,7 +652,7 @@ async def test_assert_valid_verifier_public_did(mock_agent_controller: AcaPyClie
             proof_request=SendProofRequest(
                 protocol_version=PresentProofProtocolVersion.v1,
                 connection_id="abcde",
-                proof_request=indy_proof_request,
+                indy_proof_request=indy_proof_request,
             ),
         )
 
@@ -680,7 +682,7 @@ async def test_assert_valid_verifier_x_no_public_did_no_invitation_key(
                 proof_request=SendProofRequest(
                     protocol_version=PresentProofProtocolVersion.v1,
                     connection_id="a-connection-id",
-                    proof_request=indy_proof_request,
+                    indy_proof_request=indy_proof_request,
                 ),
             )
 
@@ -720,6 +722,6 @@ async def test_assert_valid_verifier_x_not_verifier(
                 proof_request=SendProofRequest(
                     protocol_version=PresentProofProtocolVersion.v1,
                     connection_id="a-connection-id",
-                    proof_request=indy_proof_request,
+                    indy_proof_request=indy_proof_request,
                 ),
             )

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -88,7 +88,8 @@ async def assert_valid_prover(
     # Get schema ids
     bound_logger.debug("Getting schema ids from presentation")
     schema_ids = await get_schema_ids(
-        aries_controller=aries_controller, presentation=presentation.presentation_spec
+        aries_controller=aries_controller,
+        presentation=presentation.indy_presentation_spec,
     )
 
     # Verify the schemas are actually in the list from TR

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from app.models.tenants import Tenant, WalletRecordWithGroups
 
 

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -1,0 +1,16 @@
+from typing import Optional
+from app.models.tenants import Tenant, WalletRecordWithGroups
+
+
+def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
+    label: str = wallet_record.settings["default_label"]
+    image_url: Optional[str] = wallet_record.settings.get("image_url")
+
+    return Tenant(
+        tenant_id=wallet_record.wallet_id,
+        tenant_name=label,
+        image_url=image_url,
+        created_at=wallet_record.created_at,
+        updated_at=wallet_record.updated_at,
+        group_id=wallet_record.group_id if hasattr(wallet_record, "group_id") else None,
+    )

--- a/docs/Common Steps.md
+++ b/docs/Common Steps.md
@@ -101,7 +101,7 @@ To create schemas and effectively write them to the ledger as well as registerin
    {
      "protocol_version": "v1",
      "connection_id": "string",
-     "proof_request": {
+     "indy_proof_request": {
        "requested_attributes": {
          "additionalProp1": {
            "name": "string",
@@ -144,7 +144,7 @@ To create schemas and effectively write them to the ledger as well as registerin
    {
      "protocol_version": "v1",
      "proof_id": "string",
-     "presentation_spec": {
+     "indy_presentation_spec": {
        "requested_attributes": {
          "additionalProp1": {
            "cred_id": "string",


### PR DESCRIPTION
Introduces DIF models (DIFProofRequest and DIFPresSpec) to the create, send, and accept proof request verifier routes. Adds support for JSON-LD and JWT VCs.

To do: refactor issuer/verifier tests (to distinguish indy-specific tests) and add more expansive ld-proof test cases.