### PR TITLE
Skip deploy to EKS if dependabot

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -278,6 +278,9 @@ jobs:
       id-token: write # Required to authenticate with AWS
       contents: read # Required to clone this repository
     runs-on: ubuntu-latest
+
+    if: github.actor != 'dependabot[bot]'
+
     env:
       TAILSCALE_VERSION: 1.50.1
       HELMFILE_VERSION: v0.157.0


### PR DESCRIPTION
This will make it so that dependabot PRs won't trigger EKS deployments.

Merging a PR will still trigger deployments to EKS.