### PR TITLE
:sparkles: Add caching to schema_id fetch from ledger

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp~=3.9.0
 aries-cloudcontroller==0.9.0.post2
 base58~=2.1.1
+beaker~=1.12.1
 fastapi~=0.104.1
 fastapi_websocket_pubsub~=0.3.8
 httpx~=0.25.1

--- a/app/services/acapy_ledger.py
+++ b/app/services/acapy_ledger.py
@@ -12,6 +12,7 @@ from aries_cloudcontroller import (
 )
 
 from app.exceptions import CloudApiException
+from app.util.caching import cache
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)
@@ -200,6 +201,7 @@ async def write_credential_def(
     return write_cred_response.credential_definition_id
 
 
+@cache.cache(expire=60 * 60 * 24)  # 24 hour caching
 async def schema_id_from_credential_definition_id(
     controller: AcaPyClient, credential_definition_id: str
 ):

--- a/app/util/caching.py
+++ b/app/util/caching.py
@@ -1,0 +1,9 @@
+from beaker.cache import CacheManager
+from beaker.util import parse_cache_config_options
+
+cache_opts = {
+    "cache.type": "memory",
+    "cache.expire": 60 * 60,  # default 1 hour caching
+}
+
+cache = CacheManager(**parse_cache_config_options(cache_opts))


### PR DESCRIPTION
Note: `beaker`, the cache library, has a critical vulnerability:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-7489
An insecure data serialization method could theoretically allow arbitrary code execution.