### PR TITLE
Patch concurrency group

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: cicd-build-${{ matrix.image }}
+      group: cicd-build-${{ matrix.image }}-${{ github.ref }}
       cancel-in-progress: false
 
     outputs:


### PR DESCRIPTION
Add `${{ github.ref }}` to concurrency group for image builds

Will prevent PR's from cancelling each other's builds