### PR TITLE
:art: remove custom JsonldApi workaround

### DIFF
--- a/app/routes/jsonld.py
+++ b/app/routes/jsonld.py
@@ -1,9 +1,6 @@
-from typing import Optional
-
 from aiohttp import ClientResponseError
-from aries_cloudcontroller import Doc, SignRequest, SignResponse, VerifyResponse
+from aries_cloudcontroller import Doc, SignRequest, SignResponse, VerifyRequest
 from fastapi import APIRouter, Depends
-from uplink import Body, Consumer, json, post, returns
 
 from app.dependencies.acapy_clients import client_from_auth
 from app.dependencies.auth import AcaPyAuth, acapy_auth
@@ -14,24 +11,6 @@ from shared.log_config import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/generic/jsonld", tags=["jsonld"])
-
-
-# NOTE: Wrong/incomplete aca-py openAPI spec results in wrong/overly-strict model for controller endpoint
-# Hence, custom override api endpoint that is incorrect in aca-py
-class JsonldApi(Consumer):
-    async def verify(
-        self, *, body: Optional[JsonLdVerifyRequest] = None
-    ) -> VerifyResponse:
-        """Verify a JSON-LD structure."""
-        return await self.__verify(
-            body=body,
-        )
-
-    @returns.json
-    @json
-    @post("/jsonld/verify")
-    def __verify(self, *, body: Body(type=JsonLdVerifyRequest) = {}) -> VerifyResponse:
-        """Internal uplink method for verify"""
 
 
 @router.post("/sign", response_model=SignResponse)
@@ -132,12 +111,9 @@ async def verify_jsonld(
             else:
                 verkey = body.verkey
 
-            aries_controller.jsonld = JsonldApi(
-                base_url=aries_controller.base_url, client=aries_controller.client
-            )
             bound_logger.debug("Verifying JsonLD")
             jsonld_verify_response = await aries_controller.jsonld.verify(
-                body=JsonLdVerifyRequest(doc=body.doc, verkey=verkey)
+                body=VerifyRequest(doc=body.doc, verkey=verkey)
             )
             if not jsonld_verify_response.valid:
                 raise CloudApiException(

--- a/app/tests/e2e/test_jsonld.py
+++ b/app/tests/e2e/test_jsonld.py
@@ -146,8 +146,8 @@ async def test_verify_jsonld(
 
     # # Error invalid
     jsonld_verify.verkey = None
-    faber_pub_did = (await faber_acapy_client.wallet.get_public_did()).result.did
-    jsonld_verify.public_did = faber_pub_did
+    faber_pub_did_result = await faber_acapy_client.wallet.get_public_did()
+    jsonld_verify.public_did = faber_pub_did_result.result.did
 
     with pytest.raises(HTTPException) as exc:
         await faber_client.post(JSONLD_BASE_PATH + "/verify", json=jsonld_verify.dict())

--- a/app/tests/e2e/test_jsonld.py
+++ b/app/tests/e2e/test_jsonld.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from aries_cloudcontroller import AcaPyClient, SignatureOptions
 from assertpy import assert_that
@@ -145,9 +147,10 @@ async def test_verify_jsonld(
     assert_that(exc.value.status_code).is_equal_to(400)
 
     # # Error invalid
-    jsonld_verify.verkey = None
+    time.sleep(1)  # Sleep in case reading public did is too soon after registering it
     faber_pub_did_result = await faber_acapy_client.wallet.get_public_did()
     jsonld_verify.public_did = faber_pub_did_result.result.did
+    jsonld_verify.verkey = None
 
     with pytest.raises(HTTPException) as exc:
         await faber_client.post(JSONLD_BASE_PATH + "/verify", json=jsonld_verify.dict())


### PR DESCRIPTION
Remove the custom JsonldApi override that was implemented as a workaround for a previous ACA-Py release:
```
# NOTE: Wrong/incomplete aca-py openAPI spec results in wrong/overly-strict model for controller endpoint
# Hence, custom override api endpoint that is incorrect in aca-py
```
and just use the default, autogenerated API and request model from cloudcontroller