### PR TITLE
:sparkles: Add `save_exchange_record` argument to send credentials

### DIFF
--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Dict, Optional
 
 from aries_cloudcontroller import LDProofVCDetail
-from pydantic import BaseModel, ValidationInfo, field_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from shared.models.protocol import IssueCredentialProtocolVersion
 
@@ -22,6 +22,10 @@ class CredentialBase(BaseModel):
     type: CredentialType = CredentialType.INDY
     indy_credential_detail: Optional[IndyCredential] = None
     ld_credential_detail: Optional[LDProofVCDetail] = None
+    auto_remove_exchange_record: Optional[bool] = Field(
+        default=None,
+        description="Whether to remove the credential exchange record on completion",
+    )
 
     @field_validator("indy_credential_detail", mode="before")
     @classmethod

--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -22,8 +22,8 @@ class CredentialBase(BaseModel):
     type: CredentialType = CredentialType.INDY
     indy_credential_detail: Optional[IndyCredential] = None
     ld_credential_detail: Optional[LDProofVCDetail] = None
-    auto_remove_exchange_record: Optional[bool] = Field(
-        default=None,
+    auto_remove_exchange_record: bool = Field(
+        default=True,
         description="Whether to remove the credential exchange record on completion",
     )
 

--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -22,9 +22,9 @@ class CredentialBase(BaseModel):
     type: CredentialType = CredentialType.INDY
     indy_credential_detail: Optional[IndyCredential] = None
     ld_credential_detail: Optional[LDProofVCDetail] = None
-    auto_remove_exchange_record: bool = Field(
-        default=True,
-        description="Whether to remove the credential exchange record on completion",
+    save_exchange_record: bool = Field(
+        default=False,
+        description="Whether an exchange record should be saved on completion",
     )
 
     @field_validator("indy_credential_detail", mode="before")

--- a/app/services/issuer/acapy_issuer.py
+++ b/app/services/issuer/acapy_issuer.py
@@ -58,7 +58,6 @@ class Issuer(ABC):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
-        auto_remove: Optional[bool],
     ) -> CredentialExchange:
         """
         Request credential

--- a/app/services/issuer/acapy_issuer.py
+++ b/app/services/issuer/acapy_issuer.py
@@ -55,7 +55,10 @@ class Issuer(ABC):
     @classmethod
     @abstractmethod
     async def request_credential(
-        cls, controller: AcaPyClient, credential_exchange_id: str
+        cls,
+        controller: AcaPyClient,
+        credential_exchange_id: str,
+        auto_remove: Optional[bool],
     ) -> CredentialExchange:
         """
         Request credential
@@ -64,8 +67,10 @@ class Issuer(ABC):
         -----------
         controller: AcaPyClient
             The aries_cloudcontroller object
-        credential_exchange_id:
+        credential_exchange_id: str
             The credential_exchange_id of the exchange
+        auto_remove: Optional[bool]
+            Whether to override environment setting for auto-deleting cred ex records
 
         Returns:
         --------

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -83,7 +83,6 @@ class IssuerV1(Issuer):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
-        auto_remove: Optional[bool] = None,
     ):
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
@@ -94,7 +93,6 @@ class IssuerV1(Issuer):
         bound_logger.debug("Sending v1 credential request")
         record = await controller.issue_credential_v1_0.send_request(
             cred_ex_id=credential_exchange_id,
-            body=V10CredentialExchangeAutoRemoveRequest(auto_remove=auto_remove),
         )
 
         bound_logger.debug("Returning v1 send request result as CredentialExchange.")

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -42,7 +42,7 @@ class IssuerV1(Issuer):
         bound_logger.debug("Issue v1 credential (automated)")
         record = await controller.issue_credential_v1_0.issue_credential_automated(
             body=V10CredentialProposalRequestMand(
-                auto_remove=credential.auto_remove_exchange_record,
+                auto_remove=credential.save_exchange_record,
                 connection_id=credential.connection_id,
                 credential_proposal=credential_preview,
                 cred_def_id=credential.indy_credential_detail.credential_definition_id,
@@ -69,7 +69,7 @@ class IssuerV1(Issuer):
         bound_logger.debug("Creating v1 credential offer")
         record = await controller.issue_credential_v1_0.create_offer(
             body=V10CredentialConnFreeOfferRequest(
-                auto_remove=credential.auto_remove_exchange_record,
+                auto_remove=credential.save_exchange_record,
                 credential_preview=credential_preview,
                 cred_def_id=credential.indy_credential_detail.credential_definition_id,
             )

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -6,6 +6,7 @@ from aries_cloudcontroller import (
     CredentialPreview,
     V10CredentialConnFreeOfferRequest,
     V10CredentialExchange,
+    V10CredentialExchangeAutoRemoveRequest,
     V10CredentialProposalRequestMand,
     V10CredentialStoreRequest,
 )
@@ -77,7 +78,10 @@ class IssuerV1(Issuer):
 
     @classmethod
     async def request_credential(
-        cls, controller: AcaPyClient, credential_exchange_id: str
+        cls,
+        controller: AcaPyClient,
+        credential_exchange_id: str,
+        auto_remove: Optional[bool] = None,
     ):
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
@@ -87,7 +91,8 @@ class IssuerV1(Issuer):
 
         bound_logger.debug("Sending v1 credential request")
         record = await controller.issue_credential_v1_0.send_request(
-            cred_ex_id=credential_exchange_id
+            cred_ex_id=credential_exchange_id,
+            body=V10CredentialExchangeAutoRemoveRequest(auto_remove=auto_remove),
         )
 
         bound_logger.debug("Returning v1 send request result as CredentialExchange.")

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -42,6 +42,7 @@ class IssuerV1(Issuer):
         bound_logger.debug("Issue v1 credential (automated)")
         record = await controller.issue_credential_v1_0.issue_credential_automated(
             body=V10CredentialProposalRequestMand(
+                auto_remove=credential.auto_remove_exchange_record,
                 connection_id=credential.connection_id,
                 credential_proposal=credential_preview,
                 cred_def_id=credential.indy_credential_detail.credential_definition_id,
@@ -68,6 +69,7 @@ class IssuerV1(Issuer):
         bound_logger.debug("Creating v1 credential offer")
         record = await controller.issue_credential_v1_0.create_offer(
             body=V10CredentialConnFreeOfferRequest(
+                auto_remove=credential.auto_remove_exchange_record,
                 credential_preview=credential_preview,
                 cred_def_id=credential.indy_credential_detail.credential_definition_id,
             )

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -40,9 +40,10 @@ class IssuerV1(Issuer):
         )
 
         bound_logger.debug("Issue v1 credential (automated)")
+        auto_remove = not credential.save_exchange_record
         record = await controller.issue_credential_v1_0.issue_credential_automated(
             body=V10CredentialProposalRequestMand(
-                auto_remove=credential.save_exchange_record,
+                auto_remove=auto_remove,
                 connection_id=credential.connection_id,
                 credential_proposal=credential_preview,
                 cred_def_id=credential.indy_credential_detail.credential_definition_id,
@@ -67,9 +68,10 @@ class IssuerV1(Issuer):
         )
 
         bound_logger.debug("Creating v1 credential offer")
+        auto_remove = not credential.save_exchange_record
         record = await controller.issue_credential_v1_0.create_offer(
             body=V10CredentialConnFreeOfferRequest(
-                auto_remove=credential.save_exchange_record,
+                auto_remove=auto_remove,
                 credential_preview=credential_preview,
                 cred_def_id=credential.indy_credential_detail.credential_definition_id,
             )

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -51,9 +51,10 @@ class IssuerV2(Issuer):
             )
 
         bound_logger.debug("Issue v2 credential (automated)")
+        auto_remove = not credential.save_exchange_record
         record = await controller.issue_credential_v2_0.issue_credential_automated(
             body=V20CredExFree(
-                auto_remove=credential.save_exchange_record,
+                auto_remove=auto_remove,
                 connection_id=credential.connection_id,
                 filter=cred_filter,
                 credential_preview=credential_preview,
@@ -87,10 +88,11 @@ class IssuerV2(Issuer):
             )
 
         bound_logger.debug("Creating v2 credential offer")
+        auto_remove = not credential.save_exchange_record
         record = (
             await controller.issue_credential_v2_0.issue_credential20_create_offer_post(
                 body=V20CredOfferConnFreeRequest(
-                    auto_remove=credential.save_exchange_record,
+                    auto_remove=auto_remove,
                     credential_preview=credential_preview,
                     filter=cred_filter,
                 )

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -105,7 +105,6 @@ class IssuerV2(Issuer):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
-        auto_remove: Optional[bool] = None,
     ):
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
@@ -116,7 +115,6 @@ class IssuerV2(Issuer):
         bound_logger.debug("Sending v2 credential request")
         record = await controller.issue_credential_v2_0.send_request(
             cred_ex_id=credential_exchange_id,
-            body=V20CredRequestRequest(auto_remove=auto_remove),
         )
 
         bound_logger.debug("Returning v2 send request result as CredentialExchange.")

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -99,7 +99,10 @@ class IssuerV2(Issuer):
 
     @classmethod
     async def request_credential(
-        cls, controller: AcaPyClient, credential_exchange_id: str
+        cls,
+        controller: AcaPyClient,
+        credential_exchange_id: str,
+        auto_remove: Optional[bool] = None,
     ):
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
@@ -109,7 +112,8 @@ class IssuerV2(Issuer):
 
         bound_logger.debug("Sending v2 credential request")
         record = await controller.issue_credential_v2_0.send_request(
-            cred_ex_id=credential_exchange_id, body=V20CredRequestRequest()
+            cred_ex_id=credential_exchange_id,
+            body=V20CredRequestRequest(auto_remove=auto_remove),
         )
 
         bound_logger.debug("Returning v2 send request result as CredentialExchange.")

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -114,7 +114,7 @@ class IssuerV2(Issuer):
 
         bound_logger.debug("Sending v2 credential request")
         record = await controller.issue_credential_v2_0.send_request(
-            cred_ex_id=credential_exchange_id,
+            cred_ex_id=credential_exchange_id, body=V20CredRequestRequest()
         )
 
         bound_logger.debug("Returning v2 send request result as CredentialExchange.")

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -53,6 +53,7 @@ class IssuerV2(Issuer):
         bound_logger.debug("Issue v2 credential (automated)")
         record = await controller.issue_credential_v2_0.issue_credential_automated(
             body=V20CredExFree(
+                auto_remove=credential.auto_remove_exchange_record,
                 connection_id=credential.connection_id,
                 filter=cred_filter,
                 credential_preview=credential_preview,
@@ -89,7 +90,9 @@ class IssuerV2(Issuer):
         record = (
             await controller.issue_credential_v2_0.issue_credential20_create_offer_post(
                 body=V20CredOfferConnFreeRequest(
-                    credential_preview=credential_preview, filter=cred_filter
+                    auto_remove=credential.auto_remove_exchange_record,
+                    credential_preview=credential_preview,
+                    filter=cred_filter,
                 )
             )
         )

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -53,7 +53,7 @@ class IssuerV2(Issuer):
         bound_logger.debug("Issue v2 credential (automated)")
         record = await controller.issue_credential_v2_0.issue_credential_automated(
             body=V20CredExFree(
-                auto_remove=credential.auto_remove_exchange_record,
+                auto_remove=credential.save_exchange_record,
                 connection_id=credential.connection_id,
                 filter=cred_filter,
                 credential_preview=credential_preview,
@@ -90,7 +90,7 @@ class IssuerV2(Issuer):
         record = (
             await controller.issue_credential_v2_0.issue_credential20_create_offer_post(
                 body=V20CredOfferConnFreeRequest(
-                    auto_remove=credential.auto_remove_exchange_record,
+                    auto_remove=credential.save_exchange_record,
                     credential_preview=credential_preview,
                     filter=cred_filter,
                 )

--- a/app/tests/e2e/test_credentials.py
+++ b/app/tests/e2e/test_credentials.py
@@ -244,10 +244,10 @@ async def meld_co_issue_credential_to_alice(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("auto_remove_for_faber", [None, False, True])
+@pytest.mark.parametrize("auto_remove_for_faber", [False, True])
 async def test_issue_credential_with_auto_remove(
     faber_client: RichAsyncClient,
-    credential_definition_id: str,
+    credential_definition_id: str,  # pylint: disable=redefined-outer-name
     faber_and_alice_connection: FaberAliceConnect,
     alice_member_client: RichAsyncClient,
     alice_tenant: CreateTenantResponse,

--- a/app/tests/e2e/test_credentials.py
+++ b/app/tests/e2e/test_credentials.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import Optional
 
 import pytest
 
@@ -302,8 +301,7 @@ async def test_issue_credential_with_save_exchange_record(
     # Alice cred ex recs should be empty regardless
     assert len(alice_cred_ex_recs) == 0
 
-    if save_exchange_record is False:
-        assert len(faber_cred_ex_recs) == 0  # default is to remove records
-
-    if save_exchange_record is True:
+    if save_exchange_record:
         assert len(faber_cred_ex_recs) == 1  # Save record is True, should be 1 record
+    else:
+        assert len(faber_cred_ex_recs) == 0  # default is to remove records

--- a/app/tests/e2e/test_credentials.py
+++ b/app/tests/e2e/test_credentials.py
@@ -244,14 +244,14 @@ async def meld_co_issue_credential_to_alice(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("auto_remove_for_faber", [False, True])
-async def test_issue_credential_with_auto_remove(
+@pytest.mark.parametrize("save_exchange_record", [False, True])
+async def test_issue_credential_with_save_exchange_record(
     faber_client: RichAsyncClient,
     credential_definition_id: str,  # pylint: disable=redefined-outer-name
     faber_and_alice_connection: FaberAliceConnect,
     alice_member_client: RichAsyncClient,
     alice_tenant: CreateTenantResponse,
-    auto_remove_for_faber: Optional[bool],
+    save_exchange_record: bool,
 ) -> CredentialExchange:
     credential = {
         "protocol_version": "v1",
@@ -260,7 +260,7 @@ async def test_issue_credential_with_auto_remove(
             "credential_definition_id": credential_definition_id,
             "attributes": {"speed": "10"},
         },
-        "auto_remove_exchange_record": auto_remove_for_faber,
+        "save_exchange_record": save_exchange_record,
     }
 
     alice_credentials_listener = SseListener(
@@ -302,8 +302,8 @@ async def test_issue_credential_with_auto_remove(
     # Alice cred ex recs should be empty regardless
     assert len(alice_cred_ex_recs) == 0
 
-    if auto_remove_for_faber is None or auto_remove_for_faber is True:
-        assert len(faber_cred_ex_recs) == 0  # default before is remove records
+    if save_exchange_record is False:
+        assert len(faber_cred_ex_recs) == 0  # default is to remove records
 
-    if auto_remove_for_faber is False:
-        assert len(faber_cred_ex_recs) == 1  # Auto Remove = False, should be 1 record
+    if save_exchange_record is True:
+        assert len(faber_cred_ex_recs) == 1  # Save record is True, should be 1 record


### PR DESCRIPTION
`auto_remove` allows the issuer to control whether exchange records are automatically deleted or not. The default environment behavior is not to preserve exchange records (i.e. automatically deleted), and this allows the issuer to override this default behavior, if they request `save_exchange_record=True`.