### PR TITLE
:sparkles: add `/v1` prefix to endpoints, and drop `/generic`

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -469,9 +469,8 @@ jobs:
             apply \
               --environment ${{ vars.ENVIRONMENT }} \
               -f ./charts/helmfiles/aries-cloudapi-python.yaml \
-              --set image.tag=${{ env.IMAGE_TAG }} \
-              --set image.registry=ghcr.io/${{ github.repository_owner }} \
-              --set replicaCount=1
+              --state-values-set image.tag=${{ env.IMAGE_TAG }} \
+              --state-values-set image.registry=ghcr.io/${{ github.repository_owner }}
           helm-plugins: |
             https://github.com/databus23/helm-diff,
             https://github.com/jkroepke/helm-secrets
@@ -487,10 +486,9 @@ jobs:
             apply \
               --environment ${{ vars.ENVIRONMENT }} \
               -f ./charts/helmfiles/aries-cloudapi-python.yaml \
-              --set image.tag=${{ env.IMAGE_TAG }} \
-              --set image.registry=ghcr.io/${{ github.repository_owner }} \
-              --selector app!=governance-ga-agent,app!=governance-multitenant-agent \
-              --set replicaCount=1
+              --state-values-set image.tag=${{ env.IMAGE_TAG }} \
+              --state-values-set image.registry=ghcr.io/${{ github.repository_owner }} \
+              --selector app!=governance-ga-agent,app!=governance-multitenant-agent
           helm-plugins: |
             https://github.com/databus23/helm-diff,
             https://github.com/jkroepke/helm-secrets
@@ -515,8 +513,8 @@ jobs:
             apply \
               --environment ${{ vars.ENVIRONMENT }} \
               -f ./charts/helmfiles/aries-cloudapi-python.yaml \
-              --set image.tag=${{ env.IMAGE_TAG }} \
-              --set image.registry=ghcr.io/${{ github.repository_owner }} \
+              --state-values-set image.tag=${{ env.IMAGE_TAG }} \
+              --state-values-set image.registry=ghcr.io/${{ github.repository_owner }} \
               --selector app=governance-ga-agent \
               --selector app=governance-multitenant-agent \
               --set env.WALLET_DB_HOST=${{ secrets.DB_PROXY_HOST }} \

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -34,7 +34,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/tenants", tags=["admin: tenants"])
+router = APIRouter(prefix="/v1/tenants", tags=["admin: tenants"])
 
 
 @router.post("", response_model=CreateTenantResponse)

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -12,7 +12,7 @@ from shared.models.webhook_topics import Connection
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/generic/connections", tags=["connections"])
+router = APIRouter(prefix="/v1/connections", tags=["connections"])
 
 
 @router.post("/create-invitation", response_model=InvitationResult)

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -45,7 +45,7 @@ from shared.log_config import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(
-    prefix="/generic/definitions",
+    prefix="/v1/definitions",
     tags=["definitions"],
 )
 

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -30,7 +30,7 @@ from shared.models.webhook_topics import CredentialExchange
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/generic/issuer/credentials", tags=["issuer"])
+router = APIRouter(prefix="/v1/issuer/credentials", tags=["issuer"])
 
 
 @router.get("", response_model=List[CredentialExchange])

--- a/app/routes/jsonld.py
+++ b/app/routes/jsonld.py
@@ -15,7 +15,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/generic/jsonld", tags=["jsonld"])
+router = APIRouter(prefix="/v1/jsonld", tags=["jsonld"])
 
 
 @router.post("/sign", response_model=SignResponse)

--- a/app/routes/messaging.py
+++ b/app/routes/messaging.py
@@ -8,7 +8,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/generic/messaging", tags=["messaging"])
+router = APIRouter(prefix="/v1/messaging", tags=["messaging"])
 
 
 @router.post("/send-message")

--- a/app/routes/oob.py
+++ b/app/routes/oob.py
@@ -13,7 +13,7 @@ from shared.models.webhook_topics import Connection
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/generic/oob", tags=["out-of-band"])
+router = APIRouter(prefix="/v1/oob", tags=["out-of-band"])
 
 
 @router.post("/create-invitation", response_model=InvitationRecord)

--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -17,7 +17,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/sse", tags=["sse"])
+router = APIRouter(prefix="/v1/sse", tags=["sse"])
 
 
 @router.get(

--- a/app/routes/trust_registry.py
+++ b/app/routes/trust_registry.py
@@ -9,7 +9,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/trust-registry", tags=["trust-registry"])
+router = APIRouter(prefix="/v1/trust-registry", tags=["trust-registry"])
 
 
 @router.get("/schemas", response_model=List[Schema])

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -23,7 +23,7 @@ from shared.models.webhook_topics import PresentationExchange
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/generic/verifier", tags=["verifier"])
+router = APIRouter(prefix="/v1/verifier", tags=["verifier"])
 
 
 @router.post("/create-request", response_model=PresentationExchange)

--- a/app/routes/wallet/credentials.py
+++ b/app/routes/wallet/credentials.py
@@ -17,7 +17,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/wallet/credentials", tags=["wallet"])
+router = APIRouter(prefix="/v1/wallet/credentials", tags=["wallet"])
 
 
 @router.get("", response_model=CredInfoList)

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -12,7 +12,7 @@ from shared.log_config import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/wallet/dids", tags=["wallet"])
+router = APIRouter(prefix="/v1/wallet/dids", tags=["wallet"])
 
 
 @router.post("", response_model=DID)

--- a/app/routes/webhooks.py
+++ b/app/routes/webhooks.py
@@ -9,7 +9,7 @@ from shared.models.webhook_topics import CloudApiTopics, CloudApiWebhookEventGen
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+router = APIRouter(prefix="/v1/webhooks", tags=["webhooks"])
 
 
 @router.get("")

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -11,6 +11,6 @@ def test_create_app():
 
         # Verifying that all routes are included
         routes = [route.path for route in app.routes]
-        expected_routes = ["/openapi.json", "/tenants"]
+        expected_routes = ["/openapi.json", "/v1/tenants"]
         for route in expected_routes:
             assert route in routes

--- a/docs/Common Steps.md
+++ b/docs/Common Steps.md
@@ -92,7 +92,7 @@ To create schemas and effectively write them to the ledger as well as registerin
    This should correspond to a schema you created previously, and the `connection_id` is the ID of the connection you created in the previous step. If you're unsure what that ID is, you can always run a GET request against the `connections` endpoint to find it.
 
 6. Accept and store the credential in the holder wallet
-7. Using the holder (authenticating with the holder auth header), issue a GET request against the `/generic/issuer/credentials` endpoint, providing the connection ID of the connection established above. _Note: The connection IDs are unique for each entity, so the connection between the issuer and the holder is one connection with two separate connection IDs - one for the issuer and one for the holder._ This will provide you with a credential record that should be in the state of being offered. Providing the connection ID again, you can now use the holder to store the credential by posting to `/generic/issuer/credentials/{credential_id}/store`
+7. Using the holder (authenticating with the holder auth header), issue a GET request against the `/v1/issuer/credentials` endpoint, providing the connection ID of the connection established above. _Note: The connection IDs are unique for each entity, so the connection between the issuer and the holder is one connection with two separate connection IDs - one for the issuer and one for the holder._ This will provide you with a credential record that should be in the state of being offered. Providing the connection ID again, you can now use the holder to store the credential by posting to `/v1/issuer/credentials/{credential_id}/store`
 8. (Optional) Get yor credentials from your wallet (`wallet/credentials`) check whether the credential is actually stored. You can also check this via the webhooks/sse.
 
 ## Verifying a Credential
@@ -101,7 +101,7 @@ To create schemas and effectively write them to the ledger as well as registerin
 2. Register an entity as a verifier (verifier)
    1. In other words, create or update a wallet, passing the role "verifier"
 3. Create a connection between 1. prover and 2. verifier the same way as in **Issuing a Credential**
-4. Create a proof request (`/generic/verifier/create-request`) using the verifier and send it to the prover. Consult the Swagger `verifier` endpoints. POST to `/generic/verifier/send-request` with a payload of the following form, replacing the values accordingly (and ensuring they can be covered by the previously created schema and issued credential):
+4. Create a proof request (`/v1/verifier/create-request`) using the verifier and send it to the prover. Consult the Swagger `verifier` endpoints. POST to `/v1/verifier/send-request` with a payload of the following form, replacing the values accordingly (and ensuring they can be covered by the previously created schema and issued credential):
 
    ```json
    {
@@ -140,11 +140,11 @@ To create schemas and effectively write them to the ledger as well as registerin
 
 5. Send the proof request.
 
-   1. From the prover, get the proof records using `/generic/verifier/proofs` and create a proof request you want to send, just as above (same payload format and endpoint).
+   1. From the prover, get the proof records using `/v1/verifier/proofs` and create a proof request you want to send, just as above (same payload format and endpoint).
 
 6. Accept the proof request.
 
-   1. From the verifier, you can now accept (or reject; see `/generic/verifier/reject-request` on Swagger for payload) by POSTing to `/generic/verifier/send-request`, adjusting the payload to:
+   1. From the verifier, you can now accept (or reject; see `/v1/verifier/reject-request` on Swagger for payload) by POSTing to `/v1/verifier/send-request`, adjusting the payload to:
 
    ```json
    {

--- a/docs/Governance as Code.md
+++ b/docs/Governance as Code.md
@@ -6,7 +6,7 @@ Schemas are used to define attributes related to credentials. To define schemas 
 
 1. Access the API through the [Governance Cloud API](http://localhost:8100/docs).
 2. Authenticate with `governance.` + `APIKEY` role.
-3. Generate a new schema with a `POST` to the following API endpoint: `/generic/definitions/schemas`.
+3. Generate a new schema with a `POST` to the following API endpoint: `/v1/definitions/schemas`.
 
 An example of a successful response to generate a DID:
 
@@ -133,7 +133,7 @@ To create credential definitions through the `Transaction Endorser Protocol` for
 
 1. Access the [Cloud API Swagger UI](http://localhost:8100/docs)
 2. Authenticate as an Issuer using `tenant.`+`JWTKey` x-api-key
-3. Create a new schema with a `POST` to the API endpoint `/generic/definitions/credentials` using the request body illustrated in the example below.
+3. Create a new schema with a `POST` to the API endpoint `/v1/definitions/credentials` using the request body illustrated in the example below.
 
    >NOTE: The schema ID should already exist in the ledger and be accessible in the Trust Registry
 

--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -97,7 +97,7 @@ Here is an example Javascript implementation
 
 ```js
 const EventSource = require('eventsource');
-url = "http://localhost:8100/sse/<wallet_id>"
+url = "http://localhost:8100/v1/sse/<wallet_id>"
 
 const headers = {
     'x-api-key':"tenant.<tenant/wallet_token>",

--- a/docs/examples/1. Onboarding.md
+++ b/docs/examples/1. Onboarding.md
@@ -10,7 +10,7 @@ The difference between an `Issuer`, `Verifier` and `Holder` is that issuers and 
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/admin/tenants' \
+  'http://localhost:8100/v1/admin/tenants' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant-admin.adminApiKey' \
@@ -45,7 +45,7 @@ The `access_token` is what must be used as x-api-key to act as this tenant.
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/admin/tenants' \
+  'http://localhost:8100/v1/admin/tenants' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant-admin.adminApiKey' \
@@ -79,7 +79,7 @@ Response:
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/admin/tenants' \
+  'http://localhost:8100/v1/admin/tenants' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant-admin.adminApiKey' \

--- a/docs/examples/2. Create Schema.md
+++ b/docs/examples/2. Create Schema.md
@@ -4,7 +4,7 @@ Only the `Governance` role can create Schemas. Note the `x-api-key` used in the 
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/definitions/schemas' \
+  'http://localhost:8100/v1/definitions/schemas' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: governance.adminApiKey' \

--- a/docs/examples/3. Create Credential Definition.md
+++ b/docs/examples/3. Create Credential Definition.md
@@ -4,7 +4,7 @@ Once a schema has been created by the governance agent, the `Issuer` can create 
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/definitions/credentials' \
+  'http://localhost:8100/v1/definitions/credentials' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant.<Issuer token>' \

--- a/docs/examples/4. Create Connection with Issuer.md
+++ b/docs/examples/4. Create Connection with Issuer.md
@@ -1,6 +1,6 @@
 # 4: Create Connection
 
-Now that the Issuer has a credential definition, they can start issuing credentials. However, in order to do that, they first needs to create a connection to the holder. There are multiple ways to create connections. We will use the `/generic/connections/` endpoints in these examples.
+Now that the Issuer has a credential definition, they can start issuing credentials. However, in order to do that, they first needs to create a connection to the holder. There are multiple ways to create connections. We will use the `/v1/connections/` endpoints in these examples.
 
 ## Create connection between Issuer and Holder
 
@@ -10,7 +10,7 @@ As the `Issuer` we create a connection invitation.
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/connections/create-invitation' \
+  'http://localhost:8100/v1/connections/create-invitation' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant.<Issuer token>' \
@@ -42,13 +42,13 @@ Response:
 }
 ```
 
-The `Holder` accepts the connection by using the `invitation` object above, and by posting to the `/generic/connections/accept-invitation` endpoint.
+The `Holder` accepts the connection by using the `invitation` object above, and by posting to the `/v1/connections/accept-invitation` endpoint.
 
 >Note: the `invitation` object can also be obtained by decoding the base64 payload in the invitation_url, after the `c_i=` indicator.
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/connections/accept-invitation' \
+  'http://localhost:8100/v1/connections/accept-invitation' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant.<Holder token>' \

--- a/docs/examples/5. Issue Credential.md
+++ b/docs/examples/5. Issue Credential.md
@@ -8,7 +8,7 @@ Now that a connection has been made between the `Issuer` and the `Holder`, the `
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/issuer/credentials' \
+  'http://localhost:8100/v1/issuer/credentials' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -H 'x-api-key: tenant.<Issuer token>' \
@@ -54,7 +54,7 @@ Response:
 
 As you can see from the state, an offer has now been sent, and needs to be accepted/requested by the holder.
 
-> Note that the issuer will now have what's called a _credential exchange record_ in state: offer-sent. _Pending_ exchange records can be viewed by calling `GET /generic/issuer/credentials`, and _completed_ credential exchange records are deleted by default, but can be preserved by adding an optional `save_exchange_record=True` field to the request.
+> Note that the issuer will now have what's called a _credential exchange record_ in state: offer-sent. _Pending_ exchange records can be viewed by calling `GET /v1/issuer/credentials`, and _completed_ credential exchange records are deleted by default, but can be preserved by adding an optional `save_exchange_record=True` field to the request.
 
 ## Holder requests credential
 
@@ -62,7 +62,7 @@ Now the `Holder` needs to respond to the credential sent to them. Below the `Hol
 
 ```bash
 curl -X 'GET' \
-  'http://localhost:8100/generic/connections' \
+  'http://localhost:8100/v1/connections' \
   -H 'accept: application/json'
   -H 'x-api-key: tenant.<Holder token>'
 ```
@@ -93,11 +93,11 @@ Response:
 
 Note the `connection_id` in the above response.
 
-The `Holder` can then find the credentials offered to them on this `connection_id` by calling `/generic/issuer/credentials` with the optional `connection_id` query parameter:
+The `Holder` can then find the credentials offered to them on this `connection_id` by calling `/v1/issuer/credentials` with the optional `connection_id` query parameter:
 
 ```bash
 curl -X 'GET' \
-  'http://localhost:8100/generic/issuer/credentials?connection_id=ac3b0d56-eb33-408a-baeb-0370164d47ae' \
+  'http://localhost:8100/v1/issuer/credentials?connection_id=ac3b0d56-eb33-408a-baeb-0370164d47ae' \
   -H 'accept: application/json'
   -H 'x-api-key: tenant.<Holder token>'
 ```
@@ -131,11 +131,11 @@ Response:
 
 Note the `credential_id` and `state: offer-received`. Additionally, note that the holder and the issuer have different `credential_id` references for the same credential exchange interaction.
 
-The `Holder` can now requests the credential, using the `credential_id` from the above response, by calling `/generic/issuer/credentials/{credential_id}/request`:
+The `Holder` can now requests the credential, using the `credential_id` from the above response, by calling `/v1/issuer/credentials/{credential_id}/request`:
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/issuer/credentials/v1-c492cec7-2f2d-4d5f-b839-b57dcd8f8eee/request' \
+  'http://localhost:8100/v1/issuer/credentials/v1-c492cec7-2f2d-4d5f-b839-b57dcd8f8eee/request' \
   -H 'accept: application/json' \
   -H 'x-api-key: tenant.<Holder token>'
   -d ''
@@ -198,7 +198,7 @@ Once the state is done the credential will be in the `Holder's` wallet. We can l
 
 ```bash
 curl -X 'GET' \
-  'http://localhost:8100/wallet/credentials' \
+  'http://localhost:8100/v1/wallet/credentials' \
   -H 'accept: application/json'
   -H 'x-api-key: tenant.<Holder token>'
 ```

--- a/docs/examples/6. Create Connection with Verifier.md
+++ b/docs/examples/6. Create Connection with Verifier.md
@@ -6,7 +6,7 @@ Again we first create a `connection`. This time between the `Verifier` and `Hold
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/connections/create-invitation' \
+  'http://localhost:8100/v1/connections/create-invitation' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -41,7 +41,7 @@ The `Holder` accepts the invitation, using the `invitation` object in the above 
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/connections/accept-invitation' \
+  'http://localhost:8100/v1/connections/accept-invitation' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/docs/examples/7. Verify Credential.md
+++ b/docs/examples/7. Verify Credential.md
@@ -8,7 +8,7 @@ Once the connection is established, the Verifier can send a proof request.
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/verifier/send-request' \
+  'http://localhost:8100/v1/verifier/send-request' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -74,7 +74,7 @@ Response:
 }
 ```
 
-> Note that the verifier will now have what's called a _presentation exchange record_ in state: request-sent. _Pending_ presentation records can be viewed by calling `GET /generic/verifier/proofs`, and _completed_ presentation exchange records are deleted by default, but can be preserved by adding an optional `save_exchange_record=True` field to the request.
+> Note that the verifier will now have what's called a _presentation exchange record_ in state: request-sent. _Pending_ presentation records can be viewed by calling `GET /v1/verifier/proofs`, and _completed_ presentation exchange records are deleted by default, but can be preserved by adding an optional `save_exchange_record=True` field to the request.
 
 ## Holder responds to proof request
 
@@ -103,11 +103,11 @@ The holder would have received a webhook event on topic `proofs`, indicating the
 }
 ```
 
-The Holder will now see a presentation exchange record when they call `GET` on the `/generic/verifier/proofs` endpoint:
+The Holder will now see a presentation exchange record when they call `GET` on the `/v1/verifier/proofs` endpoint:
 
 ```bash
 curl -X 'GET' \
-  'http://localhost:8100/generic/verifier/proofs' \
+  'http://localhost:8100/v1/verifier/proofs' \
   -H 'accept: application/json'
   -H 'x-api-key: tenant.<holder token>' \
 ```
@@ -162,13 +162,13 @@ Response:
 
 Note that their role indicates `prover`, and the state is `request-received`. Prover is the term used for a holder in a proof exchange. Additionally, note that the prover and the verifier have different `proof_id` references for the same proof interaction.
 
-The Holder/Prover can now check which credentials match the fields that are requested in the proof request by using the `proof_id` and making a call to `/generic/verifier/proofs/{proof_id}/credentials`.
+The Holder/Prover can now check which credentials match the fields that are requested in the proof request by using the `proof_id` and making a call to `/v1/verifier/proofs/{proof_id}/credentials`.
 
 >NOTE: If the call is successful, but returns an empty list `[]`, it means that the credentials of the `Holder` do not match the requested fields in the proof request.
 
 ```bash
 curl -X 'GET' \
-  'http://localhost:8100/generic/verifier/proofs/v1-93e29a31-5eab-4091-9d1d-f27220f445fd/credentials' \
+  'http://localhost:8100/v1/verifier/proofs/v1-93e29a31-5eab-4091-9d1d-f27220f445fd/credentials' \
   -H 'accept: application/json'
 ```
 
@@ -205,7 +205,7 @@ We can now use the `referent` (the referent is the holder's reference to their c
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8100/generic/verifier/accept-request' \
+  'http://localhost:8100/v1/verifier/accept-request' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -374,7 +374,7 @@ Verifier can get the proof with all its data by making the following call:
 
 ```bash
 curl -X 'GET' \
-  'http://localhost:8100/generic/verifier/proofs' \
+  'http://localhost:8100/v1/verifier/proofs' \
   -H 'accept: application/json'
 ```
 


### PR DESCRIPTION
Changes Made

- API Versioning Introduced: All endpoints now include a `/v1` prefix
- Removal of `/generic` prefix: The `/generic` prefix has been removed from all endpoints where it was previously used. 