### PR TITLE
:bug: Fix ACA-Py race condition in configuration of endorser connection

### DIFF
--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -240,17 +240,20 @@ async def onboard_issuer_no_public_did(
         return endorser_connection, connection_record
 
     async def set_endorser_roles(endorser_connection, connection_record):
+        endorser_connection_id = endorser_connection["connection_id"]
+        issuer_connection_id = connection_record.connection_id
+
         bound_logger.debug("Setting roles for endorser")
         await endorser_controller.endorse_transaction.set_endorser_role(
-            conn_id=endorser_connection["connection_id"],
+            conn_id=endorser_connection_id,
             transaction_my_job="TRANSACTION_ENDORSER",
         )
 
         await issuer_controller.endorse_transaction.set_endorser_role(
-            conn_id=connection_record.connection_id,
+            conn_id=issuer_connection_id,
             transaction_my_job="TRANSACTION_AUTHOR",
         )
-        bound_logger.debug("Successfully set roles for endorser.")
+        bound_logger.debug("Successfully set roles for connection.")
 
     async def configure_endorsement(connection_record, endorser_did):
         # Make sure endorsement has been configured

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -150,8 +150,6 @@ async def onboard_issuer(
         bound_logger.debug("Obtained public DID for the to-be issuer")
     except CloudApiException:
         bound_logger.debug("No public DID for the to-be issuer")
-        # Onboarding an issuer with no public DID can fail when creating a connection with
-        # the endorser. If something goes wrong, the whole coroutine should be re-attempted
         issuer_did: acapy_wallet.Did = await onboard_issuer_no_public_did(
             name, endorser_controller, issuer_controller, issuer_wallet_id
         )

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -16,7 +16,6 @@ from app.models.tenants import OnboardResult, UpdateTenantRequest
 from app.services import acapy_ledger, acapy_wallet
 from app.services.trust_registry import TrustRegistryRole, actor_by_id, update_actor
 from app.util.did import qualified_did_sov
-from app.util.retry_method import coroutine_with_retry
 from shared import ACAPY_ENDORSER_ALIAS
 from shared.log_config import get_logger
 
@@ -148,10 +147,8 @@ async def onboard_issuer(
         bound_logger.debug("No public DID for the to-be issuer")
         # Onboarding an issuer with no public DID can fail when creating a connection with
         # the endorser. If something goes wrong, the whole coroutine should be re-attempted
-        issuer_did: acapy_wallet.Did = await coroutine_with_retry(
-            onboard_issuer_no_public_did,
-            (name, endorser_controller, issuer_controller, issuer_wallet_id),
-            bound_logger,
+        issuer_did: acapy_wallet.Did = await onboard_issuer_no_public_did(
+            name, endorser_controller, issuer_controller, issuer_wallet_id
         )
 
     bound_logger.debug("Creating OOB invitation on behalf of issuer")

--- a/app/services/onboarding.py
+++ b/app/services/onboarding.py
@@ -352,7 +352,7 @@ async def onboard_issuer_no_public_did(
     except Exception as e:
         bound_logger.exception("Could not create connection with endorser.")
         raise CloudApiException(
-            f"Error creating connection with endorser: {str(e)}.",
+            f"Error creating connection with endorser: {str(e)}",
         ) from e
 
     bound_logger.info("Successfully registered DID for issuer.")

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -2,6 +2,7 @@ import pytest
 from aries_cloudcontroller import (
     AcaPyClient,
     ConnRecord,
+    ConnectionMetadata,
     InvitationCreateRequest,
     InvitationMessage,
     InvitationRecord,
@@ -119,12 +120,40 @@ async def test_onboard_issuer_no_public_did(
     when(mock_agent_controller.endorse_transaction).set_endorser_role(...).thenReturn(
         to_async()
     )
+    # Mock the assert_connection_metadata methods
+    when(endorser_controller.connection).get_metadata(...).thenReturn(
+        to_async(
+            ConnectionMetadata(
+                results={
+                    "transaction_jobs": {
+                        "transaction_my_job": "TRANSACTION_ENDORSER",
+                    },
+                }
+            )
+        )
+    )
+
     when(endorser_controller.endorse_transaction).set_endorser_role(...).thenReturn(
         to_async()
     )
+    when(mock_agent_controller.connection).get_metadata(...).thenReturn(
+        to_async(
+            ConnectionMetadata(
+                results={
+                    "transaction_jobs": {
+                        "transaction_my_job": "TRANSACTION_AUTHOR",
+                        "transaction_their_job": "TRANSACTION_ENDORSER",
+                    },
+                }
+            )
+        )
+    )
+
     when(mock_agent_controller.endorse_transaction).set_endorser_info(...).thenReturn(
         to_async()
     )
+    when(onboarding).assert_endorser_info_set(...).thenReturn(to_async(True))
+
     when(acapy_wallet).create_did(mock_agent_controller).thenReturn(
         to_async(
             Did(

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -89,12 +89,13 @@ async def test_onboard_issuer_no_public_did(
     mock_agent_controller: AcaPyClient,
 ):
     endorser_controller = get_mock_agent_controller()
+    endorser_did = "EndorserDid"
 
     when(acapy_wallet).get_public_did(controller=mock_agent_controller).thenRaise(
         CloudApiException(detail="Error")
     )
     when(acapy_wallet).get_public_did(controller=endorser_controller).thenReturn(
-        to_async(Did(did="EndorserController", verkey="EndorserVerkey"))
+        to_async(Did(did=endorser_did, verkey="EndorserVerkey"))
     )
 
     when(endorser_controller.out_of_band).create_invitation(...).thenReturn(

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -1,5 +1,5 @@
-from aiohttp import ClientResponseError
 import pytest
+from aiohttp import ClientResponseError
 from aries_cloudcontroller import (
     AcaPyClient,
     ConnectionMetadata,

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -1,8 +1,8 @@
 import pytest
 from aries_cloudcontroller import (
     AcaPyClient,
-    ConnRecord,
     ConnectionMetadata,
+    ConnRecord,
     InvitationCreateRequest,
     InvitationMessage,
     InvitationRecord,

--- a/app/util/assert_connection_metadata.py
+++ b/app/util/assert_connection_metadata.py
@@ -1,0 +1,100 @@
+import asyncio
+from typing import Callable
+from aiohttp import ClientResponseError
+
+from aries_cloudcontroller import AcaPyClient
+
+from app.exceptions.cloud_api_error import CloudApiException
+
+DEFAULT_RETRIES = 10
+DEFAULT_DELAY = 0.1
+
+
+async def assert_metadata_set(
+    controller: AcaPyClient,
+    conn_id: str,
+    check_fn: Callable,
+    retries=DEFAULT_RETRIES,
+    delay=DEFAULT_DELAY,
+):
+    """Checks if connection record metadata has been set according to a custom check function.
+
+    Args:
+        controller: The AcaPyClient instance for the respective agent
+        conn_id: Connection id of the connection you're interested in
+        check_fn: A function that takes the metadata and returns True if it meets the desired condition
+        retries: Number of retries before failing
+        delay: Delay in seconds between each retry
+
+    Returns:
+        True if condition is met, raises an exception otherwise.
+    """
+    for _ in range(retries):
+        # Delay is placed at the start to avoid race condition in ACA-Py, where reading metadata causes duplicate
+        # record error if metadata is still due to be updated
+        await asyncio.sleep(delay)
+        try:
+            connection_metadata = await controller.connection.get_metadata(
+                conn_id=conn_id
+            )
+            metadata_dict = connection_metadata.results
+            if check_fn(metadata_dict):
+                return True
+        except ClientResponseError:
+            # A duplicate record error (aries_cloudagent.storage.error.StorageDuplicateError) may occur in ACA-Py
+            # if we fetch metadata while it's being updated
+            pass
+
+    raise CloudApiException(
+        f"Failed to assert that metadata meets the desired condition after {retries} attempts."
+    )
+
+
+async def assert_endorser_role_set(
+    controller, conn_id, retries=DEFAULT_RETRIES, delay=DEFAULT_DELAY
+):
+    check_fn = (
+        lambda metadata: metadata.get("transaction_jobs", {}).get("transaction_my_job")
+        == "TRANSACTION_ENDORSER"
+    )
+    try:
+        await assert_metadata_set(controller, conn_id, check_fn, retries, delay)
+    except CloudApiException:
+        raise CloudApiException(
+            "Failed to assert that the endorser role has been set in the connection metadata."
+        )
+
+
+async def assert_author_role_set(
+    controller, conn_id, retries=DEFAULT_RETRIES, delay=DEFAULT_DELAY
+):
+    check_fn = (
+        lambda metadata: metadata.get("transaction_jobs", {}).get("transaction_my_job")
+        == "TRANSACTION_AUTHOR"
+        and metadata.get("transaction_jobs", {}).get("transaction_their_job")
+        == "TRANSACTION_ENDORSER"
+    )
+    try:
+        await assert_metadata_set(controller, conn_id, check_fn, retries, delay)
+    except CloudApiException:
+        raise CloudApiException(
+            "Failed to assert that the author role has been set in the connection metadata."
+        )
+
+
+async def assert_endorser_info_set(
+    controller, conn_id, endorser_did, retries=DEFAULT_RETRIES, delay=DEFAULT_DELAY
+):
+    check_fn = (
+        lambda metadata: metadata.get("transaction_jobs", {}).get("transaction_my_job")
+        == "TRANSACTION_AUTHOR"
+        and metadata.get("transaction_jobs", {}).get("transaction_their_job")
+        == "TRANSACTION_ENDORSER"
+        and metadata.get("endorser_info", {}).get("endorser_did") == endorser_did
+    )
+    try:
+        await assert_metadata_set(controller, conn_id, check_fn, retries, delay)
+    except CloudApiException:
+        raise CloudApiException(
+            "Failed to assert that the endorser info has been set in the connection metadata."
+        )

--- a/app/util/assert_connection_metadata.py
+++ b/app/util/assert_connection_metadata.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import Callable
-from aiohttp import ClientResponseError
 
+from aiohttp import ClientResponseError
 from aries_cloudcontroller import AcaPyClient
 
 from app.exceptions.cloud_api_error import CloudApiException

--- a/app/util/assert_connection_metadata.py
+++ b/app/util/assert_connection_metadata.py
@@ -7,7 +7,7 @@ from aries_cloudcontroller import AcaPyClient
 from app.exceptions.cloud_api_error import CloudApiException
 
 DEFAULT_RETRIES = 10
-DEFAULT_DELAY = 0.1
+DEFAULT_DELAY = 0.2
 
 
 async def assert_metadata_set(

--- a/app/util/assert_connection_metadata.py
+++ b/app/util/assert_connection_metadata.py
@@ -59,10 +59,10 @@ async def assert_endorser_role_set(
     )
     try:
         await assert_metadata_set(controller, conn_id, check_fn, retries, delay)
-    except CloudApiException:
+    except Exception as e:
         raise CloudApiException(
             "Failed to assert that the endorser role has been set in the connection metadata."
-        )
+        ) from e
 
 
 async def assert_author_role_set(
@@ -76,10 +76,10 @@ async def assert_author_role_set(
     )
     try:
         await assert_metadata_set(controller, conn_id, check_fn, retries, delay)
-    except CloudApiException:
+    except Exception as e:
         raise CloudApiException(
             "Failed to assert that the author role has been set in the connection metadata."
-        )
+        ) from e
 
 
 async def assert_endorser_info_set(
@@ -94,7 +94,7 @@ async def assert_endorser_info_set(
     )
     try:
         await assert_metadata_set(controller, conn_id, check_fn, retries, delay)
-    except CloudApiException:
+    except Exception as e:
         raise CloudApiException(
             "Failed to assert that the endorser info has been set in the connection metadata."
-        )
+        ) from e


### PR DESCRIPTION
When onboarding an issuer that does not yet have a public did, a connection first needs to be created between the endorser and the to-be issuer.

Setting up the endorser connection metadata happens asynchronously in ACA-Py, and takes some moments to complete after `set_endorser_role` responds with a success. This leads to some race conditions, where the subsequent `set_endorser_info` method is called too quickly, because the connection metadata has not yet completely updated in ACA-Py storage.

So, it is necessary to assert that roles have been set (in the connection metadata) before the 'info' can be set, and all of this needs to be set before the issuer's did can be registered on the ledger.

This PR adds assert methods in the onboarding logic for an issuer, such that the race condition is eliminated and success rate of onboarding an issuer is more deterministic and reliable.