### PR TITLE
:bug: fix missing group_id in update/get_tenant response

### DIFF
--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -12,9 +12,7 @@ def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
     label: str = wallet_record.settings["default_label"]
     wallet_name: str = wallet_record.settings["wallet.name"]
     image_url: Optional[str] = wallet_record.settings.get("image_url")
-    group_id: Optional[str] = (
-        wallet_record.group_id if hasattr(wallet_record, "group_id") else None
-    )
+    group_id: Optional[str] = wallet_record.settings.get("wallet.group_id")
 
     return Tenant(
         wallet_id=wallet_record.wallet_id,


### PR DESCRIPTION
Resolves #567

With the group_id plugin changes (appending group_id to wallet record settings), this could now be easily resolved.