### PR TITLE
`triggering_actor` -> `actor`

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -288,7 +288,7 @@ jobs:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
   deploy:
-    if: github.triggering_actor != 'dependabot[bot]' && github.event.pull_request.draft == false
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false
     name: Deploy to EKS
     environment:
       name: dev


### PR DESCRIPTION
If commit/PR author is `dependabot[bot]` but one of us re-run a workflow (e.g: failed jobs) then we're the triggering actor