### PR TITLE
:sparkles: Reuse SSL cert context for all HTTP requests

### DIFF
--- a/app/event_handling/sse_listener.py
+++ b/app/event_handling/sse_listener.py
@@ -1,10 +1,11 @@
 import json
 from typing import Any, Dict
 
-import httpx
+from httpx import Timeout
 
 from shared import WEBHOOKS_URL
 from shared.log_config import get_logger
+from shared.util.rich_async_client import RichAsyncClient
 
 logger = get_logger(__name__)
 base_url = f"{WEBHOOKS_URL}/sse"
@@ -33,8 +34,8 @@ class SseListener:
         """
         url = f"{base_url}/{self.wallet_id}/{self.topic}/{desired_state}"
 
-        timeout = httpx.Timeout(timeout)
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        timeout = Timeout(timeout)
+        async with RichAsyncClient(timeout=timeout) as client:
             async with client.stream("GET", url) as response:
                 async for line in response.aiter_lines():
                     if line.startswith("data: "):
@@ -55,8 +56,8 @@ class SseListener:
         """
         url = f"{base_url}/{self.wallet_id}/{self.topic}/{field}/{field_id}/{desired_state}"
 
-        timeout = httpx.Timeout(timeout)
-        async with httpx.AsyncClient(timeout=timeout) as client:
+        timeout = Timeout(timeout)
+        async with RichAsyncClient(timeout=timeout) as client:
             async with client.stream("GET", url) as response:
                 async for line in response.aiter_lines():
                     if line.startswith("data: "):

--- a/app/services/sse.py
+++ b/app/services/sse.py
@@ -35,9 +35,7 @@ async def sse_subscribe_wallet(
     """
     bound_logger = logger.bind(body={"wallet_id": wallet_id})
     try:
-        async with RichAsyncClient(
-            timeout=default_timeout, raise_status_error=False
-        ) as client:
+        async with RichAsyncClient(timeout=default_timeout) as client:
             bound_logger.debug("Connecting stream to /sse/wallet_id")
             async with client.stream(
                 "GET", f"{WEBHOOKS_URL}/sse/{wallet_id}"
@@ -63,9 +61,7 @@ async def sse_subscribe_wallet_topic(
     """
     bound_logger = logger.bind(body={"wallet_id": wallet_id, "topic": topic})
     try:
-        async with RichAsyncClient(
-            timeout=default_timeout, raise_status_error=False
-        ) as client:
+        async with RichAsyncClient(timeout=default_timeout) as client:
             bound_logger.debug("Connecting stream to /sse/wallet_id/topic")
             async with client.stream(
                 "GET", f"{WEBHOOKS_URL}/sse/{wallet_id}/{topic}"
@@ -96,9 +92,7 @@ async def sse_subscribe_event_with_state(
         body={"wallet_id": wallet_id, "topic": topic, "state": desired_state}
     )
     try:
-        async with RichAsyncClient(
-            timeout=event_timeout, raise_status_error=False
-        ) as client:
+        async with RichAsyncClient(timeout=event_timeout) as client:
             bound_logger.debug(
                 "Connecting stream to /sse/wallet_id/topic/desired_state"
             )
@@ -132,9 +126,7 @@ async def sse_subscribe_stream_with_fields(
         body={"wallet_id": wallet_id, "topic": topic, field: field_id}
     )
     try:
-        async with RichAsyncClient(
-            timeout=default_timeout, raise_status_error=False
-        ) as client:
+        async with RichAsyncClient(timeout=default_timeout) as client:
             bound_logger.debug(
                 "Connecting stream to /sse/wallet_id/topic/field/field_id"
             )
@@ -174,9 +166,7 @@ async def sse_subscribe_event_with_field_and_state(
         }
     )
     try:
-        async with RichAsyncClient(
-            timeout=event_timeout, raise_status_error=False
-        ) as client:
+        async with RichAsyncClient(timeout=event_timeout) as client:
             bound_logger.debug(
                 "Connecting stream to /sse/wallet_id/topic/field/field_id/desired_state"
             )

--- a/app/services/sse.py
+++ b/app/services/sse.py
@@ -1,10 +1,11 @@
 from typing import AsyncGenerator
 
 from fastapi import Request
-from httpx import AsyncClient, HTTPError, Response, Timeout
+from httpx import HTTPError, Response, Timeout
 
 from shared import WEBHOOKS_URL
 from shared.log_config import get_logger
+from shared.util.rich_async_client import RichAsyncClient
 
 logger = get_logger(__name__)
 SSE_PING_PERIOD = 15
@@ -34,7 +35,9 @@ async def sse_subscribe_wallet(
     """
     bound_logger = logger.bind(body={"wallet_id": wallet_id})
     try:
-        async with AsyncClient(timeout=default_timeout) as client:
+        async with RichAsyncClient(
+            timeout=default_timeout, raise_status_error=False
+        ) as client:
             bound_logger.debug("Connecting stream to /sse/wallet_id")
             async with client.stream(
                 "GET", f"{WEBHOOKS_URL}/sse/{wallet_id}"
@@ -60,7 +63,9 @@ async def sse_subscribe_wallet_topic(
     """
     bound_logger = logger.bind(body={"wallet_id": wallet_id, "topic": topic})
     try:
-        async with AsyncClient(timeout=default_timeout) as client:
+        async with RichAsyncClient(
+            timeout=default_timeout, raise_status_error=False
+        ) as client:
             bound_logger.debug("Connecting stream to /sse/wallet_id/topic")
             async with client.stream(
                 "GET", f"{WEBHOOKS_URL}/sse/{wallet_id}/{topic}"
@@ -91,7 +96,9 @@ async def sse_subscribe_event_with_state(
         body={"wallet_id": wallet_id, "topic": topic, "state": desired_state}
     )
     try:
-        async with AsyncClient(timeout=event_timeout) as client:
+        async with RichAsyncClient(
+            timeout=event_timeout, raise_status_error=False
+        ) as client:
             bound_logger.debug(
                 "Connecting stream to /sse/wallet_id/topic/desired_state"
             )
@@ -125,7 +132,9 @@ async def sse_subscribe_stream_with_fields(
         body={"wallet_id": wallet_id, "topic": topic, field: field_id}
     )
     try:
-        async with AsyncClient(timeout=default_timeout) as client:
+        async with RichAsyncClient(
+            timeout=default_timeout, raise_status_error=False
+        ) as client:
             bound_logger.debug(
                 "Connecting stream to /sse/wallet_id/topic/field/field_id"
             )
@@ -165,7 +174,9 @@ async def sse_subscribe_event_with_field_and_state(
         }
     )
     try:
-        async with AsyncClient(timeout=event_timeout) as client:
+        async with RichAsyncClient(
+            timeout=event_timeout, raise_status_error=False
+        ) as client:
             bound_logger.debug(
                 "Connecting stream to /sse/wallet_id/topic/field/field_id/desired_state"
             )

--- a/app/services/trust_registry.py
+++ b/app/services/trust_registry.py
@@ -6,6 +6,7 @@ from typing_extensions import TypedDict
 from app.exceptions.trust_registry_exception import TrustRegistryException
 from shared.constants import TRUST_REGISTRY_URL
 from shared.log_config import get_logger
+from shared.util.rich_async_client import RichAsyncClient
 
 logger = get_logger(__name__)
 
@@ -110,7 +111,7 @@ async def actor_by_did(did: str) -> Optional[Actor]:
     bound_logger = logger.bind(body={"did": did})
     bound_logger.info("Fetching actor by DID from trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             actor_res = await client.get(
                 f"{TRUST_REGISTRY_URL}/registry/actors/did/{did}"
             )
@@ -151,7 +152,7 @@ async def assert_actor_name(actor_name: str) -> bool:
     bound_logger.info("Fetching actor by name from trust registry")
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             actor_response = await client.get(
                 f"{TRUST_REGISTRY_URL}/registry/actors/name/{actor_name}"
             )
@@ -191,7 +192,7 @@ async def actor_by_id(actor_id: str) -> Optional[Actor]:
     bound_logger = logger.bind(body={"actor_id": actor_id})
     bound_logger.info("Fetching actor by ID from trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             actor_res = await client.get(
                 f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}"
             )
@@ -231,7 +232,7 @@ async def actors_with_role(role: TrustRegistryRole) -> List[Actor]:
     bound_logger = logger.bind(body={"role": role})
     bound_logger.info("Fetching all actors with requested role from trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             actors_res = await client.get(f"{TRUST_REGISTRY_URL}/registry/actors")
     except httpx.HTTPError as e:
         bound_logger.exception("HTTP Error caught when fetching from trust registry.")
@@ -278,7 +279,7 @@ async def registry_has_schema(schema_id: str) -> bool:
         "Asserting if schema is registered. Fetching schema by ID from trust registry"
     )
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             bound_logger.debug("Fetch schema from trust registry")
             schema_res = await client.get(
                 f"{TRUST_REGISTRY_URL}/registry/schemas/{schema_id}"
@@ -309,7 +310,7 @@ async def get_trust_registry_schemas() -> List[str]:
     """
     logger.info("Fetching all schemas from trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             schemas_res = await client.get(f"{TRUST_REGISTRY_URL}/registry/schemas")
     except httpx.HTTPError as e:
         logger.exception("HTTP Error caught when fetching from trust registry.")
@@ -341,7 +342,7 @@ async def get_trust_registry() -> TrustRegistry:
     """
     logger.info("Fetching complete trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             trust_registry_res = await client.get(f"{TRUST_REGISTRY_URL}/registry")
     except httpx.HTTPError as e:
         logger.exception("HTTP Error caught when fetching trust registry.")
@@ -375,7 +376,7 @@ async def register_schema(schema_id: str) -> None:
     bound_logger = logger.bind(body={"schema_id": schema_id})
     bound_logger.info("Registering schema on trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             schema_res = await client.post(
                 f"{TRUST_REGISTRY_URL}/registry/schemas", json={"schema_id": schema_id}
             )
@@ -409,7 +410,7 @@ async def register_actor(actor: Actor) -> None:
     bound_logger = logger.bind(body={"actor": actor})
     bound_logger.info("Registering actor on trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             actor_res = await client.post(
                 f"{TRUST_REGISTRY_URL}/registry/actors", json=actor
             )
@@ -450,7 +451,7 @@ async def remove_actor_by_id(actor_id: str) -> None:
     bound_logger = logger.bind(body={"actor_id": actor_id})
     bound_logger.info("Removing actor from trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             remove_response = await client.delete(
                 f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}"
             )
@@ -489,7 +490,7 @@ async def remove_schema_by_id(schema_id: str) -> None:
     bound_logger = logger.bind(body={"schema_id": schema_id})
     bound_logger.info("Removing schema from trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             remove_response = await client.delete(
                 f"{TRUST_REGISTRY_URL}/registry/schemas/{schema_id}"
             )
@@ -515,7 +516,7 @@ async def update_actor(actor: Actor) -> None:
     bound_logger = logger.bind(body={"actor": actor})
     bound_logger.info("Updating actor on trust registry")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             update_response = await client.put(
                 f"{TRUST_REGISTRY_URL}/registry/actors/{actor['id']}", json=actor
             )

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,9 +1,5 @@
-from unittest.mock import AsyncMock, Mock
-
 import mockito
 import pytest
-from httpx import Response
-from pytest_mock import MockerFixture
 
 # flake8: noqa
 # pylint: disable=unused-import
@@ -81,15 +77,3 @@ def unstub_mockito():
 
     # Teardown phase: After each test, unstub all stubbed methods
     mockito.unstub()
-
-
-@pytest.fixture
-def mock_async_client(mocker: MockerFixture) -> Mock:
-    patch_async_client = mocker.patch("httpx.AsyncClient")
-
-    mocked_async_client = Mock()
-    response = Response(status_code=200)
-    mocked_async_client.get = AsyncMock(return_value=response)
-    patch_async_client.return_value.__aenter__.return_value = mocked_async_client
-
-    return mocked_async_client

--- a/app/tests/e2e/test_exception_handler.py
+++ b/app/tests/e2e/test_exception_handler.py
@@ -1,15 +1,17 @@
 import pytest
-from httpx import AsyncClient
 
 from app.routes.connections import router
 from shared import CLOUDAPI_URL
+from shared.util.rich_async_client import RichAsyncClient
 
 CONNECTIONS_BASE_PATH = router.prefix
 
 
 @pytest.mark.anyio
 async def test_error_handler():
-    async with AsyncClient(base_url=CLOUDAPI_URL) as client:
+    async with RichAsyncClient(
+        base_url=CLOUDAPI_URL, raise_status_error=False
+    ) as client:
         response = await client.get(CONNECTIONS_BASE_PATH)
         assert response.status_code == 403
         assert response.text == '{"detail":"Not authenticated"}'

--- a/app/tests/services/test_trust_registry.py
+++ b/app/tests/services/test_trust_registry.py
@@ -2,8 +2,21 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from httpx import HTTPStatusError, Response
+from pytest_mock import MockerFixture
 
 import app.services.trust_registry as trf
+
+
+@pytest.fixture
+def mock_async_client(mocker: MockerFixture) -> Mock:
+    patch_async_client = mocker.patch("app.services.trust_registry.RichAsyncClient")
+
+    mocked_async_client = Mock()
+    response = Response(status_code=200)
+    mocked_async_client.get = AsyncMock(return_value=response)
+    patch_async_client.return_value.__aenter__.return_value = mocked_async_client
+
+    return mocked_async_client
 
 
 @pytest.mark.anyio

--- a/app/tests/util/ledger.py
+++ b/app/tests/util/ledger.py
@@ -1,14 +1,15 @@
 from typing import Literal, Optional
 
-import httpx
 from aries_cloudcontroller import AcaPyClient
 from fastapi import HTTPException
+from httpx import HTTPError
 from pydantic import BaseModel, Field
 
 from app.services import acapy_wallet
 from app.services.acapy_ledger import accept_taa_if_required
 from shared import LEDGER_REGISTRATION_URL, LEDGER_TYPE
 from shared.log_config import get_logger
+from shared.util.rich_async_client import RichAsyncClient
 
 logger = get_logger(__name__)
 
@@ -46,11 +47,11 @@ async def post_to_ledger(
 
     logger.info(f"Try post to ledger: {payload}")
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             response = await client.post(
                 LEDGER_REGISTRATION_URL, json=payload.model_dump(), timeout=300
             )
-    except httpx.HTTPError as e:
+    except HTTPError as e:
         raise e from e
 
     if response.is_error:

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -2,7 +2,7 @@ import base64
 import json
 from typing import Dict, List, Optional
 
-import httpx
+from httpx import HTTPError
 from pydantic import BaseModel
 
 from app.event_handling.sse_listener import SseListener
@@ -82,10 +82,10 @@ async def get_hooks_per_topic_per_wallet(
 ) -> List:
     wallet_id = get_wallet_id_from_async_client(client)
     try:
-        async with httpx.AsyncClient() as client:
+        async with RichAsyncClient(raise_status_error=False) as client:
             hooks = await client.get(
                 f"{WEBHOOKS_URL}/webhooks/{wallet_id}/{topic}"
             ).json()
         return hooks if hooks else []
-    except httpx.HTTPError as e:
+    except HTTPError as e:
         raise e from e

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -1,18 +1,10 @@
 import base64
 import json
-from typing import Dict, List, Optional
-
-from httpx import HTTPError
-from pydantic import BaseModel
+from typing import Dict, Optional
 
 from app.event_handling.sse_listener import SseListener
-from shared import WEBHOOKS_URL, RichAsyncClient
+from shared import RichAsyncClient
 from shared.models.topics import CloudApiTopics
-
-
-class FilterMap(BaseModel):
-    filter_key: str
-    filter_value: str
 
 
 def get_wallet_id_from_b64encoded_jwt(jwt: str) -> str:
@@ -75,17 +67,3 @@ async def check_webhook_state(
         return True
     else:
         raise Exception(f"Could not satisfy webhook filter: `{filter_map}`.")
-
-
-async def get_hooks_per_topic_per_wallet(
-    client: RichAsyncClient, topic: CloudApiTopics
-) -> List:
-    wallet_id = get_wallet_id_from_async_client(client)
-    try:
-        async with RichAsyncClient(raise_status_error=False) as client:
-            hooks = await client.get(
-                f"{WEBHOOKS_URL}/webhooks/{wallet_id}/{topic}"
-            ).json()
-        return hooks if hooks else []
-    except HTTPError as e:
-        raise e from e

--- a/endorser/endorser_processor.py
+++ b/endorser/endorser_processor.py
@@ -291,12 +291,9 @@ async def is_valid_issuer(did: str, schema_id: str):
         return False
 
     try:
-        async with RichAsyncClient(raise_status_error=False) as client:
+        async with RichAsyncClient() as client:
             bound_logger.debug("Fetch schema from trust registry")
-            schema_res = await client.get(
-                f"{TRUST_REGISTRY_URL}/registry/schemas/{schema_id}"
-            )
-            schema_res.raise_for_status()
+            await client.get(f"{TRUST_REGISTRY_URL}/registry/schemas/{schema_id}")
     except HTTPStatusError as http_err:
         if http_err.response.status_code == 404:
             bound_logger.info("Schema id not registered in trust registry.")

--- a/endorser/endorser_processor.py
+++ b/endorser/endorser_processor.py
@@ -142,10 +142,10 @@ async def should_accept_endorsement(
         client, attachment
     )
 
-    MAX_RETRIES = 5
-    RETRY_DELAY = 1  # in seconds
+    max_retries = 5
+    retry_delay = 1  # in seconds
 
-    for attempt in range(MAX_RETRIES):
+    for attempt in range(max_retries):
         try:
             valid_issuer = await is_valid_issuer(did, schema_id)
 
@@ -166,9 +166,9 @@ async def should_accept_endorsement(
                 e,
             )
 
-            if attempt < MAX_RETRIES - 1:
+            if attempt < max_retries - 1:
                 bound_logger.info("Retrying...")
-                await asyncio.sleep(RETRY_DELAY)
+                await asyncio.sleep(retry_delay)
             else:
                 bound_logger.error("Max retries reached. Giving up.")
                 return False

--- a/endorser/tests/test_endorser_processor.py
+++ b/endorser/tests/test_endorser_processor.py
@@ -117,7 +117,7 @@ def test_is_governance_agent():
 
 @pytest.mark.anyio
 async def test_is_valid_issuer(mocker: MockerFixture):
-    patch_async_client = mocker.patch("httpx.AsyncClient")
+    patch_async_client = mocker.patch("RichAsyncClient")
     mocked_async_client = MagicMock()
     patch_async_client.return_value.__aenter__.return_value = mocked_async_client
 
@@ -131,7 +131,7 @@ async def test_is_valid_issuer(mocker: MockerFixture):
     )
     schema_response.raise_for_status = Mock()
     mocked_async_client.get = AsyncMock(side_effect=[actor_response, schema_response])
-    # Mock the `async with httpx.AsyncClient` to return mocked_async_client
+    # Mock the `async with RichAsyncClient` to return mocked_async_client
 
     assert await is_valid_issuer(did, schema_id)
 
@@ -146,7 +146,7 @@ async def test_is_valid_issuer(mocker: MockerFixture):
 
 @pytest.mark.anyio
 async def test_is_valid_issuer_x_res_errors(mocker: MockerFixture):
-    patch_async_client = mocker.patch("httpx.AsyncClient")
+    patch_async_client = mocker.patch("RichAsyncClient")
     mocked_async_client = MagicMock()
     patch_async_client.return_value.__aenter__.return_value = mocked_async_client
 

--- a/endorser/tests/test_endorser_processor.py
+++ b/endorser/tests/test_endorser_processor.py
@@ -117,7 +117,7 @@ def test_is_governance_agent():
 
 @pytest.mark.anyio
 async def test_is_valid_issuer(mocker: MockerFixture):
-    patch_async_client = mocker.patch("RichAsyncClient")
+    patch_async_client = mocker.patch("endorser.endorser_processor.RichAsyncClient")
     mocked_async_client = MagicMock()
     patch_async_client.return_value.__aenter__.return_value = mocked_async_client
 
@@ -146,7 +146,7 @@ async def test_is_valid_issuer(mocker: MockerFixture):
 
 @pytest.mark.anyio
 async def test_is_valid_issuer_x_res_errors(mocker: MockerFixture):
-    patch_async_client = mocker.patch("RichAsyncClient")
+    patch_async_client = mocker.patch("endorser.endorser_processor.RichAsyncClient")
     mocked_async_client = MagicMock()
     patch_async_client.return_value.__aenter__.return_value = mocked_async_client
 

--- a/endorser/tests/test_endorser_processor.py
+++ b/endorser/tests/test_endorser_processor.py
@@ -157,11 +157,10 @@ async def test_is_valid_issuer_x_res_errors(mocker: MockerFixture):
     schema_response = Response(
         200, json={"id": schema_id, "did": did, "version": "1.0", "name": "name"}
     )
-    schema_response.raise_for_status = Mock()
     # Error actor res
     mocked_async_client.get = AsyncMock(
         side_effect=[
-            Response(400, json={}),
+            Response(404, json={}),
             schema_response,
         ]
     )
@@ -169,13 +168,10 @@ async def test_is_valid_issuer_x_res_errors(mocker: MockerFixture):
 
     # Error schema res
     not_schema_id = "not-the-schema-id"
-    error_response = Response(status_code=400)
-    error_response.raise_for_status = Mock(
-        side_effect=HTTPStatusError(
-            response=error_response,
-            message="Something went wrong",
-            request=not_schema_id,
-        )
+    error_response = HTTPStatusError(
+        response=Response(status_code=500),
+        message="Something went wrong",
+        request=not_schema_id,
     )
     mocked_async_client.get = AsyncMock(side_effect=[actor_response, error_response])
     with pytest.raises(HTTPStatusError):
@@ -192,13 +188,10 @@ async def test_is_valid_issuer_x_res_errors(mocker: MockerFixture):
 
     # schema not registered
     not_schema_id = "not-the-schema-id"
-    error_response = Response(status_code=404)
-    error_response.raise_for_status = Mock(
-        side_effect=HTTPStatusError(
-            response=error_response,
-            message="Schema does not exist in registry.",
-            request=not_schema_id,
-        )
+    error_response = HTTPStatusError(
+        response=Response(status_code=404),
+        message="Schema does not exist in registry.",
+        request=not_schema_id,
     )
     mocked_async_client.get = AsyncMock(side_effect=[actor_response, error_response])
     assert not await is_valid_issuer(did, schema_id)

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -9,16 +9,24 @@ logger = logging.getLogger(__name__)
 
 # Async Client with built in error handling
 class RichAsyncClient(AsyncClient):
-    def __init__(self, *args, name: Optional[str] = None, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        *args,
+        name: Optional[str] = None,
+        verify=True,
+        raise_status_error=True,
+        **kwargs,
+    ):
         self._name = (
             name + " - HTTP" if name else "HTTP"
         )  # prepend to exception messages to add context
+        self.raise_status_error = raise_status_error
 
     async def post(self, url: str, **kwargs):
         try:
             response = await super().post(url, **kwargs)
-            response.raise_for_status()  # Raise exception for 4xx and 5xx status codes
+            if self.raise_status_error:
+                response.raise_for_status()  # Raise exception for 4xx and 5xx status codes
         except HTTPStatusError as e:
             code = e.response.status_code
             detail = f"{self._name} POST `{url}` failed. Status code: {code}. Response: `{e.response.text}`."
@@ -29,7 +37,8 @@ class RichAsyncClient(AsyncClient):
     async def get(self, url: str, **kwargs):
         try:
             response = await super().get(url, **kwargs)
-            response.raise_for_status()
+            if self.raise_status_error:
+                response.raise_for_status()
         except HTTPStatusError as e:
             code = e.response.status_code
             detail = f"{self._name} GET `{url}` failed. Status code: {code}. Response: `{e.response.text}`."
@@ -40,7 +49,8 @@ class RichAsyncClient(AsyncClient):
     async def delete(self, url: str, **kwargs):
         try:
             response = await super().delete(url, **kwargs)
-            response.raise_for_status()
+            if self.raise_status_error:
+                response.raise_for_status()
         except HTTPStatusError as e:
             code = e.response.status_code
             detail = f"{self._name} DELETE `{url}` failed. Status code: {code}. Response: `{e.response.text}`."
@@ -51,7 +61,8 @@ class RichAsyncClient(AsyncClient):
     async def put(self, url: str, **kwargs):
         try:
             response = await super().put(url, **kwargs)
-            response.raise_for_status()
+            if self.raise_status_error:
+                response.raise_for_status()
         except HTTPStatusError as e:
             code = e.response.status_code
             detail = f"{self._name} PUT `{url}` failed. Status code: {code}. Response: `{e.response.text}`."

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -1,4 +1,5 @@
 import logging
+import ssl
 from typing import Optional
 
 from fastapi import HTTPException
@@ -6,17 +7,20 @@ from httpx import AsyncClient, HTTPStatusError
 
 logger = logging.getLogger(__name__)
 
+ssl_context = ssl.create_default_context()
 
-# Async Client with built in error handling
+
+# Async Client with built in error handling and re-using SSL certs
 class RichAsyncClient(AsyncClient):
     def __init__(
         self,
         *args,
         name: Optional[str] = None,
-        verify=True,
+        verify=ssl_context,
         raise_status_error=True,
         **kwargs,
     ):
+        super().__init__(verify=verify, *args, **kwargs)
         self._name = (
             name + " - HTTP" if name else "HTTP"
         )  # prepend to exception messages to add context

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -3,7 +3,7 @@ import ssl
 from typing import Optional
 
 from fastapi import HTTPException
-from httpx import AsyncClient, HTTPStatusError
+from httpx import AsyncClient, HTTPStatusError, Response
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +19,14 @@ class RichAsyncClient(AsyncClient):
         verify=ssl_context,
         raise_status_error=True,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(verify=verify, *args, **kwargs)
         self._name = (
             name + " - HTTP" if name else "HTTP"
         )  # prepend to exception messages to add context
         self.raise_status_error = raise_status_error
 
-    async def post(self, url: str, **kwargs):
+    async def post(self, url: str, **kwargs) -> Response:
         try:
             response = await super().post(url, **kwargs)
             if self.raise_status_error:
@@ -38,7 +38,7 @@ class RichAsyncClient(AsyncClient):
             raise HTTPException(status_code=code, detail=detail) from e
         return response
 
-    async def get(self, url: str, **kwargs):
+    async def get(self, url: str, **kwargs) -> Response:
         try:
             response = await super().get(url, **kwargs)
             if self.raise_status_error:
@@ -50,7 +50,7 @@ class RichAsyncClient(AsyncClient):
             raise HTTPException(status_code=code, detail=detail) from e
         return response
 
-    async def delete(self, url: str, **kwargs):
+    async def delete(self, url: str, **kwargs) -> Response:
         try:
             response = await super().delete(url, **kwargs)
             if self.raise_status_error:
@@ -62,7 +62,7 @@ class RichAsyncClient(AsyncClient):
             raise HTTPException(status_code=code, detail=detail) from e
         return response
 
-    async def put(self, url: str, **kwargs):
+    async def put(self, url: str, **kwargs) -> Response:
         try:
             response = await super().put(url, **kwargs)
             if self.raise_status_error:

--- a/trustregistry/tests/test_actor.py
+++ b/trustregistry/tests/test_actor.py
@@ -1,10 +1,10 @@
 import json
 
 import pytest
-from httpx import AsyncClient
 
 from app.util.string import random_string
 from shared import TRUST_REGISTRY_URL
+from shared.util.rich_async_client import RichAsyncClient
 
 new_actor = {
     "id": "darth-vader",
@@ -30,7 +30,7 @@ def generate_actor():
 
 @pytest.mark.anyio
 async def test_get_actors():
-    async with AsyncClient() as client:
+    async with RichAsyncClient() as client:
         response = await client.get(f"{TRUST_REGISTRY_URL}/registry/actors")
 
     assert response.status_code == 200
@@ -56,7 +56,7 @@ async def test_register_actor():
     id_payload["id"] = new_actor["id"]
     id_payload = json.dumps(id_payload)
 
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.post(
             f"{TRUST_REGISTRY_URL}/registry/actors",
             content=payload,
@@ -100,7 +100,7 @@ async def test_register_actor():
 
 @pytest.mark.anyio
 async def test_get_actor():
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         # test by id
         response = await client.get(f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}")
 
@@ -144,7 +144,7 @@ async def test_get_actor():
 
 @pytest.mark.anyio
 async def test_update_actor():
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.put(
             f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}",
             json=new_actor,
@@ -169,7 +169,7 @@ async def test_update_actor_x():
     updated_actor = new_actor.copy()
     updated_actor["did"] = None
 
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.put(
             f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}",
             json=updated_actor,
@@ -184,7 +184,7 @@ async def test_update_actor_x():
 
 @pytest.mark.anyio
 async def test_remove_actors():
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.delete(
             f"{TRUST_REGISTRY_URL}/registry/actors/{actor_id}"
         )

--- a/trustregistry/tests/test_main.py
+++ b/trustregistry/tests/test_main.py
@@ -1,12 +1,12 @@
 import pytest
-from httpx import AsyncClient
 
 from shared import TRUST_REGISTRY_URL
+from shared.util.rich_async_client import RichAsyncClient
 
 
 @pytest.mark.anyio
 async def test_root():
-    async with AsyncClient() as client:
+    async with RichAsyncClient() as client:
         resp = await client.get(f"{TRUST_REGISTRY_URL}")
 
     assert resp.status_code == 200
@@ -16,7 +16,7 @@ async def test_root():
 
 @pytest.mark.anyio
 async def test_registry():
-    async with AsyncClient() as client:
+    async with RichAsyncClient() as client:
         resp = await client.get(f"{TRUST_REGISTRY_URL}/registry")
 
     assert resp.status_code == 200

--- a/trustregistry/tests/test_schema.py
+++ b/trustregistry/tests/test_schema.py
@@ -1,7 +1,7 @@
 import pytest
-from httpx import AsyncClient
 
 from shared import TRUST_REGISTRY_URL
+from shared.util.rich_async_client import RichAsyncClient
 from trustregistry.registry.registry_schemas import SchemaID, _get_schema_attrs
 
 schema_id = "string:2:string:string"
@@ -10,7 +10,7 @@ updated_schema_id = "string_updated:2:string_updated:string_updated"
 
 @pytest.mark.anyio
 async def test_get_schemas():
-    async with AsyncClient() as client:
+    async with RichAsyncClient() as client:
         response = await client.get(f"{TRUST_REGISTRY_URL}/registry/schemas")
     assert response.status_code == 200
     assert "schemas" in response.json()
@@ -26,7 +26,7 @@ async def test_register_schema():
     }
     payload = {"schema_id": schema_id}
 
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.post(
             f"{TRUST_REGISTRY_URL}/registry/schemas",
             json=payload,
@@ -59,7 +59,7 @@ async def test_get_schema_by_id():
         "version": "string",
     }
 
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.get(
             f"{TRUST_REGISTRY_URL}/registry/schemas/{schema_id}"
         )
@@ -83,7 +83,7 @@ async def test_update_schema():
     }
     payload = {"schema_id": updated_schema_id}
 
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.put(
             f"{TRUST_REGISTRY_URL}/registry/schemas/{schema_id}",
             json=payload,
@@ -108,7 +108,7 @@ async def test_update_schema():
 
 @pytest.mark.anyio
 async def test_remove_schema():
-    async with AsyncClient() as client:
+    async with RichAsyncClient(raise_status_error=False) as client:
         response = await client.delete(
             f"{TRUST_REGISTRY_URL}/registry/schemas/{updated_schema_id}"
         )

--- a/webhooks/tests/test_sse.py
+++ b/webhooks/tests/test_sse.py
@@ -3,7 +3,7 @@ import logging
 
 import httpx
 import pytest
-from httpx import AsyncClient, Response, Timeout
+from httpx import Response, Timeout
 
 from app.tests.util.ecosystem_connections import BobAliceConnect
 from app.tests.util.webhooks import get_wallet_id_from_async_client
@@ -112,7 +112,7 @@ async def test_sse_subscribe_event(
 async def get_sse_stream_response(url, duration=2) -> Response:
     timeout = Timeout(duration)
     try:
-        async with AsyncClient(timeout=timeout) as client:
+        async with RichAsyncClient(timeout=timeout) as client:
             async with client.stream("GET", url) as response:
                 response_text = ""
                 try:
@@ -139,7 +139,7 @@ def response_to_json(response_text):
 
 async def listen_for_event(url, duration=10):
     timeout = Timeout(duration)
-    async with AsyncClient(timeout=timeout) as client:
+    async with RichAsyncClient(timeout=timeout) as client:
         async with client.stream("GET", url) as response:
             async for line in response.aiter_lines():
                 if line.startswith("data: "):

--- a/webhooks/tests/test_webhooks.py
+++ b/webhooks/tests/test_webhooks.py
@@ -1,5 +1,4 @@
 import pytest
-from httpx import AsyncClient
 
 from app.tests.util.ecosystem_connections import BobAliceConnect
 from app.tests.util.webhooks import get_wallet_id_from_async_client
@@ -11,7 +10,7 @@ from webhooks.main import app
 async def test_connection_webhooks(
     alice_member_client: RichAsyncClient, bob_and_alice_connection: BobAliceConnect
 ):
-    async with AsyncClient(app=app, base_url=WEBHOOKS_URL) as client:
+    async with RichAsyncClient(app=app, base_url=WEBHOOKS_URL) as client:
         alice_wallet_id = get_wallet_id_from_async_client(alice_member_client)
         alice_connection_id = bob_and_alice_connection.alice_connection_id
 


### PR DESCRIPTION
:sparkles: replaces all uses of httpx.AsyncClient with our RichAsyncClient, which provides reusing of SSL certs, and improved error handling.

Other minor improvement: in endorser processor, we fetch actors from the trust registry to assert they are an issuer. If some internal server error occurs when calling trust registry, we will now retry 5 times before failing to assert