### PR TITLE
:hammer: Update script for drop db

### DIFF
--- a/scripts/aurora-delete.sh
+++ b/scripts/aurora-delete.sh
@@ -106,7 +106,7 @@ drop_db_function() {
   for DB in $DB_LIST; do
     (
       log "Dropping database: $DB"
-      PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres -c "DROP DATABASE \"${DB}\""
+      PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres -c "DROP DATABASE \"${DB}\" WITH (FORCE)"
     )
   done
   log "$STEP: done"


### PR DESCRIPTION
Forcefully drop db's, to circumvent the following error in deploy to EKS job:
```
[2023-11-30T11:37:56+0000]: INFO: Dropping database: ***
ERROR:  database "***" is being accessed by other users
DETAIL:  There are 2 other sessions using the database.
Error: Process completed with exit code 1.
```