### PR TITLE
Hotfix: Helm `3.13.1`

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -281,7 +281,7 @@ jobs:
     env:
       TAILSCALE_VERSION: 1.50.1
       HELMFILE_VERSION: v0.157.0
-      HELM_VERSION: v3.13.3
+      HELM_VERSION: v3.13.1
 
     concurrency:
       group: cicd-deploy


### PR DESCRIPTION
Helm `3.13.3` doesn't exist... How did the CI/CD succeed earlier?