### PR TITLE
Bump Mozilla sops action

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -361,7 +361,7 @@ jobs:
         run: sudo apt-get install -y postgresql-client redis-tools
 
       - name: Sops Binary Installer
-        uses: mdgreenwald/mozilla-sops-action@v1.5.0
+        uses: mdgreenwald/mozilla-sops-action@v1.6.0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
* `mdgreenwald/mozilla-sops-action@v1.5.0` -> `1.6.0`

This gets rid of
> [Deploy to EKS](https://github.com/didx-xyz/aries-cloudapi-python/actions/runs/8185142066/job/22380921256)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: mdgreenwald/mozilla-sops-action@v1.5.0. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.