### PR TITLE
:sparkles: add wallet_name to create tenant request, and allow fetch by wallet_name

### DIFF
--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel, Field
 from app.models.trust_registry import TrustRegistryRole
 
 # Deduplicate some descriptions and field definitions
-name_description = "A required alias for the tenant, publicized to other agents when forming a connection. "
-"If the tenant is an issuer or verifier, this name will be displayed on the trust registry and must be unique."
-name_examples = ["A required alias for the tenant"]
+label_description = "A required alias for the tenant, publicized to other agents when forming a connection. "
+"If the tenant is an issuer or verifier, this label will be displayed on the trust registry and must be unique."
+label_examples = ["Tenant Label"]
 group_id_field = Field(
     None,
     description="An optional group identifier. Useful with `get_tenants` to fetch wallets by group id.",
@@ -25,7 +25,9 @@ class CreateWalletRequestWithGroups(CreateWalletRequest):
 
 
 class CreateTenantRequest(BaseModel):
-    name: str = Field(..., description=name_description, examples=name_examples)
+    wallet_label: str = Field(
+        ..., description=label_description, examples=label_examples
+    )
     wallet_name: Optional[str] = Field(
         None,
         description="An optional wallet name. Useful with `get_tenants` to fetch wallets by wallet name. "
@@ -38,8 +40,8 @@ class CreateTenantRequest(BaseModel):
 
 
 class UpdateTenantRequest(BaseModel):
-    name: Optional[str] = Field(
-        None, description=name_description, examples=name_examples
+    wallet_label: Optional[str] = Field(
+        None, description=label_description, examples=label_examples
     )
     roles: Optional[List[TrustRegistryRole]] = None
     group_id: Optional[str] = group_id_field
@@ -48,7 +50,7 @@ class UpdateTenantRequest(BaseModel):
 
 class Tenant(BaseModel):
     wallet_id: str = Field(..., examples=["545135a4-ecbc-4400-8594-bdb74c51c88d"])
-    tenant_name: str = Field(..., examples=["Alice"])
+    wallet_label: str = Field(..., examples=["Alice"])
     wallet_name: str = Field(..., examples=["SomeWalletName"])
     created_at: str = Field(...)
     updated_at: Optional[str] = Field(None)

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -5,38 +5,54 @@ from pydantic import BaseModel, Field
 
 from app.models.trust_registry import TrustRegistryRole
 
+# Deduplicate some descriptions and field definitions
+name_description = "A required alias for the tenant, publicized to other agents when forming a connection. "
+"If the tenant is an issuer or verifier, this name will be displayed on the trust registry and must be unique."
+name_examples = ["A required alias for the tenant"]
+group_id_field = Field(
+    None,
+    description="An optional group identifier. Useful with `get_tenants` to fetch wallets by group id.",
+    examples=["Some Group Id"],
+)
+image_url_field = Field(
+    None,
+    examples=["https://upload.wikimedia.org/wikipedia/commons/7/70/Example.png"],
+)
+
 
 class CreateWalletRequestWithGroups(CreateWalletRequest):
-    group_id: Optional[str] = None
+    group_id: Optional[str] = group_id_field
 
 
-class TenantRequestBase(BaseModel):
-    image_url: Optional[str] = Field(
-        None, examples=["https://yoma.africa/images/sample.png"]
+class CreateTenantRequest(BaseModel):
+    name: str = Field(..., description=name_description, examples=name_examples)
+    wallet_name: Optional[str] = Field(
+        None,
+        description="An optional wallet name. Useful with `get_tenants` to fetch wallets by wallet name. "
+        "If selected, must be unique.",
+        examples=["An optional, unique wallet name"],
     )
-
-
-class CreateTenantRequest(TenantRequestBase):
-    name: str = Field(..., examples=["Yoma"])  # used as label and trust registry name
     roles: Optional[List[TrustRegistryRole]] = None
-    group_id: Optional[str] = Field(None, examples=["SomeGroupId"])
+    group_id: Optional[str] = group_id_field
+    image_url: Optional[str] = image_url_field
 
 
-class UpdateTenantRequest(TenantRequestBase):
+class UpdateTenantRequest(BaseModel):
     name: Optional[str] = Field(
-        None, examples=["Yoma"]
-    )  # used as label and trust registry name
+        None, description=name_description, examples=name_examples
+    )
     roles: Optional[List[TrustRegistryRole]] = None
-    group_id: Optional[str] = Field(None, examples=["SomeGroupId"])
+    group_id: Optional[str] = group_id_field
+    image_url: Optional[str] = image_url_field
 
 
 class Tenant(BaseModel):
     wallet_id: str = Field(..., examples=["545135a4-ecbc-4400-8594-bdb74c51c88d"])
     tenant_name: str = Field(..., examples=["Alice"])
-    image_url: Optional[str] = Field(None, examples=["https://yoma.africa/image.png"])
+    image_url: Optional[str] = image_url_field
     created_at: str = Field(...)
     updated_at: Optional[str] = Field(None)
-    group_id: Optional[str] = Field(None, examples=["SomeGroupId"])
+    group_id: Optional[str] = group_id_field
 
 
 class TenantAuth(BaseModel):

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -31,8 +31,8 @@ class CreateTenantRequest(BaseModel):
     wallet_name: Optional[str] = Field(
         None,
         description="An optional wallet name. Useful with `get_tenants` to fetch wallets by wallet name. "
-        "If selected, must be unique.",
-        examples=["An optional, unique wallet name"],
+        "If selected, must be unique. Otherwise, randomly generated.",
+        examples=["Unique name"],
     )
     roles: Optional[List[TrustRegistryRole]] = None
     group_id: Optional[str] = group_id_field

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -49,9 +49,10 @@ class UpdateTenantRequest(BaseModel):
 class Tenant(BaseModel):
     wallet_id: str = Field(..., examples=["545135a4-ecbc-4400-8594-bdb74c51c88d"])
     tenant_name: str = Field(..., examples=["Alice"])
-    image_url: Optional[str] = image_url_field
+    wallet_name: str = Field(..., examples=["SomeWalletName"])
     created_at: str = Field(...)
     updated_at: Optional[str] = Field(None)
+    image_url: Optional[str] = image_url_field
     group_id: Optional[str] = group_id_field
 
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp~=3.8.4
-aries-cloudcontroller==0.9.0.post0
+aries-cloudcontroller==0.9.0.post1
 base58~=2.1.1
 fastapi~=0.104.0
 fastapi_websocket_pubsub~=0.3.8

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -51,6 +51,7 @@ async def create_tenant(
 
     name = body.name
     roles = body.roles
+    wallet_name=body.wallet_name or uuid4().hex,
 
     if roles:
         bound_logger.info("Create tenant with roles. Assert name is unique")
@@ -78,7 +79,7 @@ async def create_tenant(
                     key_management_mode="managed",
                     label=name,
                     wallet_key=base58.b58encode(token_urlsafe(48)).decode(),
-                    wallet_name=body.wallet_name or uuid4().hex,
+                    wallet_name=wallet_name,
                     wallet_type="askar",
                     group_id=body.group_id,
                 )
@@ -130,10 +131,11 @@ async def create_tenant(
 
     response = CreateTenantResponse(
         wallet_id=wallet_response.wallet_id,
+        tenant_name=name,
+        wallet_name=wallet_name,
         created_at=wallet_response.created_at,
         image_url=body.image_url,
         updated_at=wallet_response.updated_at,
-        tenant_name=name,
         access_token=tenant_api_key(auth.role, wallet_response.token),
         group_id=body.group_id,
     )

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -44,7 +44,7 @@ router = APIRouter(prefix="/admin/tenants", tags=["admin: tenants"])
 async def create_tenant(
     body: CreateTenantRequest,
     auth: AcaPyAuth = Depends(acapy_auth),
-) -> Tenant:
+) -> CreateTenantResponse:
     """Create a new tenant."""
     bound_logger = logger.bind(body=body)
     bound_logger.info("POST request received: Starting tenant creation")
@@ -178,7 +178,7 @@ async def delete_tenant_by_id(
 async def get_wallet_auth_token(
     wallet_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> TenantAuth:
     bound_logger = logger.bind(body={"wallet_id": wallet_id})
     bound_logger.info("GET request received: Access token for tenant")
 

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -78,7 +78,7 @@ async def create_tenant(
                     key_management_mode="managed",
                     label=name,
                     wallet_key=base58.b58encode(token_urlsafe(48)).decode(),
-                    wallet_name=uuid4().hex,
+                    wallet_name=body.wallet_name or uuid4().hex,
                     wallet_type="askar",
                     group_id=body.group_id,
                 )

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -55,14 +55,14 @@ async def create_tenant(
     if roles:
         bound_logger.info("Create tenant with roles. Assert name is unique")
         try:
-            actor_name_exists = await assert_actor_name(body.name)
+            actor_name_exists = await assert_actor_name(name)
         except TrustRegistryException:
             raise CloudApiException(
                 "An error occurred when trying to register actor. Please try again"
             )
 
         if actor_name_exists:
-            bound_logger.info("Actor exists can't create wallet")
+            bound_logger.info("Actor name already exists; can't create wallet")
             raise HTTPException(
                 409, f"Can't create Tenant. Actor with name `{name}` already exists."
             )
@@ -76,7 +76,7 @@ async def create_tenant(
                 body=CreateWalletRequestWithGroups(
                     image_url=body.image_url,
                     key_management_mode="managed",
-                    label=body.name,
+                    label=name,
                     wallet_key=base58.b58encode(token_urlsafe(48)).decode(),
                     wallet_name=uuid4().hex,
                     wallet_type="askar",

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -51,7 +51,7 @@ async def create_tenant(
 
     name = body.name
     roles = body.roles
-    wallet_name=body.wallet_name or uuid4().hex,
+    wallet_name = body.wallet_name or uuid4().hex
 
     if roles:
         bound_logger.info("Create tenant with roles. Assert name is unique")

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from aiohttp import ClientResponseError
+from aries_cloudcontroller import ApiException
 from fastapi import APIRouter, Depends, Query
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -139,10 +139,10 @@ async def send_credential(
             result = await issuer.send_credential(
                 controller=aries_controller, credential=credential
             )
-        except ClientResponseError as e:
+        except ApiException as e:
             logger.warning(
-                "ClientResponseError was caught while sending credentials, with message `{}`.",
-                e.message,
+                "ApiException was caught while sending credentials, with message `{}`.",
+                e.reason,
             )
             raise CloudApiException(
                 f"Failed to create or send credential: {e}", 500

--- a/app/routes/jsonld.py
+++ b/app/routes/jsonld.py
@@ -1,5 +1,10 @@
-from aiohttp import ClientResponseError
-from aries_cloudcontroller import Doc, SignRequest, SignResponse, VerifyRequest
+from aries_cloudcontroller import (
+    ApiException,
+    Doc,
+    SignRequest,
+    SignResponse,
+    VerifyRequest,
+)
 from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -70,10 +75,10 @@ async def sign_jsonld(
                     verkey=verkey,
                 )
             )
-    except ClientResponseError as e:
+    except ApiException as e:
         logger.warning(
-            "A ClientResponseError was caught while signing jsonld. The error message is: '{}'.",
-            e.message,
+            "An ApiException was caught while signing jsonld. The error message is: '{}'.",
+            e.reason,
         )
         raise CloudApiException("Failed to sign payload.") from e
 
@@ -120,10 +125,10 @@ async def verify_jsonld(
                     f"Failed to verify payload with error message: `{jsonld_verify_response.error}`.",
                     422,
                 )
-    except ClientResponseError as e:
+    except ApiException as e:
         logger.warning(
-            "A ClientResponseError was caught while verifying jsonld. The error message is: '{}'.",
-            e.message,
+            "An ApiException was caught while verifying jsonld. The error message is: '{}'.",
+            e.reason,
         )
         raise CloudApiException("Failed to verify payload.") from e
 

--- a/app/services/acapy_ledger.py
+++ b/app/services/acapy_ledger.py
@@ -1,8 +1,8 @@
 from typing import Optional, Tuple
 
-from aiohttp import ClientResponseError
 from aries_cloudcontroller import (
     AcaPyClient,
+    ApiException,
     CredentialDefinitionSendRequest,
     SchemaGetResult,
     TAAAccept,
@@ -80,9 +80,9 @@ async def accept_taa(
             "An unexpected error occurred while trying to accept TAA."
         ) from e
 
-    if isinstance(accept_taa_response, ClientResponseError):
+    if isinstance(accept_taa_response, ApiException):
         logger.warning(
-            "Failed to accept TAA with ClientResponseError. Response: `{}`.",
+            "Failed to accept TAA with ApiException. Response: `{}`.",
             accept_taa_response,
         )
         raise CloudApiException("Something went wrong. Could not accept TAA.", 400)
@@ -142,10 +142,10 @@ async def register_nym_on_ledger(
         )
         bound_logger.info("Successfully registered NYM on ledger.")
         return response
-    except ClientResponseError as e:
+    except ApiException as e:
         bound_logger.warning(
-            "A ClientResponseError was caught while registering NYM. The error message is: '{}'.",
-            e.message,
+            "An ApiException was caught while registering NYM. The error message is: '{}'.",
+            e.reason,
         )
         # if not nym_response.success:
         raise CloudApiException("Error registering NYM on ledger.") from e

--- a/app/services/onboarding/util/register_issuer_did.py
+++ b/app/services/onboarding/util/register_issuer_did.py
@@ -122,7 +122,7 @@ async def configure_endorsement(
 async def register_issuer_did(
     endorser_controller: AcaPyClient,
     issuer_controller: AcaPyClient,
-    name: str,
+    issuer_label: str,
     logger: Logger,
 ):
     logger.info("Creating DID for issuer")
@@ -132,7 +132,7 @@ async def register_issuer_did(
         endorser_controller,
         did=issuer_did.did,
         verkey=issuer_did.verkey,
-        alias=name,
+        alias=issuer_label,
     )
 
     logger.debug("Accepting TAA on behalf of issuer")

--- a/app/services/onboarding/util/set_endorser_metadata.py
+++ b/app/services/onboarding/util/set_endorser_metadata.py
@@ -3,8 +3,7 @@ import os
 from logging import Logger
 from typing import Callable
 
-from aiohttp import ClientResponseError
-from aries_cloudcontroller import AcaPyClient
+from aries_cloudcontroller import AcaPyClient, ApiException
 
 from app.exceptions.cloud_api_error import CloudApiException
 
@@ -23,7 +22,7 @@ async def set_endorser_role(
         )
         logger.debug("Successfully set endorser role.")
         await asyncio.sleep(DEFAULT_DELAY)  # Allow ACA-Py records to update
-    except ClientResponseError as e:
+    except ApiException as e:
         logger.error("Failed to set endorser role: {}.", e)
         raise CloudApiException(
             "Failed to set the endorser role in the endorser-issuer connection, "
@@ -43,7 +42,7 @@ async def set_author_role(
         )
         logger.debug("Successfully set author role.")
         await asyncio.sleep(DEFAULT_DELAY)  # Allow ACA-Py records to update
-    except ClientResponseError as e:
+    except ApiException as e:
         logger.error("Failed to set author role: {}.", e)
         raise CloudApiException(
             "Failed to set the author role in the issuer-endorser connection, "
@@ -66,7 +65,7 @@ async def set_endorser_info(
         )
         logger.debug("Successfully set endorser info.")
         await asyncio.sleep(DEFAULT_DELAY)  # Allow ACA-Py records to update
-    except ClientResponseError as e:
+    except ApiException as e:
         logger.error("Failed to set endorser info: {}.", e)
         raise CloudApiException(
             "Failed to set the endorser info in the issuer-endorser connection, "
@@ -113,7 +112,7 @@ async def assert_metadata_set(
             metadata_dict = connection_metadata.results
             if check_fn(metadata_dict):
                 return True
-        except ClientResponseError as e:
+        except ApiException as e:
             logger.error("Exception occurred when getting metadata: {}", e)
 
     raise SettingMetadataException(

--- a/app/services/onboarding/verifier.py
+++ b/app/services/onboarding/verifier.py
@@ -9,7 +9,7 @@ from shared.log_config import get_logger
 logger = get_logger(__name__)
 
 
-async def onboard_verifier(*, name: str, verifier_controller: AcaPyClient):
+async def onboard_verifier(*, verifier_controller: AcaPyClient, verifier_label: str):
     """Onboard the controller as verifier.
 
     The onboarding will take care of the following:
@@ -17,8 +17,9 @@ async def onboard_verifier(*, name: str, verifier_controller: AcaPyClient):
 
     Args:
         verifier_controller (AcaPyClient): authenticated ACA-Py client for verifier
+        verifier_label (str): alias for the verifier
     """
-    bound_logger = logger.bind(body={"name": name})
+    bound_logger = logger.bind(body={"verifier_label": verifier_label})
     bound_logger.info("Onboarding verifier")
 
     onboarding_result = {}
@@ -42,7 +43,7 @@ async def onboard_verifier(*, name: str, verifier_controller: AcaPyClient):
                 multi_use=True,
                 body=InvitationCreateRequest(
                     use_public_did=False,
-                    alias=f"Trust Registry {name}",
+                    alias=f"Trust Registry {verifier_label}",
                     handshake_protocols=["https://didcomm.org/didexchange/1.0"],
                 ),
             )

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -1,8 +1,8 @@
 from typing import Optional, Union
 
-from aiohttp import ClientResponseError
 from aries_cloudcontroller import (
     AcaPyClient,
+    ApiException,
     CredRevRecordResult,
     IssuerCredRevRecord,
     IssuerRevRegRecord,
@@ -308,10 +308,10 @@ async def revoke_credential(
                 publish=auto_publish_to_ledger,
             )
         )
-    except ClientResponseError as e:
+    except ApiException as e:
         bound_logger.info(
-            "A ClientResponseError was caught while revoking credential. The error message is: '{}'.",
-            e.message,
+            "An ApiException was caught while revoking credential. The error message is: '{}'.",
+            e.reason,
         )
         raise CloudApiException("Failed to revoke credential.", 400) from e
 
@@ -386,10 +386,10 @@ async def get_credential_definition_id_from_exchange_id(
                 cred_ex_id=credential_exchange_id
             )
         ).credential_definition_id
-    except ClientResponseError as err1:
+    except ApiException as err1:
         bound_logger.info(
-            "A ClientResponseError was caught while getting v1 record. The error message is: '{}'",
-            err1.message,
+            "An ApiException was caught while getting v1 record. The error message is: '{}'",
+            err1.reason,
         )
         try:
             bound_logger.info("Trying to get v2 records")
@@ -407,10 +407,10 @@ async def get_credential_definition_id_from_exchange_id(
                     rev_reg_parts[-1],
                 ]
             )
-        except ClientResponseError as err2:
+        except ApiException as err2:
             bound_logger.info(
-                "A ClientResponseError was caught while getting v2 record. The error message is: '{}'",
-                err2.message,
+                "An ApiException was caught while getting v2 record. The error message is: '{}'",
+                err2.reason,
             )
             return
         except Exception:

--- a/app/tests/admin/test_onboarding.py
+++ b/app/tests/admin/test_onboarding.py
@@ -76,7 +76,7 @@ async def test_onboard_issuer_public_did_exists(
     )
 
     onboard_result = await issuer.onboard_issuer(
-        name="issuer_name",
+        issuer_label="issuer_name",
         endorser_controller=endorser_controller,
         issuer_controller=mock_agent_controller,
         issuer_wallet_id="issuer_wallet_id",
@@ -154,7 +154,7 @@ async def test_onboard_issuer_no_public_did(
     )
 
     onboard_result = await issuer.onboard_issuer(
-        name="issuer_name",
+        issuer_label="issuer_name",
         endorser_controller=endorser_controller,
         issuer_controller=mock_agent_controller,
         issuer_wallet_id="issuer_wallet_id",
@@ -188,7 +188,7 @@ async def test_onboard_verifier_public_did_exists(mock_agent_controller: AcaPyCl
     )
 
     onboard_result = await verifier.onboard_verifier(
-        name="verifier_name", verifier_controller=mock_agent_controller
+        verifier_label="verifier_name", verifier_controller=mock_agent_controller
     )
 
     assert_that(onboard_result).has_did("did:sov:WgWxqztrNooG92RXvxSTWv")
@@ -214,7 +214,7 @@ async def test_onboard_verifier_no_public_did(mock_agent_controller: AcaPyClient
     )
 
     onboard_result = await verifier.onboard_verifier(
-        name="verifier_name", verifier_controller=mock_agent_controller
+        verifier_label="verifier_name", verifier_controller=mock_agent_controller
     )
 
     assert_that(onboard_result).has_did(did_key)
@@ -245,7 +245,7 @@ async def test_onboard_verifier_no_recipient_keys(mock_agent_controller: AcaPyCl
 
     with pytest.raises(CloudApiException):
         await verifier.onboard_verifier(
-            name="verifier_name", verifier_controller=mock_agent_controller
+            verifier_label="verifier_name", verifier_controller=mock_agent_controller
         )
 
 

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -456,6 +456,44 @@ async def test_get_tenants_by_group(tenant_admin_client: RichAsyncClient):
 
 
 @pytest.mark.anyio
+async def test_get_tenants_by_wallet_name(tenant_admin_client: RichAsyncClient):
+    wallet_name = uuid4().hex
+    group_id = "backstreetboys"
+    response = await tenant_admin_client.post(
+        TENANTS_BASE_PATH,
+        json={
+            "image_url": "https://image.ca",
+            "wallet_label": "abc",
+            "wallet_name": wallet_name,
+            "group_id": group_id,
+        },
+    )
+
+    assert response.status_code == 200
+    created_tenant = response.json()
+    wallet_id = created_tenant["wallet_id"]
+
+    response = await tenant_admin_client.get(
+        f"{TENANTS_BASE_PATH}?wallet_name={wallet_name}"
+    )
+    assert response.status_code == 200
+    tenants = response.json()
+    assert len(tenants) == 1
+
+    # Make sure created tenant is returned
+    assert_that(tenants).extracting("wallet_id").contains(wallet_id)
+    assert_that(tenants).extracting("group_id").contains(group_id)
+
+    response = await tenant_admin_client.get(
+        f"{TENANTS_BASE_PATH}?wallet_name=spicegirls"
+    )
+    assert response.status_code == 200
+    tenants = response.json()
+    assert len(tenants) == 0
+    assert tenants == []
+
+
+@pytest.mark.anyio
 async def test_delete_tenant(
     tenant_admin_client: RichAsyncClient, tenant_admin_acapy_client: AcaPyClient
 ):

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -67,7 +67,7 @@ async def test_create_tenant_member_wo_wallet_name(
     wallet_name = wallet.settings["wallet.name"]
     assert tenant["wallet_id"] == wallet.wallet_id
     assert tenant["group_id"] == group_id
-    assert tenant["tenant_name"] == name
+    assert tenant["wallet_label"] == name
     assert tenant["created_at"] == wallet.created_at
     assert tenant["updated_at"] == wallet.updated_at
     assert tenant["wallet_name"] == wallet_name
@@ -102,7 +102,7 @@ async def test_create_tenant_member_w_wallet_name(
     wallet_name = wallet.settings["wallet.name"]
     assert tenant["wallet_id"] == wallet.wallet_id
     assert tenant["group_id"] == group_id
-    assert tenant["tenant_name"] == name
+    assert tenant["wallet_label"] == name
     assert tenant["created_at"] == wallet.created_at
     assert tenant["updated_at"] == wallet.updated_at
     assert tenant["wallet_name"] == wallet_name
@@ -136,7 +136,7 @@ async def test_create_tenant_member_w_wallet_name(
 
     assert tenant["wallet_id"] == wallet.wallet_id
     assert tenant["group_id"] == group_id
-    assert tenant["tenant_name"] == name
+    assert tenant["wallet_label"] == name
     assert tenant["created_at"] == wallet.created_at
     assert tenant["updated_at"] == wallet.updated_at
     assert tenant["wallet_name"] == wallet_name
@@ -202,7 +202,7 @@ async def test_create_tenant_issuer(
         )
 
     # Actor
-    assert_that(actor).has_name(tenant["tenant_name"])
+    assert_that(actor).has_name(tenant["wallet_label"])
     assert_that(actor).has_did(f"did:sov:{public_did.did}")
     assert_that(actor).has_roles(["issuer"])
 
@@ -211,7 +211,7 @@ async def test_create_tenant_issuer(
 
     # Tenant
     assert_that(tenant).has_wallet_id(wallet.wallet_id)
-    assert_that(tenant).has_tenant_name(name)
+    assert_that(tenant).has_wallet_label(name)
     assert_that(tenant).has_created_at(wallet.created_at)
     assert_that(tenant).has_updated_at(wallet.updated_at)
     assert_that(wallet.settings["wallet.name"]).is_length(32)
@@ -270,13 +270,13 @@ async def test_create_tenant_verifier(
     # Connection invitation
     assert_that(connection).has_state("invitation")
 
-    assert_that(actor).has_name(tenant["tenant_name"])
+    assert_that(actor).has_name(tenant["wallet_label"])
     assert_that(actor).has_did(ed25519_verkey_to_did_key(connection.invitation_key))
     assert_that(actor).has_roles(["verifier"])
 
     # Tenant
     assert_that(tenant).has_wallet_id(wallet.wallet_id)
-    assert_that(tenant).has_tenant_name(name)
+    assert_that(tenant).has_wallet_label(name)
     assert_that(tenant).has_created_at(wallet.created_at)
     assert_that(tenant).has_updated_at(wallet.updated_at)
     assert_that(wallet.settings["wallet.name"]).is_length(32)
@@ -329,7 +329,7 @@ async def test_update_tenant_verifier_to_issuer(
     # Tenant
     assert_that(verifier_tenant).has_wallet_id(wallet.wallet_id)
     assert_that(verifier_tenant).has_image_url(image_url)
-    assert_that(verifier_tenant).has_tenant_name(name)
+    assert_that(verifier_tenant).has_wallet_label(name)
     assert_that(verifier_tenant).has_created_at(wallet.created_at)
     assert_that(verifier_tenant).has_updated_at(wallet.updated_at)
 
@@ -348,7 +348,7 @@ async def test_update_tenant_verifier_to_issuer(
     new_tenant = response.json()
     assert_that(new_tenant).has_wallet_id(wallet.wallet_id)
     assert_that(new_tenant).has_image_url(new_image_url)
-    assert_that(new_tenant).has_tenant_name(new_name)
+    assert_that(new_tenant).has_wallet_label(new_name)
     assert_that(new_tenant).has_created_at(wallet.created_at)
 
     new_actor = await trust_registry.fetch_actor_by_id(verifier_wallet_id)

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -503,6 +503,7 @@ async def test_delete_tenant(
         json={
             "image_url": "https://image.ca",
             "wallet_label": wallet_label,
+            "roles": ["verifier"],
         },
     )
 

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -85,14 +85,16 @@ async def test_create_tenant_member_w_wallet_name(
     wallet_label = uuid4().hex
     wallet_name = "TestWalletName"
     group_id = "TestGroup"
+    create_tenant_payload = {
+        "image_url": "https://image.ca",
+        "wallet_label": wallet_label,
+        "group_id": group_id,
+        "wallet_name": wallet_name,
+    }
+
     response = await tenant_admin_client.post(
         TENANTS_BASE_PATH,
-        json={
-            "image_url": "https://image.ca",
-            "wallet_label": wallet_label,
-            "group_id": group_id,
-            "wallet_name": wallet_name,
-        },
+        json=create_tenant_payload,
     )
 
     assert response.status_code == 200
@@ -110,6 +112,14 @@ async def test_create_tenant_member_w_wallet_name(
     assert tenant["updated_at"] == wallet.updated_at
     assert tenant["wallet_name"] == wallet_name
     assert wallet.settings["wallet.name"] == wallet_name
+
+    with pytest.raises(HTTPException) as http_error:
+        await tenant_admin_client.post(
+            TENANTS_BASE_PATH,
+            json=create_tenant_payload,
+        )
+    assert http_error.value.status_code == 409
+    assert "already exists" in http_error.value.detail
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -46,7 +46,7 @@ async def test_get_wallet_auth_token(tenant_admin_client: RichAsyncClient):
 
 
 @pytest.mark.anyio
-async def test_create_tenant_member(
+async def test_create_tenant_member_wo_wallet_name(
     tenant_admin_client: RichAsyncClient, tenant_admin_acapy_client: AcaPyClient
 ):
     name = uuid4().hex
@@ -64,12 +64,83 @@ async def test_create_tenant_member(
         wallet_id=tenant["wallet_id"]
     )
 
+    wallet_name = wallet.settings["wallet.name"]
     assert tenant["wallet_id"] == wallet.wallet_id
     assert tenant["group_id"] == group_id
     assert tenant["tenant_name"] == name
     assert tenant["created_at"] == wallet.created_at
     assert tenant["updated_at"] == wallet.updated_at
-    assert_that(wallet.settings["wallet.name"]).is_length(32)
+    assert tenant["wallet_name"] == wallet_name
+    assert_that(wallet_name).is_length(32)
+
+
+@pytest.mark.anyio
+async def test_create_tenant_member_w_wallet_name(
+    tenant_admin_client: RichAsyncClient, tenant_admin_acapy_client: AcaPyClient
+):
+    name = uuid4().hex
+    wallet_name = "TestWalletName"
+    group_id = "TestGroup"
+    response = await tenant_admin_client.post(
+        TENANTS_BASE_PATH,
+        json={
+            "image_url": "https://image.ca",
+            "name": name,
+            "group_id": group_id,
+            "wallet_name": wallet_name,
+        },
+    )
+
+    assert response.status_code == 200
+
+    tenant = response.json()
+
+    wallet = await tenant_admin_acapy_client.multitenancy.get_wallet(
+        wallet_id=tenant["wallet_id"]
+    )
+
+    wallet_name = wallet.settings["wallet.name"]
+    assert tenant["wallet_id"] == wallet.wallet_id
+    assert tenant["group_id"] == group_id
+    assert tenant["tenant_name"] == name
+    assert tenant["created_at"] == wallet.created_at
+    assert tenant["updated_at"] == wallet.updated_at
+    assert tenant["wallet_name"] == wallet_name
+    assert_that(wallet_name).is_length(32)
+
+
+@pytest.mark.anyio
+async def test_create_tenant_member_w_wallet_name(
+    tenant_admin_client: RichAsyncClient, tenant_admin_acapy_client: AcaPyClient
+):
+    name = uuid4().hex
+    wallet_name = "TestWalletName"
+    group_id = "TestGroup"
+    response = await tenant_admin_client.post(
+        TENANTS_BASE_PATH,
+        json={
+            "image_url": "https://image.ca",
+            "name": name,
+            "group_id": group_id,
+            "wallet_name": wallet_name,
+        },
+    )
+
+    assert response.status_code == 200
+
+    tenant = response.json()
+
+    wallet = await tenant_admin_acapy_client.multitenancy.get_wallet(
+        wallet_id=tenant["wallet_id"]
+    )
+
+    assert tenant["wallet_id"] == wallet.wallet_id
+    assert tenant["group_id"] == group_id
+    assert tenant["tenant_name"] == name
+    assert tenant["created_at"] == wallet.created_at
+    assert tenant["updated_at"] == wallet.updated_at
+    assert tenant["wallet_name"] == wallet_name
+    assert wallet.settings["wallet.name"] == wallet_name
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -24,7 +24,6 @@ async def test_get_wallet_auth_token(tenant_admin_client: RichAsyncClient):
         json={
             "image_url": "https://image.ca",
             "wallet_label": uuid4().hex,
-            "roles": ["verifier"],
             "group_id": "TestGroup",
         },
     )
@@ -387,7 +386,6 @@ async def test_get_tenants(tenant_admin_client: RichAsyncClient):
         json={
             "image_url": "https://image.ca",
             "wallet_label": uuid4().hex,
-            "roles": ["verifier"],
         },
     )
 
@@ -407,7 +405,6 @@ async def test_get_tenants(tenant_admin_client: RichAsyncClient):
         json={
             "image_url": "https://image.ca",
             "wallet_label": uuid4().hex,
-            "roles": ["verifier"],
             "group_id": "ac/dc",
         },
     )
@@ -434,7 +431,6 @@ async def test_get_tenants_by_group(tenant_admin_client: RichAsyncClient):
         json={
             "image_url": "https://image.ca",
             "wallet_label": wallet_label,
-            "roles": ["verifier"],
             "group_id": group_id,
         },
     )
@@ -469,7 +465,6 @@ async def test_delete_tenant(
         json={
             "image_url": "https://image.ca",
             "wallet_label": wallet_label,
-            "roles": ["verifier"],
         },
     )
 

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -99,41 +99,6 @@ async def test_create_tenant_member_w_wallet_name(
         wallet_id=tenant["wallet_id"]
     )
 
-    wallet_name = wallet.settings["wallet.name"]
-    assert tenant["wallet_id"] == wallet.wallet_id
-    assert tenant["group_id"] == group_id
-    assert tenant["wallet_label"] == name
-    assert tenant["created_at"] == wallet.created_at
-    assert tenant["updated_at"] == wallet.updated_at
-    assert tenant["wallet_name"] == wallet_name
-    assert_that(wallet_name).is_length(32)
-
-
-@pytest.mark.anyio
-async def test_create_tenant_member_w_wallet_name(
-    tenant_admin_client: RichAsyncClient, tenant_admin_acapy_client: AcaPyClient
-):
-    name = uuid4().hex
-    wallet_name = "TestWalletName"
-    group_id = "TestGroup"
-    response = await tenant_admin_client.post(
-        TENANTS_BASE_PATH,
-        json={
-            "image_url": "https://image.ca",
-            "name": name,
-            "group_id": group_id,
-            "wallet_name": wallet_name,
-        },
-    )
-
-    assert response.status_code == 200
-
-    tenant = response.json()
-
-    wallet = await tenant_admin_acapy_client.multitenancy.get_wallet(
-        wallet_id=tenant["wallet_id"]
-    )
-
     assert tenant["wallet_id"] == wallet.wallet_id
     assert tenant["group_id"] == group_id
     assert tenant["wallet_label"] == name

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -393,11 +393,9 @@ async def test_get_tenants(tenant_admin_client: RichAsyncClient):
 
     assert response.status_code == 200
     created_tenant = response.json()
-    first_wallet_id_id = created_tenant["wallet_id"]
+    first_wallet_id = created_tenant["wallet_id"]
 
-    response = await tenant_admin_client.get(
-        f"{TENANTS_BASE_PATH}/{first_wallet_id_id}"
-    )
+    response = await tenant_admin_client.get(f"{TENANTS_BASE_PATH}/{first_wallet_id}")
 
     assert response.status_code == 200
     retrieved_tenant = response.json()

--- a/app/tests/e2e/test_trust_registry.py
+++ b/app/tests/e2e/test_trust_registry.py
@@ -68,7 +68,7 @@ async def test_get_actors(
     assert actor_did == f"did:sov:{did_result.result.did}"
 
     actor_name = actor["name"]
-    assert actor_name == faber_issuer.tenant_name
+    assert actor_name == faber_issuer.wallet_label
     assert_that(actor).contains("id", "name", "roles", "did", "didcomm_invitation")
 
     actors_by_did = await unauthed_client.get(
@@ -80,7 +80,7 @@ async def test_get_actors(
     )
 
     actors_by_name = await unauthed_client.get(
-        f"{CLOUDAPI_TRUST_REGISTRY_PATH}/actors?actor_name={faber_issuer.tenant_name}"
+        f"{CLOUDAPI_TRUST_REGISTRY_PATH}/actors?actor_name={faber_issuer.wallet_label}"
     )
     assert actors_by_name.status_code == 200
     assert_that(actors_by_name.json()[0]).contains(

--- a/app/tests/services/test_acapy_ledger.py
+++ b/app/tests/services/test_acapy_ledger.py
@@ -11,7 +11,7 @@ from aries_cloudcontroller import (
 )
 from assertpy import assert_that
 from fastapi import HTTPException
-from mockito import mock, verify, when
+from mockito import verify, when
 
 from app.exceptions.cloud_api_error import CloudApiException
 from app.services.acapy_ledger import (

--- a/app/tests/services/test_acapy_ledger.py
+++ b/app/tests/services/test_acapy_ledger.py
@@ -1,7 +1,7 @@
 import pytest
-from aiohttp import ClientResponseError
 from aries_cloudcontroller import (
     AcaPyClient,
+    ApiException,
     ModelSchema,
     SchemaGetResult,
     TAAAccept,
@@ -39,7 +39,7 @@ async def test_error_on_get_taa(mock_agent_controller: AcaPyClient):
 async def test_error_on_accept_taa(mock_agent_controller: AcaPyClient):
     when(mock_agent_controller.ledger).accept_taa(
         body=TAAAccept(mechanism="data", text=None, version=None)
-    ).thenReturn(to_async(ClientResponseError(mock(), mock())))
+    ).thenReturn(to_async(ApiException()))
 
     with pytest.raises(CloudApiException) as exc:
         await accept_taa(

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -1,7 +1,7 @@
 import pytest
-from aiohttp import ClientResponseError
 from aries_cloudcontroller import (
     AcaPyClient,
+    ApiException,
     CredRevRecordResult,
     IssuerCredRevRecord,
     IssuerRevRegRecord,
@@ -320,7 +320,7 @@ async def test_revoke_credential(mock_agent_controller: AcaPyClient):
         rev_reg_id=revocation_registry_id,
         conn_id=None,
         create_transaction_for_endorser=False,
-    ).thenRaise(ClientResponseError({}, ("x", "x")))
+    ).thenRaise(ApiException())
 
     when(rg).endorser_revoke().thenReturn(to_async(None))
 
@@ -362,7 +362,7 @@ async def test_get_credential_definition_id_from_exchange_id(
     # Success v2
     when(mock_agent_controller.issue_credential_v1_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ClientResponseError({}, ("x", "x")))
+    ).thenRaise(ApiException())
     when(mock_agent_controller.issue_credential_v2_0).get_record(
         cred_ex_id=cred_ex_id
     ).thenReturn(
@@ -386,10 +386,10 @@ async def test_get_credential_definition_id_from_exchange_id(
     # Not found
     when(mock_agent_controller.issue_credential_v1_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ClientResponseError({}, ("y", "y")))
+    ).thenRaise(ApiException())
     when(mock_agent_controller.issue_credential_v2_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ClientResponseError({}, ("z", "z")))
+    ).thenRaise(ApiException())
 
     get_credential_definition_id_from_exchange_id_result = (
         await rg.get_credential_definition_id_from_exchange_id(

--- a/app/tests/util/tenants.py
+++ b/app/tests/util/tenants.py
@@ -19,14 +19,16 @@ async def post_tenant_request(
 
 async def create_issuer_tenant(admin_client: RichAsyncClient, name: str):
     request = CreateTenantRequest(
-        name=append_random_string(name), roles=["issuer"], group_id="IssuerGroup"
+        wallet_label=append_random_string(name),
+        roles=["issuer"],
+        group_id="IssuerGroup",
     )
     return await post_tenant_request(admin_client, request)
 
 
 async def create_verifier_tenant(admin_client: RichAsyncClient, name: str):
     request = CreateTenantRequest(
-        name=append_random_string(name),
+        wallet_label=append_random_string(name),
         roles=["verifier"],
         group_id="VerifierGroup",
     )
@@ -36,7 +38,7 @@ async def create_verifier_tenant(admin_client: RichAsyncClient, name: str):
 async def create_tenant(admin_client: RichAsyncClient, name: str):
     request = CreateTenantRequest(
         image_url="https://aries.ca/images/sample.png",
-        name=append_random_string(name),
+        wallet_label=append_random_string(name),
         group_id="TenantGroup",
     )
     return await post_tenant_request(admin_client, request)

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -7,13 +7,18 @@ from app.models.tenants import Tenant
 
 def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
     label: str = wallet_record.settings["default_label"]
+    wallet_name: str = wallet_record.settings["wallet_name"]
     image_url: Optional[str] = wallet_record.settings.get("image_url")
+    group_id: Optional[str] = (
+        wallet_record.group_id if hasattr(wallet_record, "group_id") else None
+    )
 
     return Tenant(
         wallet_id=wallet_record.wallet_id,
         tenant_name=label,
-        image_url=image_url,
+        wallet_name=wallet_name,
         created_at=wallet_record.created_at,
         updated_at=wallet_record.updated_at,
-        group_id=wallet_record.group_id if hasattr(wallet_record, "group_id") else None,
+        image_url=image_url,
+        group_id=group_id,
     )

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -7,7 +7,7 @@ from app.models.tenants import Tenant
 
 def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
     label: str = wallet_record.settings["default_label"]
-    wallet_name: str = wallet_record.settings["wallet_name"]
+    wallet_name: str = wallet_record.settings["wallet.name"]
     image_url: Optional[str] = wallet_record.settings.get("image_url")
     group_id: Optional[str] = (
         wallet_record.group_id if hasattr(wallet_record, "group_id") else None

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -15,7 +15,7 @@ def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
 
     return Tenant(
         wallet_id=wallet_record.wallet_id,
-        tenant_name=label,
+        wallet_label=label,
         wallet_name=wallet_name,
         created_at=wallet_record.created_at,
         updated_at=wallet_record.updated_at,

--- a/docs/Governance as Code.md
+++ b/docs/Governance as Code.md
@@ -45,7 +45,7 @@ An example of a successful response to create a new Issuer Tenant:
 {
   "access_token": "tenant.eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ3YWxsZXRfaWQiOiIzNTM3NmU0Yy1lYTI5LTQ1MDAtYTBhZC0xMGY3NTBkZGExM2UifQ.DEoMAD4AhLF-gHfr8JdqiRnZl31RltFIWk-al30F9Ak",
   "wallet_id": "35376e4c-ea29-4500-a0ad-10f750dda13e",
-  "tenant_name": "Issuer",
+  "wallet_label": "Issuer",
   "image_url": "https://www.abc.xyz/assets/images/logo/logo.png",
   "created_at": "2022-06-07T07:53:12.584044Z",
   "updated_at": "2022-06-07T07:53:12.584044Z"
@@ -74,7 +74,7 @@ Tenants, functioning as custodial wallets, are established within the Trust Ecos
    {
      "access_token": "tenant.eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ3YWxsZXRfaWQiOiIxOTkwYzkzNS1iNTFlLTQ0NjMtODQ0Ny1hMGFmMzFlNDRlNDIifQ.SqmG9--tCLgJ1FV_31uc4yVOchX_t7oc7jHyVKq8W3w",
      "wallet_id": "1990c935-b51e-4463-8447-a0af31e44e42",
-     "tenant_name": "Verifier",
+     "wallet_label": "Verifier",
      "image_url": "https://www.abc.xyz/assets/images/logo/logo.png",
      "created_at": "2022-06-07T07:56:45.045014Z",
      "updated_at": "2022-06-07T07:56:45.045014Z"
@@ -102,7 +102,7 @@ Similar to Verifiers, Tenants for Holders are created within the Trust Ecosystem
    {
      "access_token": "tenant.eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ3YWxsZXRfaWQiOiJjZmFmMjc2ZS1jZTc2LTQxMTYtYmUwZC03YTU0OWQ2NDgwNWIifQ.eQNCRQvKuNSlelUNZuDGpUPK7Dtvgo3uO4gDorZd2I4",
      "wallet_id": "cfaf276e-ce76-4116-be0d-7a549d64805b",
-     "tenant_name": "Holder",
+     "wallet_label": "Holder",
      "image_url": "https://www.abc.xyz/assets/images/logo/logo.png",
      "created_at": "2022-06-07T07:58:22.043147Z",
      "updated_at": "2022-06-07T07:58:22.043147Z"

--- a/endorser/requirements.txt
+++ b/endorser/requirements.txt
@@ -1,4 +1,4 @@
-aries-cloudcontroller==0.9.0.post0
+aries-cloudcontroller==0.9.0.post1
 fastapi_websocket_pubsub~=0.3.8
 httpx~=0.25.0
 loguru~=0.7.0

--- a/webhooks/requirements.txt
+++ b/webhooks/requirements.txt
@@ -1,5 +1,5 @@
 aioredis~=2.0.1
-aries-cloudcontroller==0.9.0.post0
+aries-cloudcontroller==0.9.0.post1
 dependency-injector~=4.41.0
 fastapi~=0.104.0
 fastapi_websocket_pubsub~=0.3.8


### PR DESCRIPTION
:sparkles: wallet_name can now optionally be included in create tenant request, and used to fetch wallet

:art: adds descriptions and better examples for some fields in create and update tenant requests. Renamed tenant "name" to `wallet_label`, and clarify in description that this name is used as alias in connection records
- raise 409 if wallet_name already exist
- wrote test to assert
- and to assert fetch by wallet name works
- fixed exception handling re new ApiException raised in cloudcontroller, instead of old ClientResponeError
- note: bug in cloudcontroller or our group plugin seems to still return all wallets when fetching wallet_name. No matter. We postprocess results to filter by wallet_name