### PR TITLE
:sparkles: make websocket event publishing stateless

### DIFF
--- a/webhooks/dependencies/websocket.py
+++ b/webhooks/dependencies/websocket.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter
+from fastapi_websocket_pubsub import PubSubEndpoint
+
+from shared.models.webhook_topics import WEBHOOK_TOPIC_ALL
+
+router = APIRouter()
+
+endpoint = PubSubEndpoint()
+endpoint.register_route(router, "/pubsub")
+
+
+async def publish_event_on_websocket(
+    event_json: str, wallet_id: str, topic: str
+) -> None:
+    """
+    Publish the webhook to websocket subscribers on the following topics:
+        - current wallet id
+        - topic of the event
+        - topic and wallet id combined as topic-wallet_id
+        - 'all' topic, which allows to subscribe to all published events
+
+    Args:
+        event_json (str): Webhook event serialized as json
+        wallet_id (str): The wallet_id for this event
+        topic (str): The cloudapi topic for the event
+    """
+
+    publish_topics = [topic, wallet_id, f"{topic}-{wallet_id}", WEBHOOK_TOPIC_ALL]
+
+    await endpoint.publish(topics=publish_topics, data=event_json)

--- a/webhooks/main.py
+++ b/webhooks/main.py
@@ -3,7 +3,7 @@ import os
 from fastapi import FastAPI
 
 from shared.log_config import get_logger
-from webhooks.dependencies import sse_manager
+from webhooks.dependencies import sse_manager, websocket
 from webhooks.dependencies.container import get_container
 from webhooks.routers import receive_events, sse, webhooks
 
@@ -33,6 +33,7 @@ def create_app() -> FastAPI:
     application.include_router(receive_events.router)
     application.include_router(webhooks.router)
     application.include_router(sse.router)
+    application.include_router(websocket.router)
 
     return application
 

--- a/webhooks/tests/test_receive_events.py
+++ b/webhooks/tests/test_receive_events.py
@@ -21,8 +21,7 @@ dummy_event = CloudApiWebhookEvent(
     "webhooks.dependencies.redis_service.RedisService.add_webhook_event",
     new_callable=AsyncMock,
 )
-@patch("webhooks.routers.receive_events.endpoint.publish", new_callable=AsyncMock)
-def test_topic_root(mock_publish, mock_add_webhook_event, _):
+def test_topic_root(mock_add_webhook_event, _):
     # Prepare the request payload
     acapy_topic = "connections"
     body = {"payload": "test"}
@@ -34,6 +33,5 @@ def test_topic_root(mock_publish, mock_add_webhook_event, _):
     # Verify the response
     assert response.status_code == 204
 
-    # Verify that the Redis service and endpoint publish were called
+    # Verify that the Redis service was called
     mock_add_webhook_event.assert_awaited_once()
-    mock_publish.assert_awaited_once()


### PR DESCRIPTION
in order to run cluster in high availability.

Moves websocket publishing logic to SSE manager, where events are retreived from redis via pubsub notification. This means all the events that are added to SSE queue (previously made to be stateless using redis pubsub) will now also be published to websocket endpoint.

Resolves #560 