### PR TITLE
:white_check_mark: Fix creating connections with `use_public_did`

### DIFF
--- a/app/models/connections.py
+++ b/app/models/connections.py
@@ -12,5 +12,4 @@ class CreateInvitation(BaseModel):
 
 class AcceptInvitation(BaseModel):
     alias: Optional[str] = None
-    use_existing_connection: Optional[bool] = None
     invitation: ReceiveInvitationRequest

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -50,7 +50,7 @@ async def accept_invitation(
 
     Parameters:
     ------------
-    invitation: ReceiveInvitationRequest
+    invitation: AcceptInvitation
         the invitation object obtained from create_invitation.
     """
     bound_logger = logger.bind(body=body)

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -1,5 +1,6 @@
 from aries_cloudcontroller import (
     AcaPyClient,
+    IndyPresSpec,
     V10PresentationCreateRequestRequest,
     V10PresentationProblemReportRequest,
     V10PresentationSendRequest,

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -24,8 +24,8 @@ BASE_PATH = router.prefix
         ("alias", True, True),
     ],
 )
-async def test_create_invitation(
-    bob_member_client: RichAsyncClient,
+async def test_create_invitation_no_public_did(
+    bob_member_client: RichAsyncClient,  # bob has no public did
     alias: Optional[str],
     multi_use: Optional[bool],
     use_public_did: Optional[bool],
@@ -58,6 +58,41 @@ async def test_create_invitation(
             "@id", "@type", "recipientKeys", "serviceEndpoint"
         )
         assert_that(invitation["invitation_url"]).matches(r"^https?://")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "alias,multi_use,use_public_did",
+    [
+        (None, None, None),
+        ("alias", False, False),
+        ("alias", True, False),
+        ("alias", False, True),
+        ("alias", True, True),
+    ],
+)
+async def test_create_invitation_has_public_did(
+    faber_client: RichAsyncClient,  # issuer has public did
+    alias: Optional[str],
+    multi_use: Optional[bool],
+    use_public_did: Optional[bool],
+):
+    invite_json = CreateInvitation(
+        alias=alias, multi_use=multi_use, use_public_did=use_public_did
+    ).model_dump()
+
+    response = await faber_client.post(
+        f"{BASE_PATH}/create-invitation", json=invite_json
+    )
+    assert response.status_code == 200
+
+    invitation = response.json()
+
+    assert_that(invitation["connection_id"]).is_not_empty()
+    assert_that(invitation["invitation"]).is_instance_of(dict).contains(
+        "@id", "@type", "recipientKeys", "serviceEndpoint"
+    )
+    assert_that(invitation["invitation_url"]).matches(r"^https?://")
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -113,7 +113,7 @@ async def test_accept_invitation(
 async def test_get_connections(
     bob_member_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
-    bob_and_alice_connection: BobAliceConnect,
+    bob_and_alice_connection: BobAliceConnect,  # pylint: disable=unused-argument
 ):
     alice_connections = (await alice_member_client.get(f"{BASE_PATH}")).json()
     bob_connections = (await bob_member_client.get(f"{BASE_PATH}")).json()

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -239,7 +239,7 @@ async def test_bob_and_alice_connect(
 @pytest.mark.anyio
 async def test_accept_use_public_did(
     faber_client: RichAsyncClient,  # issuer has public did
-    bob_member_client: RichAsyncClient,
+    meld_co_client: RichAsyncClient,  # also has public did
     alias: Optional[str],
     multi_use: Optional[bool],
     use_public_did: Optional[bool],
@@ -267,14 +267,14 @@ async def test_accept_use_public_did(
         invitation=invitation["invitation"],
     ).model_dump()
 
-    accept_response = await bob_member_client.post(
+    accept_response = await meld_co_client.post(
         f"{BASE_PATH}/accept-invitation",
         json=accept_invite_json,
     )
     connection_record = accept_response.json()
 
     assert await check_webhook_state(
-        client=bob_member_client,
+        client=meld_co_client,
         topic="connections",
         filter_map={
             "state": "completed",

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -62,41 +62,6 @@ async def test_create_invitation_no_public_did(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "alias,multi_use,use_public_did",
-    [
-        (None, None, None),
-        ("alias", False, False),
-        ("alias", True, False),
-        ("alias", False, True),
-        ("alias", True, True),
-    ],
-)
-async def test_create_invitation_has_public_did(
-    faber_client: RichAsyncClient,  # issuer has public did
-    alias: Optional[str],
-    multi_use: Optional[bool],
-    use_public_did: Optional[bool],
-):
-    invite_json = CreateInvitation(
-        alias=alias, multi_use=multi_use, use_public_did=use_public_did
-    ).model_dump()
-
-    response = await faber_client.post(
-        f"{BASE_PATH}/create-invitation", json=invite_json
-    )
-    assert response.status_code == 200
-
-    invitation = response.json()
-
-    assert_that(invitation["connection_id"]).is_not_empty()
-    assert_that(invitation["invitation"]).is_instance_of(dict).contains(
-        "@id", "@type", "recipientKeys", "serviceEndpoint"
-    )
-    assert_that(invitation["invitation_url"]).matches(r"^https?://")
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize(
     "alias,use_existing_connection",
     [
         (None, None),

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -61,26 +61,16 @@ async def test_create_invitation_no_public_did(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize(
-    "alias,use_existing_connection",
-    [
-        (None, None),
-        ("alias", False),
-        ("alias", True),
-    ],
-)
 async def test_accept_invitation(
     bob_member_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
-    alias: Optional[str],
-    use_existing_connection: Optional[bool],
 ):
+    alias = "test_alias"
     invitation_response = await bob_member_client.post(f"{BASE_PATH}/create-invitation")
     invitation = invitation_response.json()
 
     accept_invite_json = AcceptInvitation(
         alias=alias,
-        use_existing_connection=use_existing_connection,
         invitation=invitation["invitation"],
     ).model_dump()
 
@@ -103,10 +93,7 @@ async def test_accept_invitation(
         "connection_id", "state", "created_at", "updated_at", "invitation_key"
     )
     assert_that(connection_record).has_state("request-sent")
-
-    if alias:
-        assert_that(connection_record).contains("alias")
-        assert_that(connection_record["alias"]).is_equal_to(alias)
+    assert_that(connection_record["alias"]).is_equal_to(alias)
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -219,7 +219,6 @@ async def test_accept_use_public_did(
     assert response.status_code == 200
 
     invitation = response.json()
-    print("HIER ===> ", invitation["invitation"])
     assert_that(invitation["connection_id"]).is_not_empty()
     assert_that(invitation["invitation"]).is_instance_of(dict).contains(
         "@id", "@type", "recipientKeys", "serviceEndpoint"
@@ -240,6 +239,66 @@ async def test_accept_use_public_did(
 
     assert await check_webhook_state(
         client=meld_co_client,
+        topic="connections",
+        filter_map={
+            "state": "completed",
+            "connection_id": connection_record["connection_id"],
+        },
+    )
+
+    assert_that(connection_record).contains(
+        "connection_id", "state", "created_at", "updated_at", "invitation_key"
+    )
+    assert_that(connection_record).has_state("request-sent")
+
+
+@pytest.mark.parametrize(
+    "alias,multi_use,use_public_did",
+    [
+        ("alias", False, False),
+        ("alias", False, True),
+        ("alias", True, False),
+        ("alias", True, True),
+    ],
+)
+@pytest.mark.anyio
+async def test_accept_use_public_did_between_issuer_and_holder(
+    faber_client: RichAsyncClient,  # issuer has public did
+    alice_member_client: RichAsyncClient,  # no public did
+    alias: Optional[str],
+    multi_use: Optional[bool],
+    use_public_did: Optional[bool],
+):
+    invite_json = CreateInvitation(
+        alias=alias, multi_use=multi_use, use_public_did=use_public_did
+    ).model_dump()
+
+    response = await faber_client.post(
+        f"{BASE_PATH}/create-invitation", json=invite_json
+    )
+    assert response.status_code == 200
+
+    invitation = response.json()
+    assert_that(invitation["connection_id"]).is_not_empty()
+    assert_that(invitation["invitation"]).is_instance_of(dict).contains(
+        "@id", "@type", "recipientKeys", "serviceEndpoint"
+    )
+    assert_that(invitation["invitation_url"]).matches(r"^https?://")
+
+    accept_invite_json = AcceptInvitation(
+        alias=alias,
+        use_existing_connection=False,
+        invitation=invitation["invitation"],
+    ).model_dump()
+
+    accept_response = await alice_member_client.post(
+        f"{BASE_PATH}/accept-invitation",
+        json=accept_invite_json,
+    )
+    connection_record = accept_response.json()
+
+    assert await check_webhook_state(
+        client=alice_member_client,
         topic="connections",
         filter_map={
             "state": "completed",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -206,6 +206,19 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/agents/Dockerfile.author.agent
+    ## To run a forked version of the agent use commented out code below
+    #   context: https://github.com/didx-xyz/aries-cloudagent-python.git#add-logging-for-interop-debug
+    #   dockerfile: docker/Dockerfile
+    # user: root
+    # entrypoint:
+    #   - sh
+    #   - -c
+    #   - |
+    #     pip3 install --no-cache-dir acapy-wallet-groups-plugin==0.4.2
+    #     aca-py start \
+    #       -it http "0.0.0.0" "3020" \
+    #       -e http://governance-multitenant-agent:3020 \
+    #       --wallet-type askar --auto-promote-author-did --plugin acapy_wallet_groups_plugin
     env_file:
       - environments/governance-multitenant/aca-py-agent.default.env
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -206,7 +206,7 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/agents/Dockerfile.author.agent
-    ## To run a forked version of the agent use commented out code below
+    # # To run a forked version of the agent use commented out code below
     #   context: https://github.com/didx-xyz/aries-cloudagent-python.git#add-logging-for-interop-debug
     #   dockerfile: docker/Dockerfile
     # user: root
@@ -214,7 +214,7 @@ services:
     #   - sh
     #   - -c
     #   - |
-    #     pip3 install --no-cache-dir acapy-wallet-groups-plugin==0.4.2
+    #     pip3 install --no-cache-dir acapy-wallet-groups-plugin==0.5.4
     #     aca-py start \
     #       -it http "0.0.0.0" "3020" \
     #       -e http://governance-multitenant-agent:3020 \

--- a/environments/governance-ga/aca-py-agent.default.env
+++ b/environments/governance-ga/aca-py-agent.default.env
@@ -30,9 +30,9 @@ ACAPY_ADMIN_API_KEY=adminApiKey
 # Tails server
 ACAPY_TAILS_SERVER_BASE_URL=http://tails-server:6543
 
-ACAPY_LABEL=Alice
-ACAPY_WALLET_NAME=Alice_Name
-ACAPY_WALLET_KEY=alice_key
+ACAPY_LABEL=Governance
+ACAPY_WALLET_NAME=Governance_Wallet
+ACAPY_WALLET_KEY=Governance_Wallet_Key
 ACAPY_WALLET_TYPE=askar
 ACAPY_WALLET_STORAGE_TYPE=postgres_storage
 ACAPY_WALLET_STORAGE_CONFIG={"url":"governance-ga-wallets-db:5432"}

--- a/environments/governance-multitenant/aca-py-agent.default.env
+++ b/environments/governance-multitenant/aca-py-agent.default.env
@@ -30,9 +30,9 @@ ACAPY_ADMIN_API_KEY=adminApiKey
 # Tails server
 ACAPY_TAILS_SERVER_BASE_URL=http://tails-server:6543
 
-ACAPY_LABEL=Alice
-ACAPY_WALLET_NAME=Alice_Name
-ACAPY_WALLET_KEY=alice_key
+ACAPY_LABEL=Multitenant
+ACAPY_WALLET_NAME=Multitenant_Wallet
+ACAPY_WALLET_KEY=Multitenant_Wallet_Key
 ACAPY_WALLET_TYPE=askar
 ACAPY_WALLET_STORAGE_TYPE=postgres_storage
 ACAPY_WALLET_STORAGE_CONFIG={"url":"governance-multitenant-wallets-db:5432"}

--- a/environments/governance-multitenant/aca-py-agent.default.env
+++ b/environments/governance-multitenant/aca-py-agent.default.env
@@ -56,8 +56,8 @@ AGENT_ENDPOINT=http://governance-multitenant-agent:3020
 # ## Unless you know exactly what you are doing
 # ## Changes will probably break CloudAPI
 # Optional Helper Configurations - See https://github.com/hyperledger/aries-cloudagent-python/blob/main/aries_cloudagent/config/argparse.py
-ACAPY_AUTO_ACCEPT_INVITES=false
-ACAPY_AUTO_ACCEPT_REQUESTS=false
+ACAPY_AUTO_ACCEPT_INVITES=true
+ACAPY_AUTO_ACCEPT_REQUESTS=true
 ACAPY_AUTO_PING_CONNECTION=true
 ACAPY_AUTO_RESPOND_MESSAGES=false
 ACAPY_AUTO_RESPOND_CREDENTIAL_PROPOSAL=false


### PR DESCRIPTION
Resolves #518

Identified bug in ACA-Py ([aries-cloudagent-python/#2649](https://github.com/hyperledger/aries-cloudagent-python/issues/2649)), where `auto_accept=True`, used in receiving an invitation, does not override the default environment config of auto_accept_invite/requests = false. Because we use auto_accept=True everywhere, I canged the default env config to auto_accept_invite/requests = true.

Additionally, expanded test coverage for connections using public did.

