### PR TITLE
Disallow special characters in `wallet_label` and `wallet_name`, and limit max length

### DIFF
--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -6,11 +6,13 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.models.trust_registry import TrustRegistryRole
 
-allowable_special_chars = ".!@$*()~_-"
 # Deduplicate some descriptions and field definitions
-label_description = "A required alias for the tenant, publicized to other agents when forming a connection. "
-"If the tenant is an issuer or verifier, this label will be displayed on the trust registry and must be unique. "
-f"Allowable special characters: {allowable_special_chars}"
+allowable_special_chars = ".!@$*()~_-"  # the dash character must be at the end, otherwise it defines a regex range
+label_description = (
+    "A required alias for the tenant, publicized to other agents when forming a connection. "
+    "If the tenant is an issuer or verifier, this label will be displayed on the trust registry and must be unique. "
+    f"Allowable special characters: {allowable_special_chars}"
+)
 label_examples = ["Tenant Label"]
 group_id_field = Field(
     None,

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -90,7 +90,7 @@ class CreateTenantRequest(BaseModel):
     @classmethod
     def validate_wallet_label(cls, v):
         if len(v) > 100:
-            raise ValueError("wallet_label must be less than 100 characters long")
+            raise ValueError("wallet_label has a max length of 100 characters")
 
         if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
             raise ValueError(
@@ -104,7 +104,7 @@ class CreateTenantRequest(BaseModel):
     def validate_wallet_name(cls, v):
         if v:
             if len(v) > 100:
-                raise ValueError("wallet_name must be less than 100 characters long")
+                raise ValueError("wallet_name has a max length of 100 characters")
 
             if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
                 raise ValueError(

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -85,6 +85,7 @@ class CreateTenantRequest(BaseModel):
     extra_settings: Optional[Dict[ExtraSettings, str]] = ExtraSettings_field
 
     @field_validator("wallet_label", mode="before")
+    @classmethod
     def validate_wallet_label(cls, v):
         if not re.match(rf"^[a-zA-Z0-9\s{allowable_special_chars}]+$", v):
             raise ValueError(

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -96,6 +96,20 @@ class CreateTenantRequest(BaseModel):
             )
         return v
 
+    @field_validator("wallet_name", mode="before")
+    @classmethod
+    def validate_wallet_name(cls, v):
+        if len(v) > 100:
+            raise ValueError("wallet_name must be less than 100 characters long")
+
+        if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
+            raise ValueError(
+                "wallet_name may not contain certain special characters. Must be alphanumeric, may include "
+                f"spaces, and the following special characters are allowed: {allowable_special_chars}"
+            )
+
+        return v
+
 
 class UpdateTenantRequest(BaseModel):
     wallet_label: Optional[str] = Field(

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -102,14 +102,15 @@ class CreateTenantRequest(BaseModel):
     @field_validator("wallet_name", mode="before")
     @classmethod
     def validate_wallet_name(cls, v):
-        if len(v) > 100:
-            raise ValueError("wallet_name must be less than 100 characters long")
+        if v:
+            if len(v) > 100:
+                raise ValueError("wallet_name must be less than 100 characters long")
 
-        if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
-            raise ValueError(
-                "wallet_name may not contain certain special characters. Must be alphanumeric, may include "
-                f"spaces, and the following special characters are allowed: {allowable_special_chars}"
-            )
+            if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
+                raise ValueError(
+                    "wallet_name may not contain certain special characters. Must be alphanumeric, may include "
+                    f"spaces, and the following special characters are allowed: {allowable_special_chars}"
+                )
 
         return v
 

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -89,6 +89,9 @@ class CreateTenantRequest(BaseModel):
     @field_validator("wallet_label", mode="before")
     @classmethod
     def validate_wallet_label(cls, v):
+        if len(v) > 100:
+            raise ValueError("wallet_label must be less than 100 characters long")
+
         if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
             raise ValueError(
                 "wallet_label may not contain certain special characters. Must be alphanumeric, may include "

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -89,10 +89,10 @@ class CreateTenantRequest(BaseModel):
     @field_validator("wallet_label", mode="before")
     @classmethod
     def validate_wallet_label(cls, v):
-        if not re.match(rf"^[a-zA-Z0-9\s{allowable_special_chars}]+$", v):
+        if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
             raise ValueError(
-                "wallet_label may not contain certain special characters. Besides "
-                f" alphanumeric, allowable characters: {allowable_special_chars}"
+                "wallet_label may not contain certain special characters. Must be alphanumeric, may include "
+                f"spaces, and the following special characters are allowed: {allowable_special_chars}"
             )
         return v
 

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -123,6 +123,19 @@ class UpdateTenantRequest(BaseModel):
     extra_settings: Optional[Dict[ExtraSettings, str]] = ExtraSettings_field
     # TODO: add group_id to update request
 
+    @field_validator("wallet_label", mode="before")
+    @classmethod
+    def validate_wallet_label(cls, v):
+        if len(v) > 100:
+            raise ValueError("wallet_label must be less than 100 characters long")
+
+        if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
+            raise ValueError(
+                "wallet_label may not contain certain special characters. Must be alphanumeric, may include "
+                f"spaces, and the following special characters are allowed: {allowable_special_chars}"
+            )
+        return v
+
 
 class Tenant(BaseModel):
     wallet_id: str = Field(..., examples=["545135a4-ecbc-4400-8594-bdb74c51c88d"])

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -573,3 +573,36 @@ async def test_extra_settings(
         )
 
         assert bad_response.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_wallet_label_validation(tenant_admin_client: RichAsyncClient):
+    # Assert that 422 is raised when unacceptable special chars are used in wallet label
+    # The following chars are either reserved or unsafe to use in URIs without encoding
+    for char in [
+        "#",
+        "%",
+        "^",
+        "&",
+        "+",
+        "=",
+        "{",
+        "}",
+        "[",
+        "]",
+        "|",
+        "\\",
+        '"',
+        ":",
+        ";",
+        ",",
+        "/",
+        "?",
+    ]:
+        with pytest.raises(Exception):
+            bad_response = await tenant_admin_client.post(
+                TENANTS_BASE_PATH,
+                json={"wallet_label": uuid4().hex + char},
+            )
+
+            assert bad_response.status_code == 422

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -194,19 +194,15 @@ async def test_create_tenant_issuer(
     assert_that(tenant).has_updated_at(wallet.updated_at)
     assert_that(wallet.settings["wallet.name"]).is_length(32)
 
+    # Assert that wallet_label cannot be re-used by plain tenants
     with pytest.raises(HTTPException) as http_error:
         await tenant_admin_client.post(
             TENANTS_BASE_PATH,
-            json={
-                "image_url": "https://image.ca",
-                "wallet_label": wallet_label,
-                "roles": ["issuer"],
-                "group_id": group_id,
-            },
+            json={"wallet_label": wallet_label},
         )
 
         assert http_error.status_code == 409
-        assert "Can't create Tenant. Actor with name:" in http_error.json()["details"]
+        assert "Can't create Tenant." in http_error.json()["details"]
 
 
 @pytest.mark.anyio

--- a/shared/models/trustregistry.py
+++ b/shared/models/trustregistry.py
@@ -31,8 +31,8 @@ class Schema(BaseModel):
     version: str = Field(default=None)
     id: str = Field(default=None)
 
-    # pylint: disable=no-self-argument
     @model_validator(mode="before")
+    @classmethod
     def validate_and_set_values(cls, values: Union[dict, "Schema"]):
         # pydantic v2 removed safe way to get key, because `values` can be a dict or this type
         if not isinstance(values, dict):


### PR DESCRIPTION
Wallet label must be alphanumeric, may contain spaces, and the following special characters are allowed: `.!@$*()~_-`. The same applies for wallet_name. 

We also introduce a max length to these fields of 100 characters.

:white_check_mark: includes tests to assert these changes