### PR TITLE
Chain smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ To run specific tests, you can specify the path to the test file and the test me
 pytest app/tests/e2e/test_verifier.py::test_accept_proof_request_oob_v1 --log-cli-level=1
 ```
 
+## Running containerised tests
+
+```bash
+./manage up
+```
+In another terminal:
+```bash
+./manage up pytest
+```
+
 ## CI/CD
 
 Please, refer to the [CI/CD docs](./.github/workflows/README.md) for more information.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,8 @@ services:
       dockerfile: dockerfiles/agents/Dockerfile.agent
     env_file:
       - environments/governance-ga/aca-py-agent.default.env
+    environment:
+      ACAPY_AUTO_ENDORSE_TRANSACTIONS: false
     ports:
       - 0.0.0.0:3020:3020
       - 0.0.0.0:3021:3021
@@ -376,12 +378,46 @@ services:
       REDIS_HOST: wh-redis
     volumes:
       - ./logs/containerized-tests:/tests/outputs
+      - ./scripts/test_runner.sh:/tests/test_runner.sh
     networks:
       - governance-ga
       - host
     depends_on:
       governance-ga-web-health:
         condition: service_completed_successfully
+  pytest:
+    image: local/tests
+    container_name: tests
+    restart: "no"
+    build:
+      context: .
+      dockerfile: ./dockerfiles/tests/Dockerfile
+    command:
+      - /bin/sh
+      - -c
+      - |-
+        ./test_runner.sh pytest app/tests/e2e/test_trust_registry_integration.py
+    environment:
+      ACAPY_GOVERNANCE_AGENT_URL: http://governance-ga-agent:3021
+      ACAPY_GOVERNANCE_AGENT_API_KEY: adminApiKey
+      ACAPY_TENANT_AGENT_URL: http://governance-multitenant-agent:3021
+      ACAPY_TENANT_AGENT_API_KEY: adminApiKey
+      TRUST_REGISTRY_URL: http://governance-trust-registry:8001
+      WEBHOOKS_URL: http://governance-webhooks-web:3010
+      ACAPY_MULTITENANT_JWT_SECRET: jwtSecret
+      CLOUDAPI_URL: http://governance-ga-web:8000
+      GOVERNANCE_FASTAPI_ENDPOINT: http://governance-multitenant-web:8000
+      GOVERNANCE_ACAPY_API_KEY: adminApiKey
+      TENANT_FASTAPI_ENDPOINT: http://governance-multitenant-web:8000
+      TENANT_ACAPY_API_KEY: adminApiKey
+      LEDGER_REGISTRATION_URL: http://ledger-browser:8000/register
+      REDIS_HOST: wh-redis
+    volumes:
+      - ./logs/containerized-tests:/tests/outputs
+      - ./scripts/test_runner.sh:/tests/test_runner.sh
+    networks:
+      - governance-ga
+      - host
   governance-ga-web-health:
     image: curlimages/curl
     container_name: governance-ga-web-health

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -396,7 +396,7 @@ services:
       - /bin/sh
       - -c
       - |-
-        ./test_runner.sh pytest app/tests/e2e/test_trust_registry_integration.py
+        ./test_runner.sh 100 pytest app/tests/e2e/test_trust_registry_integration.py
     environment:
       ACAPY_GOVERNANCE_AGENT_URL: http://governance-ga-agent:3021
       ACAPY_GOVERNANCE_AGENT_API_KEY: adminApiKey

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+EXIT_CODE=0
+COUNTER=0
+PYTEST_COMMAND="$@"
+while [[ $EXIT_CODE == 0 ]]; do
+    $PYTEST_COMMAND
+    EXIT_CODE=$?
+    COUNTER=$((COUNTER+1))
+    echo "Test run $COUNTER completed with exit code $EXIT_CODE"
+done

--- a/scripts/test_runner.sh
+++ b/scripts/test_runner.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 EXIT_CODE=0
 COUNTER=0
+COMPLETIONS=$1
+shift
 PYTEST_COMMAND="$@"
-while [[ $EXIT_CODE == 0 ]]; do
+while [[ $EXIT_CODE == 0 && $COUNTER -lt $COMPLETIONS ]]; do
     $PYTEST_COMMAND
     EXIT_CODE=$?
     COUNTER=$((COUNTER+1))


### PR DESCRIPTION
Added a `tests` container and wrapper that can be used to run a specific test until `x` completions or failure without changing the existing loop behaviour of `tests` (where every iteration is a clean start).