### PR TITLE
chore: Remove erroneous close swirly in github action

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: cicd-build-${{ matrix.image }}}
+      group: cicd-build-${{ matrix.image }}
       cancel-in-progress: false
 
     outputs:


### PR DESCRIPTION
Resolves the trailing `}` in concurrency group names
![image](https://github.com/didx-xyz/aries-cloudapi-python/assets/4052340/451d387c-e400-49d2-923e-c4bd942fa969)
