### PR TITLE
Enable TAA on local dev

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -284,6 +284,8 @@ services:
     volumes:
       - webserver-cli:/home/indy/.indy-cli
       - webserver-ledger:/home/indy/ledger
+      - ./resources/ledger-nodes/aml.json:/home/indy/config/aml.json
+      - ./resources/ledger-nodes/taa.json:/home/indy/config/taa.json
     networks:
       - governance-multitenant
       - governance-ga
@@ -319,6 +321,8 @@ services:
     volumes:
       - nodes-data:/home/indy/ledger
       - ./scripts/indy_healthcheck.sh:/home/indy/indy_healthcheck.sh
+      - ./resources/ledger-nodes/aml.json:/home/indy/config/aml.json
+      - ./resources/ledger-nodes/taa.json:/home/indy/config/taa.json
     networks:
       - governance-multitenant
       - governance-ga

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -321,8 +321,6 @@ services:
     volumes:
       - nodes-data:/home/indy/ledger
       - ./scripts/indy_healthcheck.sh:/home/indy/indy_healthcheck.sh
-      - ./resources/ledger-nodes/aml.json:/home/indy/config/aml.json
-      - ./resources/ledger-nodes/taa.json:/home/indy/config/taa.json
     networks:
       - governance-multitenant
       - governance-ga

--- a/resources/ledger-nodes/aml.json
+++ b/resources/ledger-nodes/aml.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "context": "http://aml-context-descr",
+  "aml": {
+     "product_eula": "The agreement was included in the software product’s terms and conditions as part of a license to the end user.",
+     "service_agreement": "The agreement was included in the terms and conditions the user accepted as part of contracting a service.",
+     "at_submission": "The agreement was reviewed by the user and accepted at the time of submission of this transaction.",
+     "for_session": "The agreement was reviewed by the user and accepted at some point in the user’s session prior to submission.",
+     "wallet_agreement": "The agreement was reviewed by the user and this affirmation was persisted in the user’s wallet for use during submission.",
+     "on_file": "An authorized person accepted the agreement, and such acceptance is on file with the user’s organization."
+  }
+}

--- a/resources/ledger-nodes/taa.json
+++ b/resources/ledger-nodes/taa.json
@@ -1,0 +1,6 @@
+{
+    "version": "1.1",
+    "text": "This is a sample Transaction Authors Agreement **(TAA)**, for the VON test Network.\n\nOn public ledger systems this will typically contain legal constraints that must be accepted before any write operations will be permitted.",
+    "ratification_ts": 1597654073,
+    "retirement_ts": null
+  }


### PR DESCRIPTION
Serve AML & TAA docs without modifying `ledger-browser` container.