### PR TITLE
:sparkles: Improved model validation and exception handling

### DIFF
--- a/app/exceptions/__init__.py
+++ b/app/exceptions/__init__.py
@@ -4,4 +4,5 @@ from aries_cloudcontroller.exceptions import *
 
 from app.exceptions.cloudapi_exception import CloudApiException
 from app.exceptions.handle_acapy_call import handle_acapy_call
+from app.exceptions.handle_model_with_validation import handle_model_with_validation
 from app.exceptions.trust_registry_exception import TrustRegistryException

--- a/app/exceptions/cloudapi_exception.py
+++ b/app/exceptions/cloudapi_exception.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 
 
 class CloudApiException(HTTPException):
-    """Class that represents a cloud api error"""
+    """Class that represents a Cloud API error"""
 
     def __init__(
         self,

--- a/app/exceptions/handle_acapy_call.py
+++ b/app/exceptions/handle_acapy_call.py
@@ -64,5 +64,5 @@ async def handle_acapy_call(
         raise CloudApiException(status_code=e.status, detail=e.reason) from e
     except Exception as e:
         # General exceptions:
-        logger.exception("Unhandled exception")
+        logger.exception("Unexpected exception from ACA-Py call")
         raise CloudApiException(status_code=500, detail="Internal server error") from e

--- a/app/exceptions/handle_acapy_call.py
+++ b/app/exceptions/handle_acapy_call.py
@@ -59,9 +59,20 @@ async def handle_acapy_call(
         )
         raise CloudApiException(status_code=422, detail=error_msg) from e
     except ApiException as e:
-        # Handle 500 errors:
-        logger.warning("Error during {}: {}", method_identifier, e.reason)
-        raise CloudApiException(status_code=e.status, detail=e.reason) from e
+        error_msg = e.reason
+        status = e.status
+        if status == 422:
+            # handle 422 errors:
+            logger.info(
+                "Bad request: Validation error during {}: {}",
+                method_identifier,
+                error_msg,
+            )
+            raise CloudApiException(status_code=422, detail=error_msg) from e
+        else:
+            # Handle other / 500 errors:
+            logger.warning("Error during {}: {}", method_identifier, error_msg)
+            raise CloudApiException(status_code=status, detail=error_msg) from e
     except Exception as e:
         # General exceptions:
         logger.exception("Unexpected exception from ACA-Py call")

--- a/app/exceptions/handle_model_with_validation.py
+++ b/app/exceptions/handle_model_with_validation.py
@@ -1,0 +1,37 @@
+from logging import Logger
+from typing import Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from app.util.extract_validation_error import extract_validation_error_msg
+from shared.exceptions import CloudApiValueError
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def handle_model_with_validation(logger: Logger, model_class: Type[T], **kwargs) -> T:
+    """
+    Attempts to create an instance of a Pydantic model with the given arguments.
+    Logs and raises an CloudApiException if a ValidationError occurs.
+
+    Args:
+        logger: Logger instance for logging the error.
+        model_class: The Pydantic model class to instantiate.
+        **kwargs: Keyword arguments to be passed to the model class for instantiation.
+
+    Returns:
+        An instance of the model class if validation succeeds.
+
+    Raises:
+        CloudApiException with status_code=422 if validation fails.
+    """
+    try:
+        model_instance = model_class(**kwargs)
+        return model_instance
+    except ValidationError as e:
+        error_msg = extract_validation_error_msg(e)
+        model_name = model_class.__name__
+        logger.info(
+            "Bad request: Validation error from {} body: {}", model_name, error_msg
+        )
+        raise CloudApiValueError(detail=error_msg) from e

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,6 @@ from contextlib import asynccontextmanager
 
 import pydantic
 import yaml
-from aiohttp import ClientResponseError
 from aries_cloudcontroller import ApiException
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import HTTPException
@@ -149,12 +148,6 @@ def read_openapi_yaml() -> Response:
 @app.exception_handler(Exception)
 async def client_response_error_exception_handler(_: Request, exception: Exception):
     stacktrace = {"stack": traceback.format_exc()}
-
-    if isinstance(exception, ClientResponseError):
-        return JSONResponse(
-            {"detail": exception.message, **(stacktrace if debug else {})},
-            exception.status or 500,
-        )
 
     if isinstance(exception, CloudApiException):
         return JSONResponse(

--- a/app/main.py
+++ b/app/main.py
@@ -159,7 +159,7 @@ async def client_response_error_exception_handler(
         )
 
     if isinstance(exception, CloudApiValueError):
-        return JSONResponse({"detail": str(exception)}, status_code=422)
+        return JSONResponse({"detail": exception.detail}, status_code=422)
 
     if isinstance(exception, ApiException):
         return JSONResponse(

--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional
 from aries_cloudcontroller import LDProofVCDetail
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
+from shared.exceptions import CloudApiValueError
 from shared.models.protocol import IssueCredentialProtocolVersion
 
 
@@ -31,7 +32,7 @@ class CredentialBase(BaseModel):
     @classmethod
     def check_indy_credential_detail(cls, value, values: ValidationInfo):
         if values.data.get("type") == CredentialType.INDY and value is None:
-            raise ValueError(
+            raise CloudApiValueError(
                 "indy_credential_detail must be populated if `indy` credential type is selected"
             )
         return value
@@ -40,7 +41,7 @@ class CredentialBase(BaseModel):
     @classmethod
     def check_ld_credential_detail(cls, value, values: ValidationInfo):
         if values.data.get("type") == CredentialType.LD_PROOF and value is None:
-            raise ValueError(
+            raise CloudApiValueError(
                 "ld_credential_detail must be populated if `ld_proof` credential type is selected"
             )
         return value

--- a/app/models/jsonld.py
+++ b/app/models/jsonld.py
@@ -1,7 +1,9 @@
 from typing import Any, Dict, Optional
 
 from aries_cloudcontroller import SignatureOptions
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+from shared.exceptions.cloudapi_value_error import CloudApiValueError
 
 
 class JsonLdSignRequest(BaseModel):
@@ -11,8 +13,38 @@ class JsonLdSignRequest(BaseModel):
     pub_did: Optional[str] = None
     signature_options: Optional[SignatureOptions] = None
 
+    @model_validator(mode="before")
+    @classmethod
+    def validate_credential_provided(cls, values):
+        cred, cred_id = values.get("credential"), values.get("credential_id")
+        if not cred and not cred_id:
+            raise CloudApiValueError(
+                "At least one of `credential` or `credential_id` must be provided."
+            )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_not_both_verkey_and_pub_did(cls, values):
+        verkey, pub_did = values.get("verkey"), values.get("pub_did")
+        if verkey and pub_did:
+            raise CloudApiValueError(
+                "Please provide either or neither, but not both, the pub_did or the verkey for the document.",
+            )
+        return values
+
 
 class JsonLdVerifyRequest(BaseModel):
     doc: Dict[str, Any]
     public_did: Optional[str] = None
     verkey: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_not_both_verkey_and_pub_did(cls, values):
+        verkey, pub_did = values.get("verkey"), values.get("public_did")
+        if verkey and pub_did:
+            raise CloudApiValueError(
+                "Please provide either or neither, but not both, the public_did or the verkey for the document.",
+            )
+        return values

--- a/app/models/jws.py
+++ b/app/models/jws.py
@@ -2,6 +2,8 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
+from shared.exceptions import CloudApiValueError
+
 
 class JWSCreateRequest(BaseModel):
     did: Optional[str] = Field(
@@ -23,7 +25,7 @@ class JWSCreateRequest(BaseModel):
     def check_at_least_one_field_is_populated(cls, values):
         did, verification_method = values.get("did"), values.get("verification_method")
         if not did and not verification_method:
-            raise ValueError(
+            raise CloudApiValueError(
                 "At least one of `did` or `verification_method` must be populated."
             )
         return values

--- a/app/models/oob.py
+++ b/app/models/oob.py
@@ -1,7 +1,9 @@
 from typing import List, Optional
 
 from aries_cloudcontroller import AttachmentDef, InvitationMessage
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+
+from shared.exceptions.cloudapi_value_error import CloudApiValueError
 
 
 class ConnectToPublicDid(BaseModel):
@@ -15,6 +17,16 @@ class CreateOobInvitation(BaseModel):
     attachments: Optional[List[AttachmentDef]] = None
     handshake_protocols: Optional[List[str]] = None
     create_connection: Optional[bool] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_one_of_create_connection_or_attachments(cls, values):
+        create, attachments = values.get("create_connection"), values.get("attachments")
+        if not create and not attachments:
+            raise CloudApiValueError(
+                "One or both of 'create_connection' and 'attachments' must be included."
+            )
+        return values
 
 
 class AcceptOobInvitation(BaseModel):

--- a/app/models/tenants.py
+++ b/app/models/tenants.py
@@ -5,6 +5,7 @@ from aries_cloudcontroller import CreateWalletRequest
 from pydantic import BaseModel, Field, field_validator
 
 from app.models.trust_registry import TrustRegistryRole
+from shared.exceptions import CloudApiValueError
 
 # Deduplicate some descriptions and field definitions
 allowable_special_chars = ".!@$*()~_-"  # the dash character must be at the end, otherwise it defines a regex range
@@ -71,10 +72,10 @@ class CreateTenantRequest(BaseModel):
     @classmethod
     def validate_wallet_label(cls, v):
         if len(v) > 100:
-            raise ValueError("wallet_label has a max length of 100 characters")
+            raise CloudApiValueError("wallet_label has a max length of 100 characters")
 
         if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
-            raise ValueError(
+            raise CloudApiValueError(
                 "wallet_label may not contain certain special characters. Must be alphanumeric, may include "
                 f"spaces, and the following special characters are allowed: {allowable_special_chars}"
             )
@@ -85,10 +86,12 @@ class CreateTenantRequest(BaseModel):
     def validate_wallet_name(cls, v):
         if v:
             if len(v) > 100:
-                raise ValueError("wallet_name has a max length of 100 characters")
+                raise CloudApiValueError(
+                    "wallet_name has a max length of 100 characters"
+                )
 
             if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
-                raise ValueError(
+                raise CloudApiValueError(
                     "wallet_name may not contain certain special characters. Must be alphanumeric, may include "
                     f"spaces, and the following special characters are allowed: {allowable_special_chars}"
                 )
@@ -100,10 +103,10 @@ class CreateTenantRequest(BaseModel):
     def validate_group_id(cls, v):
         if v:
             if len(v) > 50:
-                raise ValueError("group_id has a max length of 50 characters")
+                raise CloudApiValueError("group_id has a max length of 50 characters")
 
             if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
-                raise ValueError(
+                raise CloudApiValueError(
                     "group_id may not contain certain special characters. Must be alphanumeric, may include "
                     f"spaces, and the following special characters are allowed: {allowable_special_chars}"
                 )
@@ -123,10 +126,12 @@ class UpdateTenantRequest(BaseModel):
     @classmethod
     def validate_wallet_label(cls, v):
         if len(v) > 100:
-            raise ValueError("wallet_label must be less than 100 characters long")
+            raise CloudApiValueError(
+                "wallet_label must be less than 100 characters long"
+            )
 
         if not re.match(rf"^[a-zA-Z0-9 {allowable_special_chars}]+$", v):
-            raise ValueError(
+            raise CloudApiValueError(
                 "wallet_label may not contain certain special characters. Must be alphanumeric, may include "
                 f"spaces, and the following special characters are allowed: {allowable_special_chars}"
             )

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -28,16 +28,18 @@ class ProofRequestBase(BaseModel):
     @field_validator("indy_proof_request", mode="before")
     @classmethod
     def check_indy_proof_request(cls, value, values: ValidationInfo):
-        if values.data.get("type") == ProofRequestType.INDY and value is None:
+        proof_type = values.data.get("type")
+
+        if proof_type == ProofRequestType.INDY and value is None:
             raise CloudApiValueError(
                 "indy_proof_request must be populated if `indy` type is selected"
             )
 
         if (
-            values.data.get("type") == ProofRequestType.INDY
+            proof_type == ProofRequestType.INDY
             and values.data.get("dif_proof_request") is not None
         ):
-            raise ValueError(
+            raise CloudApiValueError(
                 "dif_proof_request must not be populated if `indy` type is selected"
             )
         return value
@@ -45,15 +47,18 @@ class ProofRequestBase(BaseModel):
     @field_validator("dif_proof_request", mode="before")
     @classmethod
     def check_dif_proof_request(cls, value, values: ValidationInfo):
-        if values.data.get("type") == ProofRequestType.LD_PROOF and value is None:
+        proof_type = values.data.get("type")
+
+        if proof_type == ProofRequestType.LD_PROOF and value is None:
             raise CloudApiValueError(
                 "dif_proof_request must be populated if `ld_proof` type is selected"
             )
+
         if (
-            values.data.get("type") == ProofRequestType.LD_PROOF
+            proof_type == ProofRequestType.LD_PROOF
             and values.data.get("indy_proof_request") is not None
         ):
-            raise ValueError(
+            raise CloudApiValueError(
                 "indy_proof_request must not be populated if `ld_proof` type is selected"
             )
         return value

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -5,6 +5,7 @@ from aries_cloudcontroller import DIFPresSpec, DIFProofRequest, IndyPresSpec
 from aries_cloudcontroller import IndyProofRequest as AcaPyIndyProofRequest
 from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
+from shared.exceptions import CloudApiValueError
 from shared.models.protocol import PresentProofProtocolVersion
 
 
@@ -28,7 +29,7 @@ class ProofRequestBase(BaseModel):
     @classmethod
     def check_indy_proof_request(cls, value, values: ValidationInfo):
         if values.data.get("type") == ProofRequestType.INDY and value is None:
-            raise ValueError(
+            raise CloudApiValueError(
                 "indy_proof_request must be populated if `indy` type is selected"
             )
 
@@ -45,7 +46,7 @@ class ProofRequestBase(BaseModel):
     @classmethod
     def check_dif_proof_request(cls, value, values: ValidationInfo):
         if values.data.get("type") == ProofRequestType.LD_PROOF and value is None:
-            raise ValueError(
+            raise CloudApiValueError(
                 "dif_proof_request must be populated if `ld_proof` type is selected"
             )
         if (
@@ -92,7 +93,7 @@ class AcceptProofRequest(ProofId):
     @classmethod
     def check_indy_presentation_spec(cls, value, values: ValidationInfo):
         if values.data.get("type") == ProofRequestType.INDY and value is None:
-            raise ValueError(
+            raise CloudApiValueError(
                 "indy_presentation_spec must be populated if `indy` type is selected"
             )
         return value
@@ -101,7 +102,7 @@ class AcceptProofRequest(ProofId):
     @classmethod
     def check_dif_presentation_spec(cls, value, values: ValidationInfo):
         if values.data.get("type") == ProofRequestType.LD_PROOF and value is None:
-            raise ValueError(
+            raise CloudApiValueError(
                 "dif_presentation_spec must be populated if `ld_proof` type is selected"
             )
         return value

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -111,7 +111,6 @@ async def get_connection_by_id(
     Parameters:
     -----------
     connection_id: str
-
     """
     bound_logger = logger.bind(body={"connection_id": connection_id})
     bound_logger.info("GET request received: Get connection by ID")
@@ -141,10 +140,6 @@ async def delete_connection_by_id(
     Parameters:
     -----------
     connection_id: str
-
-    Returns:
-    ------------
-    Empty dict: {}
     """
     bound_logger = logger.bind(body={"connection_id": connection_id})
     bound_logger.info("DELETE request received: Delete connection by ID")

--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/v1/connections", tags=["connections"])
 async def create_invitation(
     body: Optional[CreateInvitation] = None,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> InvitationResult:
     """
     Create connection invitation.
     """
@@ -104,7 +104,7 @@ async def get_connections(
 async def get_connection_by_id(
     connection_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> Connection:
     """
     Retrieve connection by id.
 
@@ -130,11 +130,11 @@ async def get_connection_by_id(
     return result
 
 
-@router.delete("/{connection_id}")
+@router.delete("/{connection_id}", status_code=204)
 async def delete_connection_by_id(
     connection_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> None:
     """
     Delete connection by id.
 
@@ -157,4 +157,3 @@ async def delete_connection_by_id(
         )
 
     bound_logger.info("Successfully deleted connection by ID.")
-    return {}

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -17,7 +17,12 @@ from app.dependencies.auth import (
     acapy_auth_governance,
     acapy_auth_verified,
 )
-from app.exceptions import CloudApiException, TrustRegistryException
+from app.exceptions import (
+    CloudApiException,
+    TrustRegistryException,
+    handle_acapy_call,
+    handle_model_with_validation,
+)
 from app.models.definitions import (
     CreateCredentialDefinition,
     CreateSchema,
@@ -86,7 +91,9 @@ async def get_credential_definitions(
     # Get all created credential definition ids that match the filter
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Getting created credential definitions")
-        response = await aries_controller.credential_definition.get_created_cred_defs(
+        response = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credential_definition.get_created_cred_defs,
             issuer_did=issuer_did,
             cred_def_id=credential_definition_id,
             schema_id=schema_id,
@@ -98,8 +105,10 @@ async def get_credential_definitions(
         # Initiate retrieving all credential definitions
         credential_definition_ids = response.credential_definition_ids or []
         get_credential_definition_futures = [
-            aries_controller.credential_definition.get_cred_def(
-                cred_def_id=credential_definition_id
+            handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.credential_definition.get_cred_def,
+                cred_def_id=credential_definition_id,
             )
             for credential_definition_id in credential_definition_ids
         ]
@@ -152,10 +161,10 @@ async def get_credential_definition_by_id(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Getting credential definition")
-        credential_definition = (
-            await aries_controller.credential_definition.get_cred_def(
-                cred_def_id=credential_definition_id
-            )
+        credential_definition = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credential_definition.get_cred_def,
+            cred_def_id=credential_definition_id,
         )
 
         if not credential_definition.credential_definition:
@@ -250,8 +259,10 @@ async def create_credential_definition(
         await assert_valid_issuer(public_did, credential_definition.schema_id)
 
         if support_revocation:
-            endorser_connection = await aries_controller.connection.get_connections(
-                alias=ACAPY_ENDORSER_ALIAS
+            endorser_connection = await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.connection.get_connections,
+                alias=ACAPY_ENDORSER_ALIAS,
             )
             has_connections = len(endorser_connection.results) > 0
 
@@ -267,33 +278,37 @@ async def create_credential_definition(
                     "to support revocation. Please establish a connection with an endorser and try again."
                 )
 
-        listener = SseListener(topic="endorsements", wallet_id=auth.wallet_id)
-
         bound_logger.debug("Publishing credential definition")
+        request_body = handle_model_with_validation(
+            logger=bound_logger,
+            model_class=CredentialDefinitionSendRequest,
+            schema_id=credential_definition.schema_id,
+            support_revocation=support_revocation,
+            tag=credential_definition.tag,
+            revocation_registry_size=rev_reg_size,
+        )
         try:
-            result = await aries_controller.credential_definition.publish_cred_def(
-                body=CredentialDefinitionSendRequest(
-                    schema_id=credential_definition.schema_id,
-                    support_revocation=support_revocation,
-                    tag=credential_definition.tag,
-                    revocation_registry_size=rev_reg_size,
-                ),
+            result = await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.credential_definition.publish_cred_def,
+                body=request_body,
             )
             credential_definition_id = result.sent.credential_definition_id
-        except ApiException as e:
+        except CloudApiException as e:
             bound_logger.warning(
-                "An ApiException was caught while publishing credential definition: `{}` `{}`",
-                e.reason,
-                e.status,
+                "An Exception was caught while publishing credential definition: `{}` `{}`",
+                e.detail,
+                e.status_code,
             )
-            if "already exists" in e.reason:
-                raise CloudApiException(status_code=409, detail=e.reason) from e
+            if "already exists" in e.detail:
+                raise CloudApiException(status_code=409, detail=e.detail) from e
             else:
                 raise CloudApiException(
-                    detail=f"Error while creating credential definition: {e.reason}",
-                    status_code=e.status,
+                    detail=f"Error while creating credential definition: {e.detail}",
+                    status_code=e.status_code,
                 ) from e
 
+        listener = SseListener(topic="endorsements", wallet_id=auth.wallet_id)
         # Wait for cred_def transaction to be acknowledged
         if result.txn and result.txn.transaction_id:
             bound_logger.debug(
@@ -375,7 +390,9 @@ async def get_schemas(
     # Get all created schema ids that match the filter
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Fetching created schemas")
-        response = await aries_controller.schema.get_created_schemas(
+        response = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.schema.get_created_schemas,
             schema_id=schema_id,
             schema_issuer_did=schema_issuer_did,
             schema_name=schema_name,
@@ -385,7 +402,11 @@ async def get_schemas(
         # Initiate retrieving all schemas
         schema_ids = response.schema_ids or []
         get_schema_futures = [
-            aries_controller.schema.get_schema(schema_id=schema_id)
+            handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.schema.get_schema,
+                schema_id=schema_id,
+            )
             for schema_id in schema_ids
         ]
 
@@ -430,8 +451,11 @@ async def get_schema(
     bound_logger.info("GET request received: Get schema by id")
 
     async with client_from_auth(auth) as aries_controller:
-        bound_logger.debug("Fetching schema")
-        schema = await aries_controller.schema.get_schema(schema_id=schema_id)
+        schema = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.schema.get_schema,
+            schema_id=schema_id,
+        )
 
     if not schema.var_schema:
         bound_logger.info("Bad request: schema id not found.")
@@ -463,7 +487,9 @@ async def create_schema(
     bound_logger = logger.bind(body=schema)
     bound_logger.info("POST request received: Create schema (publish and register)")
 
-    schema_send_request = SchemaSendRequest(
+    schema_send_request = handle_model_with_validation(
+        logger=bound_logger,
+        model_class=SchemaSendRequest,
         attributes=schema.attribute_names,
         schema_name=schema.name,
         schema_version=schema.version,
@@ -471,26 +497,34 @@ async def create_schema(
     async with get_governance_controller(governance_auth) as aries_controller:
         try:
             bound_logger.info("Publishing schema as governance")
-            result = await aries_controller.schema.publish_schema(
-                body=schema_send_request, create_transaction_for_endorser=False
+            result = await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=aries_controller.schema.publish_schema,
+                body=schema_send_request,
+                create_transaction_for_endorser=False,
             )
-        except ApiException as e:
+        except CloudApiException as e:
             bound_logger.info(
-                "ApiException caught while trying to publish schema: `{}`",
-                e.reason,
+                "An Exception was caught while trying to publish schema: `{}`",
+                e.detail,
             )
-            if e.status == 400 and "already exist" in e.reason:
+            if e.status_code == 400 and "already exist" in e.detail:
                 bound_logger.info("Handling case of schema already existing on ledger")
                 bound_logger.debug("Fetching public DID for governance controller")
-                pub_did = await aries_controller.wallet.get_public_did()
+                pub_did = await handle_acapy_call(
+                    logger=bound_logger,
+                    acapy_call=aries_controller.wallet.get_public_did,
+                )
 
                 _schema_id = f"{pub_did.result.did}:2:{schema.name}:{schema.version}"
                 bound_logger.debug(
                     "Fetching schema id `{}` which is associated with request",
                     _schema_id,
                 )
-                _schema: SchemaGetResult = await aries_controller.schema.get_schema(
-                    schema_id=_schema_id
+                _schema: SchemaGetResult = await handle_acapy_call(
+                    logger=bound_logger,
+                    acapy_call=aries_controller.schema.get_schema,
+                    schema_id=_schema_id,
                 )
                 # Edge case where the governance agent has changed its public did
                 # Then we need to retrieve the schema in a different way as constructing the schema ID the way above
@@ -500,14 +534,19 @@ async def create_schema(
                         "Schema not found. Governance agent may have changed public DID. "
                         "Fetching schemas created by governance agent with request name and version"
                     )
-                    schemas_created_ids = (
-                        await aries_controller.schema.get_created_schemas(
-                            schema_name=schema.name, schema_version=schema.version
-                        )
+                    schemas_created_ids = await handle_acapy_call(
+                        logger=bound_logger,
+                        acapy_call=aries_controller.schema.get_created_schemas,
+                        schema_name=schema.name,
+                        schema_version=schema.version,
                     )
                     bound_logger.debug("Getting schemas associated with fetched ids")
                     schemas: List[SchemaGetResult] = [
-                        await aries_controller.schema.get_schema(schema_id=schema_id)
+                        await handle_acapy_call(
+                            logger=bound_logger,
+                            acapy_call=aries_controller.schema.get_schema,
+                            schema_id=schema_id,
+                        )
                         for schema_id in schemas_created_ids.schema_ids
                         if schema_id
                     ]
@@ -541,8 +580,8 @@ async def create_schema(
                 return result
             else:
                 bound_logger.warning(
-                    "An unhandled ApiException was caught while publishing schema. The error message is: '{}'.",
-                    e.reason,
+                    "An unhandled Exception was caught while publishing schema. The error message is: '{}'.",
+                    e.detail,
                 )
                 raise CloudApiException("Error while creating schema.") from e
 

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -2,7 +2,6 @@ import asyncio
 from typing import List, Optional
 
 from aries_cloudcontroller import (
-    ApiException,
     CredentialDefinitionSendRequest,
     SchemaGetResult,
     SchemaSendRequest,

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from aries_cloudcontroller import ApiException, IssuerCredRevRecord
+from aries_cloudcontroller import IssuerCredRevRecord
 from fastapi import APIRouter, Depends, Query
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -149,13 +149,9 @@ async def send_credential(
             result = await issuer.send_credential(
                 controller=aries_controller, credential=credential
             )
-        except ApiException as e:
-            logger.warning(
-                "An ApiException was caught while sending credentials, with message `{}`.",
-                e.reason,
-            )
+        except CloudApiException as e:
             raise CloudApiException(
-                f"Failed to create or send credential: {e.reason}", e.status
+                f"Failed to send credential: {e.detail}", e.status_code
             ) from e
 
     if result:

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -37,7 +37,7 @@ router = APIRouter(prefix="/v1/issuer/credentials", tags=["issuer"])
 async def get_credentials(
     connection_id: Optional[str] = Query(None),
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> List[CredentialExchange]:
     """
         Get a list of credential records.
 
@@ -71,7 +71,7 @@ async def get_credentials(
 async def get_credential(
     credential_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredentialExchange:
     """
         Get a credential by credential id.
 
@@ -102,7 +102,7 @@ async def get_credential(
 async def send_credential(
     credential: SendCredential,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredentialExchange:
     """
         Create and send a credential. Automating the entire flow.
 
@@ -169,7 +169,7 @@ async def send_credential(
 async def create_offer(
     credential: CreateOffer,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredentialExchange:
     """
         Create a credential offer not bound to any connection.
 
@@ -440,7 +440,7 @@ async def get_credential_revocation_record(
 async def request_credential(
     credential_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredentialExchange:
     """
         Send a credential request.
 
@@ -495,7 +495,7 @@ async def request_credential(
 async def store_credential(
     credential_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredentialExchange:
     """
         Store a credential.
 

--- a/app/routes/oob.py
+++ b/app/routes/oob.py
@@ -1,10 +1,11 @@
 from typing import Optional
 
 from aries_cloudcontroller import InvitationCreateRequest, InvitationRecord, OobRecord
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
 from app.dependencies.auth import AcaPyAuth, acapy_auth
+from app.exceptions import handle_acapy_call, handle_model_with_validation
 from app.models.oob import AcceptOobInvitation, ConnectToPublicDid, CreateOobInvitation
 from app.util.credentials import strip_protocol_prefix
 from shared.log_config import get_logger
@@ -28,26 +29,34 @@ async def create_oob_invitation(
     if body is None:
         body = CreateOobInvitation()
 
-    handshake_protocols = [
-        "https://didcomm.org/didexchange/1.0",
-        "https://didcomm.org/connections/1.0",
-    ]
+    handshake_protocols = (
+        [
+            "https://didcomm.org/didexchange/1.0",
+            "https://didcomm.org/connections/1.0",
+        ]
+        if body.create_connection
+        else None
+    )
 
     if body.attachments:
         for item in body.attachments:
             if item.id:  # Optional field
                 item.id = strip_protocol_prefix(item.id)
 
-    oob_body = InvitationCreateRequest(
+    oob_body = handle_model_with_validation(
+        logger=bound_logger,
+        model_class=InvitationCreateRequest,
         alias=body.alias,
         attachments=body.attachments,
-        handshake_protocols=handshake_protocols if body.create_connection else None,
+        handshake_protocols=handshake_protocols,
         use_public_did=body.use_public_did,
     )
 
+    bound_logger.debug("Creating invitation")
     async with client_from_auth(auth) as aries_controller:
-        logger.bind(body=oob_body).debug("Creating invitation")
-        invitation = await aries_controller.out_of_band.create_invitation(
+        invitation = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.out_of_band.create_invitation,
             multi_use=body.multi_use,
             body=oob_body,
             auto_accept=True,
@@ -71,8 +80,9 @@ async def accept_oob_invitation(
     bound_logger.info("POST request received: Accept OOB invitation")
 
     async with client_from_auth(auth) as aries_controller:
-        bound_logger.debug("Accepting invitation")
-        oob_record = await aries_controller.out_of_band.receive_invitation(
+        oob_record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.out_of_band.receive_invitation,
             auto_accept=True,
             use_existing_connection=body.use_existing_connection,
             alias=body.alias,
@@ -106,9 +116,10 @@ async def connect_to_public_did(
     bound_logger = logger.bind(body=body)
     bound_logger.info("POST request received: Connect to public DID")
     async with client_from_auth(auth) as aries_controller:
-        bound_logger.debug("Creating DID exchange request")
-        conn_record = await aries_controller.did_exchange.create_request(
-            their_public_did=body.public_did
+        conn_record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.did_exchange.create_request,
+            their_public_did=body.public_did,
         )
 
     result = conn_record_to_connection(conn_record)

--- a/app/routes/oob.py
+++ b/app/routes/oob.py
@@ -33,12 +33,6 @@ async def create_oob_invitation(
         "https://didcomm.org/connections/1.0",
     ]
 
-    if not body.create_connection and not body.attachments:
-        raise HTTPException(
-            400,
-            "One or both of 'create_connection' and 'attachments' must be included.",
-        )
-
     if body.attachments:
         for item in body.attachments:
             if item.id:  # Optional field

--- a/app/routes/wallet/credentials.py
+++ b/app/routes/wallet/credentials.py
@@ -33,8 +33,12 @@ async def list_credentials(
 
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Fetching credentials")
-        results = await aries_controller.credentials.get_records(
-            count=count, start=start, wql=wql
+        results = await handle_acapy_call(
+            logger=logger,
+            acapy_call=aries_controller.credentials.get_records,
+            count=count,
+            start=start,
+            wql=wql,
         )
 
     logger.info("Successfully listed credentials.")
@@ -73,8 +77,10 @@ async def delete_credential(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Deleting credential")
-        result = await aries_controller.credentials.delete_record(
-            credential_id=credential_id
+        await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credentials.delete_record,
+            credential_id=credential_id,
         )
 
     bound_logger.info("Successfully deleted credential.")
@@ -93,8 +99,10 @@ async def get_credential_mime_types(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Fetching MIME types")
-        result = await aries_controller.credentials.get_credential_mime_types(
-            credential_id=credential_id
+        result = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credentials.get_credential_mime_types,
+            credential_id=credential_id,
         )
 
     bound_logger.info("Successfully fetched attribute MIME types.")
@@ -116,8 +124,12 @@ async def get_credential_revocation_status(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Fetching revocation status")
-        result = await aries_controller.credentials.get_revocation_status(
-            credential_id=credential_id, var_from=from_, to=to
+        result = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credentials.get_revocation_status,
+            credential_id=credential_id,
+            var_from=from_,
+            to=to,
         )
 
     bound_logger.info("Successfully fetched revocation status.")
@@ -137,8 +149,13 @@ async def list_w3c_credentials(
 
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Fetching W3C credentials")
-        results = await aries_controller.credentials.get_w3c_credentials(
-            count=count, start=start, wql=wql, body=body
+        results = await handle_acapy_call(
+            logger=logger,
+            acapy_call=aries_controller.credentials.get_w3c_credentials,
+            count=count,
+            start=start,
+            wql=wql,
+            body=body,
         )
 
     logger.info("Successfully listed W3C credentials.")
@@ -156,8 +173,10 @@ async def get_w3c_credential(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Fetching W3C credential")
-        result = await aries_controller.credentials.get_w3c_credential(
-            credential_id=credential_id
+        result = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credentials.get_w3c_credential,
+            credential_id=credential_id,
         )
 
     bound_logger.info("Successfully fetched W3C credential.")
@@ -175,8 +194,10 @@ async def delete_w3c_credential(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Deleting W3C credential")
-        result = await aries_controller.credentials.delete_w3c_credential(
-            credential_id=credential_id
+        await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=aries_controller.credentials.delete_w3c_credential,
+            credential_id=credential_id,
         )
 
     bound_logger.info("Successfully deleted W3C credential.")

--- a/app/routes/wallet/credentials.py
+++ b/app/routes/wallet/credentials.py
@@ -27,7 +27,7 @@ async def list_credentials(
     start: Optional[str] = None,
     wql: Optional[str] = None,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredInfoList:
     """Fetch a list of credentials from the wallet."""
     logger.info("GET request received: List credentials")
 
@@ -45,7 +45,7 @@ async def list_credentials(
 async def get_credential_record(
     credential_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> IndyCredInfo:
     """Fetch a specific credential by ID."""
     bound_logger = logger.bind(credential_id=credential_id)
     bound_logger.info("GET request received: Fetch specific credential by ID")
@@ -78,14 +78,13 @@ async def delete_credential(
         )
 
     bound_logger.info("Successfully deleted credential.")
-    return result
 
 
 @router.get("/{credential_id}/mime-types", response_model=AttributeMimeTypesResult)
 async def get_credential_mime_types(
     credential_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> AttributeMimeTypesResult:
     """Retrieve attribute MIME types of a specific credential by ID."""
     bound_logger = logger.bind(credential_id=credential_id)
     bound_logger.info(
@@ -108,7 +107,7 @@ async def get_credential_revocation_status(
     from_: Optional[str] = None,
     to: Optional[str] = None,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> CredRevokedResult:
     """Query the revocation status of a specific credential by ID."""
     bound_logger = logger.bind(credential_id=credential_id)
     bound_logger.info(
@@ -132,7 +131,7 @@ async def list_w3c_credentials(
     wql: Optional[str] = None,
     body: Optional[W3CCredentialsListRequest] = None,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> VCRecordList:
     """Fetch a list of W3C credentials from the wallet."""
     logger.info("GET request received: List W3C credentials")
 
@@ -150,7 +149,7 @@ async def list_w3c_credentials(
 async def get_w3c_credential(
     credential_id: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> VCRecord:
     """Fetch a specific W3C credential by ID."""
     bound_logger = logger.bind(credential_id=credential_id)
     bound_logger.info("GET request received: Fetch specific W3C credential by ID")
@@ -181,4 +180,3 @@ async def delete_w3c_credential(
         )
 
     bound_logger.info("Successfully deleted W3C credential.")
-    return result

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -36,7 +36,7 @@ async def create_did(
 @router.get("", response_model=List[DID])
 async def list_dids(
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> List[DID]:
     """
     Retrieve list of DIDs.
     """
@@ -57,7 +57,7 @@ async def list_dids(
 @router.get("/public", response_model=DID)
 async def get_public_did(
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> DID:
     """
     Fetch the current public DID.
     """
@@ -79,7 +79,7 @@ async def get_public_did(
 async def set_public_did(
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> DID:
     """Set the current public DID."""
     logger.info("PUT request received: Set public DID")
 
@@ -109,7 +109,7 @@ async def rotate_keypair(
 async def get_did_endpoint(
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth),
-):
+) -> DIDEndpoint:
     """Get DID endpoint."""
     bound_logger = logger.bind(body={"did": did})
     bound_logger.info("GET request received: Get endpoint for DID")

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -5,7 +5,11 @@ from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
 from app.dependencies.auth import AcaPyAuth, acapy_auth
-from app.exceptions import CloudApiException
+from app.exceptions import (
+    CloudApiException,
+    handle_acapy_call,
+    handle_model_with_validation,
+)
 from app.models.wallet import SetDidEndpointRequest
 from app.services import acapy_wallet
 from shared.log_config import get_logger
@@ -44,7 +48,9 @@ async def list_dids(
 
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Fetching DIDs")
-        did_result = await aries_controller.wallet.get_dids()
+        did_result = await handle_acapy_call(
+            logger=logger, acapy_call=aries_controller.wallet.get_dids
+        )
 
     if not did_result.results:
         logger.info("No DIDs returned.")
@@ -65,7 +71,9 @@ async def get_public_did(
 
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Fetching public DID")
-        result = await aries_controller.wallet.get_public_did()
+        result = await handle_acapy_call(
+            logger=logger, acapy_call=aries_controller.wallet.get_public_did
+        )
 
     if not result.result:
         logger.info("Bad request: no public DID found.")
@@ -100,7 +108,9 @@ async def rotate_keypair(
     bound_logger.info("PATCH request received: Rotate keypair for DID")
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Rotating keypair")
-        await aries_controller.wallet.rotate_keypair(did=did)
+        await handle_acapy_call(
+            logger=logger, acapy_call=aries_controller.wallet.rotate_keypair, did=did
+        )
 
     bound_logger.info("Successfully rotated keypair.")
 
@@ -115,7 +125,9 @@ async def get_did_endpoint(
     bound_logger.info("GET request received: Get endpoint for DID")
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Fetching DID endpoint")
-        result = await aries_controller.wallet.get_did_endpoint(did=did)
+        result = await handle_acapy_call(
+            logger=logger, acapy_call=aries_controller.wallet.get_did_endpoint, did=did
+        )
 
     bound_logger.info("Successfully fetched DID endpoint.")
     return result
@@ -135,12 +147,20 @@ async def set_did_endpoint(
 
     endpoint_type = "Endpoint"
 
+    request_body = handle_model_with_validation(
+        logger=bound_logger,
+        model_class=DIDEndpointWithType,
+        did=did,
+        endpoint=body.endpoint,
+        endpoint_type=endpoint_type,
+    )
+
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Setting DID endpoint")
-        await aries_controller.wallet.set_did_endpoint(
-            body=DIDEndpointWithType(
-                did=did, endpoint=body.endpoint, endpoint_type=endpoint_type
-            )
+        await handle_acapy_call(
+            logger=logger,
+            acapy_call=aries_controller.wallet.set_did_endpoint,
+            body=request_body,
         )
 
     bound_logger.info("Successfully set DID endpoint.")

--- a/app/services/acapy_wallet.py
+++ b/app/services/acapy_wallet.py
@@ -3,7 +3,7 @@ from typing import Optional
 from aries_cloudcontroller import DID, AcaPyClient, DIDCreate
 from pydantic import BaseModel
 
-from app.exceptions import CloudApiException
+from app.exceptions import CloudApiException, handle_acapy_call
 from app.util.did import qualified_did_sov
 from shared.log_config import get_logger
 
@@ -26,7 +26,9 @@ async def assert_public_did(aries_controller: AcaPyClient) -> str:
     """
     # Assert the agent has a public did
     logger.info("Fetching public DID")
-    public_did = await aries_controller.wallet.get_public_did()
+    public_did = await handle_acapy_call(
+        logger=logger, acapy_call=aries_controller.wallet.get_public_did
+    )
 
     if not public_did.result or not public_did.result.did:
         raise CloudApiException("Agent has no public did.", 403)
@@ -53,7 +55,9 @@ async def create_did(
     logger.info("Creating local DID")
     if did_create is None:
         did_create = DIDCreate()
-    did_result = await controller.wallet.create_did(body=did_create)
+    did_result = await handle_acapy_call(
+        logger=logger, acapy_call=controller.wallet.create_did, body=did_create
+    )
 
     if (
         not did_result.result
@@ -86,7 +90,9 @@ async def set_public_did(
         DID: the did
     """
     logger.info("Setting public DID")
-    result = await controller.wallet.set_public_did(
+    result = await handle_acapy_call(
+        logger=logger,
+        acapy_call=controller.wallet.set_public_did,
         did=did,
         conn_id=connection_id,
         create_transaction_for_endorser=create_transaction_for_endorser,
@@ -112,7 +118,9 @@ async def get_public_did(controller: AcaPyClient) -> Did:
         Did: the public did
     """
     logger.info("Fetching public DID")
-    result = await controller.wallet.get_public_did()
+    result = await handle_acapy_call(
+        logger=logger, acapy_call=controller.wallet.get_public_did
+    )
 
     if not result.result:
         raise CloudApiException("No public did found", 404)

--- a/app/services/acapy_wallet.py
+++ b/app/services/acapy_wallet.py
@@ -4,6 +4,7 @@ from aries_cloudcontroller import DID, AcaPyClient, DIDCreate
 from pydantic import BaseModel
 
 from app.exceptions import CloudApiException
+from app.util.did import qualified_did_sov
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)
@@ -31,7 +32,8 @@ async def assert_public_did(aries_controller: AcaPyClient) -> str:
         raise CloudApiException("Agent has no public did.", 403)
 
     logger.info("Successfully fetched public DID.")
-    return f"did:sov:{public_did.result.did}"
+
+    return qualified_did_sov(public_did.result.did)
 
 
 async def create_did(

--- a/app/services/issuer/acapy_issuer.py
+++ b/app/services/issuer/acapy_issuer.py
@@ -102,7 +102,7 @@ class Issuer(ABC):
     @abstractmethod
     async def delete_credential_exchange_record(
         cls, controller: AcaPyClient, credential_exchange_id: str
-    ):
+    ) -> None:
         """Delete credential record.
 
         Parameters:

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -88,7 +88,11 @@ class IssuerV1(Issuer):
             cred_def_id=credential.indy_credential_detail.credential_definition_id,
         )
 
-        record = await controller.issue_credential_v1_0.create_offer(body=request_body)
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v1_0.create_offer,
+            body=request_body,
+        )
 
         bound_logger.debug("Returning v1 create offer result as CredentialExchange.")
         return cls.__record_to_model(record)

--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from aries_cloudcontroller import (
     AcaPyClient,
@@ -27,7 +27,7 @@ class IssuerV1(Issuer):
     @classmethod
     async def send_credential(
         cls, controller: AcaPyClient, credential: CredentialWithConnection
-    ):
+    ) -> CredentialExchange:
         if credential.type != CredentialType.INDY:
             raise CloudApiException(
                 f"Only Indy credential types are supported in v1. Requested type: {credential.type}",
@@ -55,7 +55,9 @@ class IssuerV1(Issuer):
         return cls.__record_to_model(record)
 
     @classmethod
-    async def create_offer(cls, controller: AcaPyClient, credential: CredentialBase):
+    async def create_offer(
+        cls, controller: AcaPyClient, credential: CredentialBase
+    ) -> CredentialExchange:
         if credential.type != CredentialType.INDY:
             raise CloudApiException(
                 f"Only Indy credential types are supported in v1. Requested type: {credential.type}",
@@ -86,7 +88,7 @@ class IssuerV1(Issuer):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
-    ):
+    ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )
@@ -104,7 +106,7 @@ class IssuerV1(Issuer):
     @classmethod
     async def store_credential(
         cls, controller: AcaPyClient, credential_exchange_id: str
-    ):
+    ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )
@@ -124,7 +126,7 @@ class IssuerV1(Issuer):
     @classmethod
     async def delete_credential_exchange_record(
         cls, controller: AcaPyClient, credential_exchange_id: str
-    ):
+    ) -> None:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )
@@ -152,7 +154,7 @@ class IssuerV1(Issuer):
     @classmethod
     async def get_records(
         cls, controller: AcaPyClient, connection_id: Optional[str] = None
-    ):
+    ) -> List[CredentialExchange]:
         bound_logger = logger.bind(body={"connection_id": connection_id})
         bound_logger.debug("Getting v1 credential records by connection id")
         result = await controller.issue_credential_v1_0.get_records(
@@ -167,7 +169,9 @@ class IssuerV1(Issuer):
         return [cls.__record_to_model(record) for record in result.results]
 
     @classmethod
-    async def get_record(cls, controller: AcaPyClient, credential_exchange_id: str):
+    async def get_record(
+        cls, controller: AcaPyClient, credential_exchange_id: str
+    ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -13,7 +13,11 @@ from aries_cloudcontroller import (
     V20CredStoreRequest,
 )
 
-from app.exceptions import CloudApiException
+from app.exceptions import (
+    CloudApiException,
+    handle_acapy_call,
+    handle_model_with_validation,
+)
 from app.models.issuer import CredentialBase, CredentialType, CredentialWithConnection
 from app.services.issuer.acapy_issuer import Issuer
 from app.util.credentials import cred_id_no_version
@@ -40,11 +44,13 @@ class IssuerV2(Issuer):
             credential_preview = cls.__preview_from_attributes(
                 attributes=credential.indy_credential_detail.attributes
             )
-            cred_filter = V20CredFilter(
-                indy=V20CredFilterIndy(
-                    cred_def_id=credential.indy_credential_detail.credential_definition_id,
-                )
+
+            indy_model = handle_model_with_validation(
+                logger=bound_logger,
+                model_class=V20CredFilterIndy,
+                cred_def_id=credential.indy_credential_detail.credential_definition_id,
             )
+            cred_filter = V20CredFilter(indy=indy_model)
         elif credential.type == CredentialType.LD_PROOF:
             cred_filter = V20CredFilter(ld_proof=credential.ld_credential_detail)
         else:
@@ -53,14 +59,16 @@ class IssuerV2(Issuer):
             )
 
         bound_logger.debug("Issue v2 credential (automated)")
-        auto_remove = not credential.save_exchange_record
-        record = await controller.issue_credential_v2_0.issue_credential_automated(
-            body=V20CredExFree(
-                auto_remove=auto_remove,
-                connection_id=credential.connection_id,
-                filter=cred_filter,
-                credential_preview=credential_preview,
-            )
+        request_body = V20CredExFree(
+            auto_remove=not credential.save_exchange_record,
+            connection_id=credential.connection_id,
+            filter=cred_filter,
+            credential_preview=credential_preview,
+        )
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.issue_credential_automated,
+            body=request_body,
         )
 
         bound_logger.debug("Returning v2 credential result as CredentialExchange.")
@@ -79,11 +87,12 @@ class IssuerV2(Issuer):
             credential_preview = cls.__preview_from_attributes(
                 attributes=credential.indy_credential_detail.attributes
             )
-            cred_filter = V20CredFilter(
-                indy=V20CredFilterIndy(
-                    cred_def_id=credential.indy_credential_detail.credential_definition_id,
-                )
+            indy_model = handle_model_with_validation(
+                logger=bound_logger,
+                model_class=V20CredFilterIndy,
+                cred_def_id=credential.indy_credential_detail.credential_definition_id,
             )
+            cred_filter = V20CredFilter(indy=indy_model)
         elif credential.type == CredentialType.LD_PROOF:
             cred_filter = V20CredFilter(ld_proof=credential.ld_credential_detail)
         else:
@@ -92,15 +101,15 @@ class IssuerV2(Issuer):
             )
 
         bound_logger.debug("Creating v2 credential offer")
-        auto_remove = not credential.save_exchange_record
-        record = (
-            await controller.issue_credential_v2_0.issue_credential20_create_offer_post(
-                body=V20CredOfferConnFreeRequest(
-                    auto_remove=auto_remove,
-                    credential_preview=credential_preview,
-                    filter=cred_filter,
-                )
-            )
+        request_body = V20CredOfferConnFreeRequest(
+            auto_remove=not credential.save_exchange_record,
+            credential_preview=credential_preview,
+            filter=cred_filter,
+        )
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.issue_credential20_create_offer_post,
+            body=request_body,
         )
 
         bound_logger.debug("Returning v2 create offer result as CredentialExchange.")
@@ -119,8 +128,12 @@ class IssuerV2(Issuer):
         credential_exchange_id = cred_id_no_version(credential_exchange_id)
 
         bound_logger.debug("Sending v2 credential request")
-        record = await controller.issue_credential_v2_0.send_request(
-            cred_ex_id=credential_exchange_id, body=V20CredRequestRequest()
+        request_body = V20CredRequestRequest()
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.send_request,
+            cred_ex_id=credential_exchange_id,
+            body=request_body,
         )
 
         bound_logger.debug("Returning v2 send request result as CredentialExchange.")
@@ -137,8 +150,12 @@ class IssuerV2(Issuer):
         credential_exchange_id = cred_id_no_version(credential_exchange_id)
 
         bound_logger.debug("Storing v2 credential record")
-        record = await controller.issue_credential_v2_0.store_credential(
-            cred_ex_id=credential_exchange_id, body=V20CredStoreRequest()
+        request_body = V20CredStoreRequest()
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.store_credential,
+            cred_ex_id=credential_exchange_id,
+            body=request_body,
         )
 
         if not record.cred_ex_record:
@@ -160,20 +177,26 @@ class IssuerV2(Issuer):
         credential_exchange_id = cred_id_no_version(credential_exchange_id)
 
         bound_logger.debug("Getting v2 credential record")
-        record = await controller.issue_credential_v2_0.get_record(
-            cred_ex_id=credential_exchange_id
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.get_record,
+            cred_ex_id=credential_exchange_id,
         )
 
         bound_logger.debug("Deleting v2 credential record")
-        await controller.issue_credential_v2_0.delete_record(
-            cred_ex_id=credential_exchange_id
+        await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.delete_record,
+            cred_ex_id=credential_exchange_id,
         )
 
         # also delete indy credential
         if record.indy and record.indy.cred_id_stored:
             bound_logger.debug("Deleting indy credential")
-            await controller.credentials.delete_record(
-                credential_id=record.indy.cred_id_stored
+            await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=controller.credentials.delete_record,
+                credential_id=record.indy.cred_id_stored,
             )
         bound_logger.debug("Successfully deleted credential.")
 
@@ -183,7 +206,9 @@ class IssuerV2(Issuer):
     ) -> List[CredentialExchange]:
         bound_logger = logger.bind(body={"connection_id": connection_id})
         bound_logger.debug("Getting v2 credential records by connection id")
-        result = await controller.issue_credential_v2_0.get_records(
+        result = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.get_records,
             connection_id=connection_id,
         )
 
@@ -209,7 +234,9 @@ class IssuerV2(Issuer):
         credential_exchange_id = cred_id_no_version(credential_exchange_id)
 
         bound_logger.debug("Getting v2 credential record")
-        record = await controller.issue_credential_v2_0.get_record(
+        record = await handle_acapy_call(
+            logger=bound_logger,
+            acapy_call=controller.issue_credential_v2_0.get_record,
             cred_ex_id=credential_exchange_id,
         )
 

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from aries_cloudcontroller import (
     AcaPyClient,
@@ -30,7 +30,7 @@ class IssuerV2(Issuer):
     @classmethod
     async def send_credential(
         cls, controller: AcaPyClient, credential: CredentialWithConnection
-    ):
+    ) -> CredentialExchange:
         bound_logger = logger.bind(body=credential)
 
         credential_preview = None
@@ -67,7 +67,9 @@ class IssuerV2(Issuer):
         return cls.__record_to_model(record)
 
     @classmethod
-    async def create_offer(cls, controller: AcaPyClient, credential: CredentialBase):
+    async def create_offer(
+        cls, controller: AcaPyClient, credential: CredentialBase
+    ) -> CredentialExchange:
         bound_logger = logger.bind(body=credential)
 
         credential_preview = None
@@ -109,7 +111,7 @@ class IssuerV2(Issuer):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
-    ):
+    ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )
@@ -127,7 +129,7 @@ class IssuerV2(Issuer):
     @classmethod
     async def store_credential(
         cls, controller: AcaPyClient, credential_exchange_id: str
-    ):
+    ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )
@@ -150,7 +152,7 @@ class IssuerV2(Issuer):
     @classmethod
     async def delete_credential_exchange_record(
         cls, controller: AcaPyClient, credential_exchange_id: str
-    ):
+    ) -> None:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )
@@ -178,7 +180,7 @@ class IssuerV2(Issuer):
     @classmethod
     async def get_records(
         cls, controller: AcaPyClient, connection_id: Optional[str] = None
-    ):
+    ) -> List[CredentialExchange]:
         bound_logger = logger.bind(body={"connection_id": connection_id})
         bound_logger.debug("Getting v2 credential records by connection id")
         result = await controller.issue_credential_v2_0.get_records(
@@ -197,7 +199,9 @@ class IssuerV2(Issuer):
         ]
 
     @classmethod
-    async def get_record(cls, controller: AcaPyClient, credential_exchange_id: str):
+    async def get_record(
+        cls, controller: AcaPyClient, credential_exchange_id: str
+    ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
         )

--- a/app/services/onboarding/issuer.py
+++ b/app/services/onboarding/issuer.py
@@ -1,6 +1,6 @@
 from aries_cloudcontroller import AcaPyClient, InvitationCreateRequest
 
-from app.exceptions import CloudApiException
+from app.exceptions import CloudApiException, handle_acapy_call
 from app.models.tenants import OnboardResult
 from app.services import acapy_wallet
 from app.services.onboarding.util.register_issuer_did import (
@@ -48,13 +48,16 @@ async def onboard_issuer(
         )
 
     bound_logger.debug("Creating OOB invitation on behalf of issuer")
-    invitation = await issuer_controller.out_of_band.create_invitation(
+    request_body = InvitationCreateRequest(
+        alias=f"Trust Registry {issuer_label}",
+        handshake_protocols=["https://didcomm.org/didexchange/1.0"],
+    )
+    invitation = await handle_acapy_call(
+        logger=bound_logger,
+        acapy_call=issuer_controller.out_of_band.create_invitation,
         auto_accept=True,
         multi_use=True,
-        body=InvitationCreateRequest(
-            alias=f"Trust Registry {issuer_label}",
-            handshake_protocols=["https://didcomm.org/didexchange/1.0"],
-        ),
+        body=request_body,
     )
 
     return OnboardResult(

--- a/app/services/onboarding/issuer.py
+++ b/app/services/onboarding/issuer.py
@@ -40,7 +40,7 @@ async def onboard_issuer(
         bound_logger.debug("Obtained public DID for the to-be issuer")
     except CloudApiException:
         bound_logger.debug("No public DID for the to-be issuer")
-        issuer_did: acapy_wallet.Did = await onboard_issuer_no_public_did(
+        issuer_did = await onboard_issuer_no_public_did(
             endorser_controller=endorser_controller,
             issuer_controller=issuer_controller,
             issuer_wallet_id=issuer_wallet_id,

--- a/app/services/onboarding/util/register_issuer_did.py
+++ b/app/services/onboarding/util/register_issuer_did.py
@@ -1,10 +1,14 @@
 from logging import Logger
 
-from aries_cloudcontroller import AcaPyClient, InvitationCreateRequest, InvitationRecord
+from aries_cloudcontroller import (
+    DID,
+    AcaPyClient,
+    InvitationCreateRequest,
+    InvitationRecord,
+)
 
 from app.exceptions import CloudApiException, handle_acapy_call
 from app.services import acapy_ledger, acapy_wallet
-from app.services.acapy_wallet import Did
 from app.services.event_handling.sse_listener import SseListener
 from app.services.onboarding.util.set_endorser_metadata import (
     set_author_role,
@@ -18,7 +22,7 @@ async def create_connection_with_endorser(
     *,
     endorser_controller: AcaPyClient,
     issuer_controller: AcaPyClient,
-    endorser_did: Did,
+    endorser_did: DID,
     name: str,
     logger: Logger,
 ):

--- a/app/services/onboarding/util/register_issuer_did.py
+++ b/app/services/onboarding/util/register_issuer_did.py
@@ -2,7 +2,7 @@ from logging import Logger
 
 from aries_cloudcontroller import AcaPyClient, InvitationCreateRequest, InvitationRecord
 
-from app.exceptions import CloudApiException
+from app.exceptions import CloudApiException, handle_acapy_call
 from app.services import acapy_ledger, acapy_wallet
 from app.services.acapy_wallet import Did
 from app.services.event_handling.sse_listener import SseListener
@@ -48,13 +48,16 @@ async def create_endorser_invitation(
     *, endorser_controller: AcaPyClient, name: str, logger: Logger
 ):
     logger.debug("Create OOB invitation on behalf of endorser")
-    invitation = await endorser_controller.out_of_band.create_invitation(
+    request_body = InvitationCreateRequest(
+        alias=name,
+        handshake_protocols=["https://didcomm.org/didexchange/1.0"],
+        use_public_did=True,
+    )
+    invitation = await handle_acapy_call(
+        logger=logger,
+        acapy_call=endorser_controller.out_of_band.create_invitation,
         auto_accept=True,
-        body=InvitationCreateRequest(
-            alias=name,
-            handshake_protocols=["https://didcomm.org/didexchange/1.0"],
-            use_public_did=True,
-        ),
+        body=request_body,
     )
     logger.debug("Created OOB invitation")
     return invitation
@@ -68,7 +71,9 @@ async def wait_for_connection_completion(
     )
 
     logger.debug("Receive invitation from endorser on behalf of issuer")
-    connection_record = await issuer_controller.out_of_band.receive_invitation(
+    connection_record = await handle_acapy_call(
+        logger=logger,
+        acapy_call=issuer_controller.out_of_band.receive_invitation,
         auto_accept=True,
         use_existing_connection=False,
         body=invitation.invitation,
@@ -182,8 +187,10 @@ async def register_issuer_did(
         ) from e
 
     logger.bind(body=txn_record["transaction_id"]).debug("Endorsing transaction")
-    await endorser_controller.endorse_transaction.endorse_transaction(
-        tran_id=txn_record["transaction_id"]
+    await handle_acapy_call(
+        logger=logger,
+        acapy_call=endorser_controller.endorse_transaction.endorse_transaction,
+        tran_id=txn_record["transaction_id"],
     )
 
     logger.debug("Issuer DID registered and endorsed successfully.")

--- a/app/services/onboarding/util/set_endorser_metadata.py
+++ b/app/services/onboarding/util/set_endorser_metadata.py
@@ -3,7 +3,7 @@ import os
 from logging import Logger
 from typing import Callable
 
-from aries_cloudcontroller import AcaPyClient, ApiException
+from aries_cloudcontroller import AcaPyClient
 
 from app.exceptions import CloudApiException, handle_acapy_call
 
@@ -17,13 +17,15 @@ async def set_endorser_role(
 ):
     try:
         logger.debug("Setting roles for endorser on endorser-issuer connection.")
-        await endorser_controller.endorse_transaction.set_endorser_role(
+        await handle_acapy_call(
+            logger=logger,
+            acapy_call=endorser_controller.endorse_transaction.set_endorser_role,
             conn_id=endorser_connection_id,
             transaction_my_job="TRANSACTION_ENDORSER",
         )
         logger.debug("Successfully set endorser role.")
         await asyncio.sleep(DEFAULT_DELAY)  # Allow ACA-Py records to update
-    except ApiException as e:
+    except CloudApiException as e:
         logger.error("Failed to set endorser role: {}.", e)
         raise CloudApiException(
             "Failed to set the endorser role in the endorser-issuer connection, "
@@ -37,13 +39,15 @@ async def set_author_role(
 ):
     try:
         logger.debug("Setting roles for author on issuer-endorser connection")
-        await issuer_controller.endorse_transaction.set_endorser_role(
+        await handle_acapy_call(
+            logger=logger,
+            acapy_call=issuer_controller.endorse_transaction.set_endorser_role,
             conn_id=issuer_connection_id,
             transaction_my_job="TRANSACTION_AUTHOR",
         )
         logger.debug("Successfully set author role.")
         await asyncio.sleep(DEFAULT_DELAY)  # Allow ACA-Py records to update
-    except ApiException as e:
+    except CloudApiException as e:
         logger.error("Failed to set author role: {}.", e)
         raise CloudApiException(
             "Failed to set the author role in the issuer-endorser connection, "
@@ -61,13 +65,15 @@ async def set_endorser_info(
 ):
     try:
         logger.debug("Setting endorser info on issuer-endorser connection")
-        await issuer_controller.endorse_transaction.set_endorser_info(
+        await handle_acapy_call(
+            logger=logger,
+            acapy_call=issuer_controller.endorse_transaction.set_endorser_info,
             conn_id=issuer_connection_id,
             endorser_did=endorser_did,
         )
         logger.debug("Successfully set endorser info.")
         await asyncio.sleep(DEFAULT_DELAY)  # Allow ACA-Py records to update
-    except ApiException as e:
+    except CloudApiException as e:
         logger.error("Failed to set endorser info: {}.", e)
         raise CloudApiException(
             "Failed to set the endorser info in the issuer-endorser connection, "

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -381,7 +381,7 @@ async def validate_rev_reg_ids(
                 raise CloudApiException(message, e.status_code) from e
             else:
                 bound_logger.error(
-                    "An ApiException was caught while validating rev_reg_id. The error message is: '{}'.",
+                    "An Exception was caught while validating rev_reg_id. The error message is: '{}'.",
                     e.detail,
                 )
                 raise CloudApiException(

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -423,7 +423,7 @@ async def wait_for_active_registry(
     active_registries = []
     sleep_duration = 0  # First sleep should be 0
 
-    while len(active_registries) != 2:
+    while len(active_registries) < 2:
         await asyncio.sleep(sleep_duration)
         active_registries = await get_created_active_registries(controller, cred_def_id)
         sleep_duration = 0.5  # Following sleeps should wait 0.5s before retry

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -44,17 +44,17 @@ class VerifierV1(Verifier):
         bound_logger = logger.bind(body=create_proof_request)
         bound_logger.debug("Creating v1 proof request")
 
-        auto_remove = not create_proof_request.save_exchange_record
+        request_body = V10PresentationCreateRequestRequest(
+            auto_remove=not create_proof_request.save_exchange_record,
+            proof_request=create_proof_request.indy_proof_request,
+            auto_verify=True,
+            comment=create_proof_request.comment,
+            trace=create_proof_request.trace,
+        )
         try:
             presentation_exchange = (
                 await controller.present_proof_v1_0.create_proof_request(
-                    body=V10PresentationCreateRequestRequest(
-                        auto_remove=auto_remove,
-                        proof_request=create_proof_request.indy_proof_request,
-                        auto_verify=True,
-                        comment=create_proof_request.comment,
-                        trace=create_proof_request.trace,
-                    )
+                    body=request_body
                 )
             )
             bound_logger.debug("Returning v1 PresentationExchange.")
@@ -80,20 +80,18 @@ class VerifierV1(Verifier):
             )
 
         bound_logger = logger.bind(body=send_proof_request)
-        auto_remove = not send_proof_request.save_exchange_record
+        request_body = V10PresentationSendRequestRequest(
+            auto_remove=not send_proof_request.save_exchange_record,
+            connection_id=send_proof_request.connection_id,
+            proof_request=send_proof_request.indy_proof_request,
+            auto_verify=True,
+            comment=send_proof_request.comment,
+            trace=send_proof_request.trace,
+        )
         try:
             bound_logger.debug("Send free v1 presentation request")
             presentation_exchange = (
-                await controller.present_proof_v1_0.send_request_free(
-                    body=V10PresentationSendRequestRequest(
-                        auto_remove=auto_remove,
-                        connection_id=send_proof_request.connection_id,
-                        proof_request=send_proof_request.indy_proof_request,
-                        auto_verify=True,
-                        comment=send_proof_request.comment,
-                        trace=send_proof_request.trace,
-                    )
-                )
+                await controller.present_proof_v1_0.send_request_free(body=request_body)
             )
             result = record_to_model(presentation_exchange)
         except Exception as e:
@@ -121,12 +119,11 @@ class VerifierV1(Verifier):
         bound_logger = logger.bind(body=accept_proof_request)
         proof_id = pres_id_no_version(proof_id=accept_proof_request.proof_id)
 
-        auto_remove = not accept_proof_request.save_exchange_record
         try:
             bound_logger.debug("Send v1 proof presentation")
             indy_pres_spec = accept_proof_request.indy_presentation_spec
             v10_pres_send_req = V10PresentationSendRequest(
-                auto_remove=auto_remove,
+                auto_remove=not accept_proof_request.save_exchange_record,
                 requested_attributes=indy_pres_spec.requested_attributes,
                 requested_predicates=indy_pres_spec.requested_predicates,
                 self_attested_attributes=indy_pres_spec.self_attested_attributes,
@@ -159,13 +156,14 @@ class VerifierV1(Verifier):
 
         # Report problem if desired
         if reject_proof_request.problem_report:
+            request_body = V10PresentationProblemReportRequest(
+                description=reject_proof_request.problem_report
+            )
             try:
                 bound_logger.debug("Submitting v1 problem report")
                 await controller.present_proof_v1_0.report_problem(
                     pres_ex_id=proof_id,
-                    body=V10PresentationProblemReportRequest(
-                        description=reject_proof_request.problem_report
-                    ),
+                    body=request_body,
                 )
             except Exception as e:
                 bound_logger.exception("An exception occurred while reporting problem.")

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -63,8 +63,12 @@ class VerifierV1(Verifier):
                 f"Failed to create presentation request: {e.detail}.", e.status_code
             ) from e
 
-        bound_logger.debug("Returning v1 PresentationExchange.")
-        return record_to_model(presentation_exchange)
+        result = record_to_model(presentation_exchange)
+        if result:
+            bound_logger.debug("Successfully created v1 presentation request.")
+        else:
+            bound_logger.warning("No result from creating v1 presentation request.")
+        return result
 
     @classmethod
     async def send_proof_request(
@@ -95,12 +99,12 @@ class VerifierV1(Verifier):
                 acapy_call=controller.present_proof_v1_0.send_request_free,
                 body=request_body,
             )
-            result = record_to_model(presentation_exchange)
         except CloudApiException as e:
             raise CloudApiException(
                 f"Failed to send presentation request: {e.detail}.", e.status_code
             ) from e
 
+        result = record_to_model(presentation_exchange)
         if result:
             bound_logger.debug("Successfully sent v1 presentation request.")
         else:
@@ -141,8 +145,8 @@ class VerifierV1(Verifier):
             raise CloudApiException(
                 f"Failed to send proof presentation: {e.detail}.", e.status_code
             ) from e
-        result = record_to_model(presentation_record)
 
+        result = record_to_model(presentation_record)
         if result:
             bound_logger.debug("Successfully sent v1 proof presentation.")
         else:
@@ -214,6 +218,7 @@ class VerifierV1(Verifier):
             raise CloudApiException(
                 f"Failed to get proof records: {e.detail}.", e.status_code
             ) from e
+
         result = [record_to_model(rec) for rec in presentation_exchange.results or []]
 
         if result:

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -1,5 +1,8 @@
+from typing import List
+
 from aries_cloudcontroller import (
     AcaPyClient,
+    IndyCredPrecis,
     V10PresentationCreateRequestRequest,
     V10PresentationProblemReportRequest,
     V10PresentationSendRequest,
@@ -178,7 +181,9 @@ class VerifierV1(Verifier):
         bound_logger.info("Successfully rejected v1 presentation exchange record.")
 
     @classmethod
-    async def get_proof_records(cls, controller: AcaPyClient):
+    async def get_proof_records(
+        cls, controller: AcaPyClient
+    ) -> List[PresentationExchange]:
         try:
             logger.debug("Fetching v1 present-proof exchange records")
             presentation_exchange = await controller.present_proof_v1_0.get_records()
@@ -196,7 +201,9 @@ class VerifierV1(Verifier):
         return result
 
     @classmethod
-    async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
+    async def get_proof_record(
+        cls, controller: AcaPyClient, proof_id: str
+    ) -> PresentationExchange:
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id)
 
@@ -219,7 +226,7 @@ class VerifierV1(Verifier):
         return result
 
     @classmethod
-    async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
+    async def delete_proof(cls, controller: AcaPyClient, proof_id: str) -> None:
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
 
@@ -235,7 +242,9 @@ class VerifierV1(Verifier):
         bound_logger.debug("Successfully deleted v1 present-proof record.")
 
     @classmethod
-    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
+    async def get_credentials_by_proof_id(
+        cls, controller: AcaPyClient, proof_id: str
+    ) -> List[IndyCredPrecis]:
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
 

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -65,12 +65,17 @@ class VerifierV2(Verifier):
                 acapy_call=controller.present_proof_v2_0.create_proof_request,
                 body=request_body,
             )
-            bound_logger.debug("Returning v2 PresentationExchange.")
-            return record_to_model(proof_record)
         except CloudApiException as e:
             raise CloudApiException(
                 f"Failed to create presentation request: {e.detail}.", e.status_code
             ) from e
+
+        result = record_to_model(proof_record)
+        if result:
+            bound_logger.debug("Successfully created v2 presentation request.")
+        else:
+            bound_logger.warning("No result from creating v2 presentation request.")
+        return result
 
     @classmethod
     async def send_proof_request(
@@ -108,12 +113,12 @@ class VerifierV2(Verifier):
                 acapy_call=controller.present_proof_v2_0.send_request_free,
                 body=request_body,
             )
-            result = record_to_model(presentation_exchange)
         except CloudApiException as e:
             raise CloudApiException(
                 f"Failed to send presentation request: {e.detail}.", e.status_code
             ) from e
 
+        result = record_to_model(presentation_exchange)
         if result:
             bound_logger.debug("Successfully sent v2 presentation request.")
         else:
@@ -151,12 +156,13 @@ class VerifierV2(Verifier):
                 pres_ex_id=pres_ex_id,
                 body=presentation_spec,
             )
-            result = record_to_model(presentation_record)
+
         except CloudApiException as e:
             raise CloudApiException(
                 f"Failed to send proof presentation: {e.detail}.", e.status_code
             ) from e
 
+        result = record_to_model(presentation_record)
         if result:
             bound_logger.debug("Successfully sent v2 proof presentation.")
         else:
@@ -226,6 +232,7 @@ class VerifierV2(Verifier):
             raise CloudApiException(
                 f"Failed to get proof records: {e.detail}.", e.status_code
             ) from e
+
         result = [record_to_model(rec) for rec in presentation_exchange.results or []]
 
         if result:
@@ -248,13 +255,13 @@ class VerifierV2(Verifier):
                 acapy_call=controller.present_proof_v2_0.get_record,
                 pres_ex_id=pres_ex_id,
             )
-            result = record_to_model(presentation_exchange)
         except CloudApiException as e:
             raise CloudApiException(
                 f"Failed to get proof record with proof id `{proof_id}`: {e.detail}.",
                 e.status_code,
             ) from e
 
+        result = record_to_model(presentation_exchange)
         if result:
             bound_logger.debug("Successfully got v2 present-proof record.")
         else:

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -1,5 +1,8 @@
+from typing import List
+
 from aries_cloudcontroller import (
     AcaPyClient,
+    IndyCredPrecis,
     V20PresCreateRequestRequest,
     V20PresProblemReportRequest,
     V20PresRequestByFormat,
@@ -194,7 +197,9 @@ class VerifierV2(Verifier):
         bound_logger.info("Successfully rejected v2 presentation exchange record.")
 
     @classmethod
-    async def get_proof_records(cls, controller: AcaPyClient):
+    async def get_proof_records(
+        cls, controller: AcaPyClient
+    ) -> List[PresentationExchange]:
         try:
             logger.debug("Fetching v2 present-proof exchange records")
             presentation_exchange = await controller.present_proof_v2_0.get_records()
@@ -212,7 +217,9 @@ class VerifierV2(Verifier):
         return result
 
     @classmethod
-    async def get_proof_record(cls, controller: AcaPyClient, proof_id: str):
+    async def get_proof_record(
+        cls, controller: AcaPyClient, proof_id: str
+    ) -> PresentationExchange:
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id)
 
@@ -235,7 +242,7 @@ class VerifierV2(Verifier):
         return result
 
     @classmethod
-    async def delete_proof(cls, controller: AcaPyClient, proof_id: str):
+    async def delete_proof(cls, controller: AcaPyClient, proof_id: str) -> None:
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
 
@@ -253,7 +260,9 @@ class VerifierV2(Verifier):
         bound_logger.debug("Successfully deleted v2 present-proof record.")
 
     @classmethod
-    async def get_credentials_by_proof_id(cls, controller: AcaPyClient, proof_id: str):
+    async def get_credentials_by_proof_id(
+        cls, controller: AcaPyClient, proof_id: str
+    ) -> List[IndyCredPrecis]:
         bound_logger = logger.bind(body={"proof_id": proof_id})
         pres_ex_id = pres_id_no_version(proof_id=proof_id)
 

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -135,7 +135,7 @@ async def test_delete_connection(
     connection_id = invitation["connection_id"]
 
     response = await bob_member_client.delete(f"{BASE_PATH}/{connection_id}")
-    assert_that(response.status_code).is_equal_to(200)
+    assert_that(response.status_code).is_equal_to(204)
 
     with pytest.raises(HTTPException) as exc:
         response = await bob_member_client.get(f"{BASE_PATH}/{connection_id}")

--- a/app/tests/e2e/test_jsonld.py
+++ b/app/tests/e2e/test_jsonld.py
@@ -5,7 +5,6 @@ from fastapi import HTTPException
 
 from app.models.jsonld import JsonLdSignRequest, JsonLdVerifyRequest
 from app.routes.jsonld import router
-from app.tests.util.ecosystem_connections import FaberAliceConnect
 from shared import RichAsyncClient
 from shared.exceptions.cloudapi_value_error import CloudApiValueError
 from shared.models.credential_exchange import CredentialExchange
@@ -55,10 +54,8 @@ signed_doc = {
 
 @pytest.mark.anyio
 async def test_sign_jsonld(
-    alice_member_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
     faber_client: RichAsyncClient,
-    faber_and_alice_connection: FaberAliceConnect,
     issue_credential_to_alice: CredentialExchange,
 ):
     # First assert 422 error for providing both pub_did and verkey:

--- a/app/tests/e2e/test_wallet_jws.py
+++ b/app/tests/e2e/test_wallet_jws.py
@@ -1,9 +1,9 @@
 import pytest
 from aries_cloudcontroller import DIDCreate
 from fastapi import HTTPException
-from pydantic import ValidationError
 
 from app.models.jws import JWSCreateRequest
+from shared.exceptions import CloudApiValueError
 from shared.util.rich_async_client import RichAsyncClient
 
 
@@ -32,7 +32,7 @@ async def test_sign_jws_success(alice_member_client: RichAsyncClient):
 
 @pytest.mark.anyio
 async def test_sign_jws_x(alice_member_client: RichAsyncClient):
-    with pytest.raises(ValidationError):
+    with pytest.raises(CloudApiValueError):
         # Requires at least one of did or verification method
         JWSCreateRequest(
             did=None,

--- a/app/tests/e2e/test_wallet_sd_jws.py
+++ b/app/tests/e2e/test_wallet_sd_jws.py
@@ -1,9 +1,9 @@
 import pytest
 from aries_cloudcontroller import DIDCreate
 from fastapi import HTTPException
-from pydantic import ValidationError
 
 from app.models.sd_jws import SDJWSCreateRequest
+from shared.exceptions import CloudApiValueError
 from shared.util.rich_async_client import RichAsyncClient
 
 
@@ -32,7 +32,7 @@ async def test_sign_sdjws_success(alice_member_client: RichAsyncClient):
 
 @pytest.mark.anyio
 async def test_sign_sdjws_x(alice_member_client: RichAsyncClient):
-    with pytest.raises(ValidationError):
+    with pytest.raises(CloudApiValueError):
         # Requires at least one of did or verification method
         SDJWSCreateRequest(
             did=None,

--- a/app/tests/services/issuer/test_issuer.py
+++ b/app/tests/services/issuer/test_issuer.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 from aiohttp import RequestInfo
 from aries_cloudcontroller import AcaPyClient

--- a/app/tests/services/issuer/test_issuer.py
+++ b/app/tests/services/issuer/test_issuer.py
@@ -2,7 +2,7 @@ import unittest
 
 import pytest
 from aiohttp import RequestInfo
-from aries_cloudcontroller import AcaPyClient, ApiException
+from aries_cloudcontroller import AcaPyClient
 from mockito import mock, verify, when
 from pytest_mock import MockerFixture
 
@@ -70,7 +70,7 @@ async def test_send_credential(
     when(test_module).schema_id_from_credential_definition_id(
         mock_agent_controller, cred_def_id
     ).thenReturn(to_async("schema_id"))
-    when(IssuerV1).send_credential(...).thenRaise(ApiException())
+    when(IssuerV1).send_credential(...).thenRaise(CloudApiException("abc"))
 
     with pytest.raises(CloudApiException):
         await test_module.send_credential(credential, mock_tenant_auth)

--- a/app/tests/services/test_acapy_ledger.py
+++ b/app/tests/services/test_acapy_ledger.py
@@ -39,14 +39,14 @@ async def test_error_on_get_taa(mock_agent_controller: AcaPyClient):
 async def test_error_on_accept_taa(mock_agent_controller: AcaPyClient):
     when(mock_agent_controller.ledger).accept_taa(
         body=TAAAccept(mechanism="data", text=None, version=None)
-    ).thenReturn(to_async(ApiException()))
+    ).thenRaise(ApiException(status=500))
 
     with pytest.raises(CloudApiException) as exc:
         await accept_taa(
             mock_agent_controller, taa=TAARecord(digest=""), mechanism="data"
         )
-    assert exc.value.status_code == 400
-    assert "Something went wrong. Could not accept TAA." in exc.value.detail
+    assert exc.value.status_code == 500
+    assert "An unexpected error occurred while trying to accept TAA" in exc.value.detail
 
 
 @pytest.mark.anyio

--- a/app/tests/services/test_onboarding.py
+++ b/app/tests/services/test_onboarding.py
@@ -1,5 +1,6 @@
 import pytest
 from aries_cloudcontroller import (
+    DID,
     AcaPyClient,
     ConnRecord,
     InvitationCreateRequest,
@@ -11,7 +12,6 @@ from mockito import verify, when
 
 from app.exceptions import CloudApiException
 from app.services import acapy_ledger, acapy_wallet
-from app.services.acapy_wallet import Did
 from app.services.event_handling.sse_listener import SseListener
 from app.services.onboarding import issuer, verifier
 from app.services.onboarding.util import register_issuer_did
@@ -26,7 +26,7 @@ async def test_onboard_issuer_public_did_exists(
 ):
     when(acapy_wallet).get_public_did(controller=mock_agent_controller).thenReturn(
         to_async(
-            Did(
+            DID(
                 did="WgWxqztrNooG92RXvxSTWv",
                 verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
             )
@@ -43,7 +43,7 @@ async def test_onboard_issuer_public_did_exists(
     )
 
     when(acapy_wallet).get_public_did(controller=endorser_controller).thenReturn(
-        Did(did="EndorserController", verkey="EndorserVerkey")
+        DID(did="EndorserController", verkey="EndorserVerkey")
     )
 
     when(mock_agent_controller.endorse_transaction).set_endorser_role(...).thenReturn(
@@ -99,7 +99,7 @@ async def test_onboard_issuer_no_public_did(
         CloudApiException(detail="Error")
     )
     when(acapy_wallet).get_public_did(controller=endorser_controller).thenReturn(
-        to_async(Did(did=endorser_did, verkey="EndorserVerkey"))
+        to_async(DID(did=endorser_did, verkey="EndorserVerkey"))
     )
 
     when(endorser_controller.out_of_band).create_invitation(...).thenReturn(
@@ -137,7 +137,7 @@ async def test_onboard_issuer_no_public_did(
 
     when(acapy_wallet).create_did(mock_agent_controller).thenReturn(
         to_async(
-            Did(
+            DID(
                 did="WgWxqztrNooG92RXvxSTWv",
                 verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
             )
@@ -187,7 +187,7 @@ async def test_onboard_issuer_no_public_did(
 async def test_onboard_verifier_public_did_exists(mock_agent_controller: AcaPyClient):
     when(acapy_wallet).get_public_did(controller=mock_agent_controller).thenReturn(
         to_async(
-            Did(
+            DID(
                 did="WgWxqztrNooG92RXvxSTWv",
                 verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
             )

--- a/app/tests/services/test_onboarding.py
+++ b/app/tests/services/test_onboarding.py
@@ -19,18 +19,18 @@ from app.tests.util.mock import to_async
 from shared.constants import GOVERNANCE_LABEL
 from shared.util.mock_agent_controller import get_mock_agent_controller
 
+did_object = DID(
+    did="WgWxqztrNooG92RXvxSTWv",
+    verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
+)
+
 
 @pytest.mark.anyio
 async def test_onboard_issuer_public_did_exists(
     mock_agent_controller: AcaPyClient,
 ):
     when(acapy_wallet).get_public_did(controller=mock_agent_controller).thenReturn(
-        to_async(
-            DID(
-                did="WgWxqztrNooG92RXvxSTWv",
-                verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
-            )
-        )
+        to_async(did_object)
     )
 
     endorser_controller = get_mock_agent_controller()
@@ -43,7 +43,7 @@ async def test_onboard_issuer_public_did_exists(
     )
 
     when(acapy_wallet).get_public_did(controller=endorser_controller).thenReturn(
-        DID(did="EndorserController", verkey="EndorserVerkey")
+        did_object
     )
 
     when(mock_agent_controller.endorse_transaction).set_endorser_role(...).thenReturn(
@@ -93,13 +93,12 @@ async def test_onboard_issuer_no_public_did(
     mock_agent_controller: AcaPyClient,
 ):
     endorser_controller = get_mock_agent_controller()
-    endorser_did = "EndorserDid"
 
     when(acapy_wallet).get_public_did(controller=mock_agent_controller).thenRaise(
         CloudApiException(detail="Error")
     )
     when(acapy_wallet).get_public_did(controller=endorser_controller).thenReturn(
-        to_async(DID(did=endorser_did, verkey="EndorserVerkey"))
+        to_async(did_object)
     )
 
     when(endorser_controller.out_of_band).create_invitation(...).thenReturn(
@@ -136,12 +135,7 @@ async def test_onboard_issuer_no_public_did(
     )
 
     when(acapy_wallet).create_did(mock_agent_controller).thenReturn(
-        to_async(
-            DID(
-                did="WgWxqztrNooG92RXvxSTWv",
-                verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
-            )
-        )
+        to_async(did_object)
     )
     when(acapy_ledger).register_nym_on_ledger(...).thenReturn(to_async())
     when(acapy_ledger).accept_taa_if_required(...).thenReturn(to_async())
@@ -186,12 +180,7 @@ async def test_onboard_issuer_no_public_did(
 @pytest.mark.anyio
 async def test_onboard_verifier_public_did_exists(mock_agent_controller: AcaPyClient):
     when(acapy_wallet).get_public_did(controller=mock_agent_controller).thenReturn(
-        to_async(
-            DID(
-                did="WgWxqztrNooG92RXvxSTWv",
-                verkey="WgWxqztrNooG92RXvxSTWvWgWxqztrNooG92RXvxSTWv",
-            )
-        )
+        to_async(did_object)
     )
 
     onboard_result = await verifier.onboard_verifier(

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -320,7 +320,7 @@ async def test_get_credential_definition_id_from_exchange_id(
     # Success v2
     when(mock_agent_controller.issue_credential_v1_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ApiException())
+    ).thenRaise(CloudApiException(detail=""))
     when(mock_agent_controller.issue_credential_v2_0).get_record(
         cred_ex_id=cred_ex_id
     ).thenReturn(
@@ -342,10 +342,10 @@ async def test_get_credential_definition_id_from_exchange_id(
     # Not found
     when(mock_agent_controller.issue_credential_v1_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ApiException())
+    ).thenRaise(CloudApiException(detail=""))
     when(mock_agent_controller.issue_credential_v2_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ApiException())
+    ).thenRaise(CloudApiException(detail=""))
 
     cred_def_id_result = await rg.get_credential_definition_id_from_exchange_id(
         controller=mock_agent_controller, credential_exchange_id=cred_ex_id
@@ -356,7 +356,7 @@ async def test_get_credential_definition_id_from_exchange_id(
     # Not found general exception
     when(mock_agent_controller.issue_credential_v1_0).get_record(
         cred_ex_id=cred_ex_id
-    ).thenRaise(ApiException())
+    ).thenRaise(CloudApiException(detail=""))
     when(mock_agent_controller.issue_credential_v2_0).get_record(
         cred_ex_id=cred_ex_id
     ).thenRaise(Exception())

--- a/app/tests/services/verifier/utils.py
+++ b/app/tests/services/verifier/utils.py
@@ -42,7 +42,6 @@ from app.util.acapy_verifier_utils import (
     assert_valid_verifier,
     ed25519_verkey_to_did_key,
     get_actor,
-    get_connection_record,
     get_schema_ids,
     is_verifier,
 )
@@ -186,37 +185,6 @@ async def test_are_valid_schemas(mock_async_client):
     assert (
         await are_valid_schemas(schema_ids=["SomeRandomDid:2:test_schema:0.3"]) is False
     )
-
-
-@pytest.mark.anyio
-async def test_get_connection_record(mock_agent_controller: AcaPyClient):
-    pres_exchange = PresentationExchange(
-        connection_id="3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        created_at="2021-09-15 13:49:47Z",
-        proof_id="v1-abcd",
-        presentation=None,
-        presentation_request=indy_proof_request,
-        role="prover",
-        state="proposal-sent",
-        protocol_version="v1",
-        updated_at=None,
-        verified="false",
-    )
-    conn_record = ConnRecord(connection_id=pres_exchange.connection_id)
-    with when(mock_agent_controller.connection).get_connection(...).thenReturn(
-        to_async(conn_record)
-    ), when(Verifier).get_proof_record(...).thenReturn(pres_exchange), patch(
-        "app.generic.verifier.verifier_utils.get_connection_record",
-        return_value=conn_record,
-    ):
-        assert (
-            await get_connection_record(
-                aries_controller=mock_agent_controller,
-                connection_id=conn_record.connection_id,
-            )
-            == conn_record
-        )
-    # todo: mocking of get_proof_record does nothing
 
 
 @pytest.mark.anyio

--- a/app/tests/test_util_did.py
+++ b/app/tests/test_util_did.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.util.did import ed25519_verkey_to_did_key, qualified_did_sov
+from shared.exceptions import CloudApiValueError
 
 
 def test_ed25519_verkey_to_did_key():
@@ -17,21 +18,21 @@ def test_ed25519_verkey_to_did_key():
         assert ed25519_verkey_to_did_key(valid_key).startswith("did:key:z")
 
     # Test invalid key lengths
-    with pytest.raises(ValueError, match="Invalid key length."):
+    with pytest.raises(CloudApiValueError, match="Invalid key length."):
         ed25519_verkey_to_did_key(
             "abcdefghijkmnopqrstuvwxyz123456789ABCDEFGH"
         )  # length 42
-    with pytest.raises(ValueError, match="Invalid key length."):
+    with pytest.raises(CloudApiValueError, match="Invalid key length."):
         ed25519_verkey_to_did_key(
             "abcdefghijkmnopqrstuvwxyz123456789ABCDEFGHJKL"
         )  # length 45
 
     # Test invalid characters
-    with pytest.raises(ValueError, match="Invalid key."):
+    with pytest.raises(CloudApiValueError, match="Invalid key."):
         ed25519_verkey_to_did_key(
             "abcdefghijkmnopqrstuvwxyz123456789ABCDEFGH*"
         )  # invalid character *
-    with pytest.raises(ValueError, match="Invalid key."):
+    with pytest.raises(CloudApiValueError, match="Invalid key."):
         ed25519_verkey_to_did_key(
             "abcdefghijkmnopqrstuvwxyz123456789ABCDEFGHJ0"
         )  # invalid character 0

--- a/app/tests/util/definitions.py
+++ b/app/tests/util/definitions.py
@@ -71,7 +71,7 @@ async def credential_definition_id_revocable(
         tag="tag",
         schema_id=schema_definition_alt.id,
         support_revocation=True,
-        revocation_registry_size=100,
+        revocation_registry_size=5000,
     )
 
     auth = acapy_auth_verified(acapy_auth(faber_client.headers["x-api-key"]))

--- a/app/tests/util/definitions.py
+++ b/app/tests/util/definitions.py
@@ -71,7 +71,7 @@ async def credential_definition_id_revocable(
         tag="tag",
         schema_id=schema_definition_alt.id,
         support_revocation=True,
-        revocation_registry_size=5000,
+        revocation_registry_size=2000,
     )
 
     auth = acapy_auth_verified(acapy_auth(faber_client.headers["x-api-key"]))

--- a/app/tests/util/ledger.py
+++ b/app/tests/util/ledger.py
@@ -29,7 +29,7 @@ class LedgerRequestVon(BaseModel):
 
 async def post_to_ledger(
     did: str, verkey: str, role: Optional[Literal["ENDORSER"]] = "ENDORSER"
-):
+) -> None:
     if LEDGER_TYPE == "sovrin":
         payload = LedgerRequestSovrin(
             network="stagingnet",
@@ -58,7 +58,7 @@ async def post_to_ledger(
     logger.info("Successfully posted to ledger.")
 
 
-async def has_public_did(aries_controller: AcaPyClient):
+async def has_public_did(aries_controller: AcaPyClient) -> bool:
     try:
         await acapy_wallet.get_public_did(aries_controller)
         return True

--- a/app/tests/util/ledger.py
+++ b/app/tests/util/ledger.py
@@ -1,6 +1,6 @@
 from typing import Literal, Optional
 
-from aries_cloudcontroller import AcaPyClient
+from aries_cloudcontroller import DID, AcaPyClient
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
@@ -68,7 +68,7 @@ async def has_public_did(aries_controller: AcaPyClient):
 
 async def create_public_did(
     aries_controller: AcaPyClient, set_public: bool = True
-) -> acapy_wallet.Did:
+) -> DID:
     logger.info("Handling create public did request")
     did_object = await acapy_wallet.create_did(aries_controller)
 

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -14,6 +14,7 @@ from app.services.verifier.acapy_verifier_v1 import VerifierV1
 from app.services.verifier.acapy_verifier_v2 import VerifierV2
 from app.util.did import ed25519_verkey_to_did_key
 from app.util.tenants import get_wallet_label_from_controller
+from shared.exceptions import CloudApiValueError
 from shared.log_config import get_logger
 from shared.models.protocol import PresentProofProtocolVersion
 
@@ -37,7 +38,7 @@ def get_verifier_by_version(
     ):
         return VerifierFacade.v2.value
     else:
-        raise ValueError(
+        raise CloudApiValueError(
             f"Unknown protocol version: `{version_candidate}`. Expecting `v1` or `v2`."
         )
 

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -37,7 +37,9 @@ def get_verifier_by_version(
     ):
         return VerifierFacade.v2.value
     else:
-        raise ValueError(f"Unknown protocol version: `{version_candidate}`.")
+        raise ValueError(
+            f"Unknown protocol version: `{version_candidate}`. Expecting `v1` or `v2`."
+        )
 
 
 async def assert_valid_prover(

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -265,11 +265,3 @@ async def get_connection_from_proof(
         controller=aries_controller, proof_id=proof_id
     )
     return proof_record.connection_id
-
-
-async def get_connection_record(
-    aries_controller: AcaPyClient,
-    connection_id: str,
-) -> ConnRecord:
-    """Retrieve the connection record"""
-    return await aries_controller.connection.get_connection(conn_id=connection_id)

--- a/app/util/credentials.py
+++ b/app/util/credentials.py
@@ -1,3 +1,6 @@
+from shared.exceptions import CloudApiValueError
+
+
 def cred_id_no_version(credential_id: str) -> str:
     if credential_id.startswith("v2-") or credential_id.startswith("v1-"):
         return credential_id[3:]
@@ -5,7 +8,7 @@ def cred_id_no_version(credential_id: str) -> str:
     elif len(credential_id.split("-")) == 5:
         return credential_id
     else:
-        raise ValueError("credential_id must start with prefix `v1-` or `v2-`.")
+        raise CloudApiValueError("credential_id must start with prefix `v1-` or `v2-`.")
 
 
 def strip_protocol_prefix(id: str):

--- a/app/util/did.py
+++ b/app/util/did.py
@@ -2,13 +2,15 @@ import re
 
 import base58
 
+from shared.exceptions import CloudApiValueError
+
 
 def ed25519_verkey_to_did_key(key: str) -> str:
     """Convert a naked ed25519 verkey to W3C did:key format."""
 
     # Length validation
     if len(key) not in (43, 44):
-        raise ValueError(
+        raise CloudApiValueError(
             "Invalid key length. ed25519 keys should be 43 or 44 characters long when base58 encoded."
         )
 
@@ -16,7 +18,7 @@ def ed25519_verkey_to_did_key(key: str) -> str:
     if not re.match(
         "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$", key
     ):
-        raise ValueError(
+        raise CloudApiValueError(
             "Invalid key. ed25519 keys should only contain base58 characters."
         )
 

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -41,7 +41,7 @@ async def get_wallet_label_from_controller(aries_controller: AcaPyClient) -> str
     controller_wallet_id = get_wallet_id_from_b64encoded_jwt(controller_token)
     async with get_tenant_admin_controller() as admin_controller:
         controller_wallet_record = await admin_controller.multitenancy.get_wallet(
-            controller_wallet_id
+            wallet_id=controller_wallet_id
         )
     controller_label = controller_wallet_record.settings["default_label"]
     return controller_label

--- a/endorser/requirements.txt
+++ b/endorser/requirements.txt
@@ -6,5 +6,4 @@ loguru~=0.7.2
 orjson~=3.9.15
 pydantic~=2.5.1
 redis~=5.1.0b4
-typing-extensions~=4.9.0
 uvicorn[standard]~=0.28.0

--- a/endorser/services/endorsement_processor.py
+++ b/endorser/services/endorsement_processor.py
@@ -15,7 +15,7 @@ from shared.log_config import get_logger
 from shared.models.endorsement import Endorsement
 from shared.models.webhook_events.payloads import CloudApiWebhookEventGeneric
 from shared.services.redis_service import RedisService
-from shared.util.rich_parsing import parse_with_error_handling
+from shared.util.rich_parsing import parse_json_with_error_handling
 
 logger = get_logger(__name__)
 
@@ -227,7 +227,7 @@ class EndorsementProcessor:
         Args:
             event_json: The JSON string representation of the endorsement event.
         """
-        event = parse_with_error_handling(
+        event = parse_json_with_error_handling(
             CloudApiWebhookEventGeneric, event_json, logger
         )
         logger.debug("Processing endorsement event for agent `{}`", event.origin)

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -2,4 +2,4 @@
 from shared.constants import *
 from shared.util.api_router import APIRouter
 from shared.util.rich_async_client import RichAsyncClient
-from shared.util.rich_parsing import parse_with_error_handling
+from shared.util.rich_parsing import parse_json_with_error_handling

--- a/shared/exceptions/__init__.py
+++ b/shared/exceptions/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from shared.exceptions.cloudapi_value_error import CloudApiValueError

--- a/shared/exceptions/cloudapi_value_error.py
+++ b/shared/exceptions/cloudapi_value_error.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict, Union
+
+from fastapi import HTTPException
+
+
+class CloudApiValueError(HTTPException):
+    """Class that represents a validation / value error"""
+
+    def __init__(self, detail: Union[str, Dict[str, Any]]) -> None:
+        super().__init__(status_code=422, detail=detail)

--- a/shared/models/credential_exchange.py
+++ b/shared/models/credential_exchange.py
@@ -17,6 +17,7 @@ State = Literal[
     "credential-revoked",
     "abandoned",
     "done",
+    "deleted",
 ]
 
 Role = Literal["issuer", "holder"]
@@ -76,6 +77,7 @@ def v1_credential_state_to_rfc_state(state: Optional[str]) -> Optional[str]:
         "credential_issued": "credential-issued",
         "credential_received": "credential-received",
         "credential_revoked": "credential-revoked",
+        "deleted": "deleted",
         "done": "done",
         "offer_received": "offer-received",
         "offer_sent": "offer-sent",
@@ -94,6 +96,7 @@ def v1_credential_state_to_rfc_state(state: Optional[str]) -> Optional[str]:
 def back_to_v1_credential_state(state: Optional[str]) -> Optional[str]:
     translation_dict = {
         "abandoned": "abandoned",
+        "deleted": "deleted",
         "done": "credential_acked",
         "credential-issued": "credential_issued",
         "credential-received": "credential_received",

--- a/shared/models/presentation_exchange.py
+++ b/shared/models/presentation_exchange.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from aries_cloudcontroller import (
     IndyProof,
@@ -7,7 +7,6 @@ from aries_cloudcontroller import (
     V20PresExRecord,
 )
 from pydantic import BaseModel
-from typing_extensions import Literal
 
 from shared.models.protocol import PresentProofProtocolVersion
 

--- a/shared/models/presentation_exchange.py
+++ b/shared/models/presentation_exchange.py
@@ -104,7 +104,7 @@ def presentation_record_to_model(
             verified=string_to_bool(record.verified),
         )
     else:
-        raise ValueError("Record format unknown.")
+        raise ValueError("Presentation record format unknown.")
 
 
 def v1_presentation_state_to_rfc_state(state: Optional[str]) -> Optional[str]:

--- a/shared/models/protocol.py
+++ b/shared/models/protocol.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from shared.exceptions.cloudapi_value_error import CloudApiValueError
+
 
 class PresentProofProtocolVersion(str, Enum):
     v1: str = "v1"
@@ -15,4 +17,4 @@ def pres_id_no_version(proof_id: str) -> str:
     if proof_id.startswith("v2-") or proof_id.startswith("v1-"):
         return proof_id[3:]
     else:
-        raise ValueError("proof_id must start with prefix `v1-` or `v2-`.")
+        raise CloudApiValueError("proof_id must start with prefix `v1-` or `v2-`.")

--- a/shared/util/rich_parsing.py
+++ b/shared/util/rich_parsing.py
@@ -3,11 +3,11 @@ from typing import Type, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
-# Define generic type for `parse_with_error_handling`
+# Define generic type for `parse_json_with_error_handling`
 T = TypeVar("T", bound=BaseModel)
 
 
-def parse_with_error_handling(model: Type[T], data: str, logger: Logger) -> T:
+def parse_json_with_error_handling(model: Type[T], data: str, logger: Logger) -> T:
     try:
         return model.model_validate_json(data)
     except ValidationError as e:

--- a/trustregistry/tests/test_models.py
+++ b/trustregistry/tests/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 
+from shared.exceptions.cloudapi_value_error import CloudApiValueError
 from shared.models.trustregistry import Actor, Schema
 from trustregistry import db
 
@@ -28,13 +29,13 @@ def test_schema():
     assert schema.version == "0.4.20"
     assert schema.id == "abc:2:doubleaceschema:0.4.20"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(CloudApiValueError):
         Schema(did="abc:def", name="doubleaceschema", version="0.4.20")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(CloudApiValueError):
         Schema(did="abc", name="double:ace:schema", version="0.4.20")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(CloudApiValueError):
         Schema(did="abc", name="doubleaceschema", version="0:4:20")
 
 

--- a/webhooks/models/topic_payloads.py
+++ b/webhooks/models/topic_payloads.py
@@ -1,8 +1,8 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional, TypedDict
 
 from aries_cloudcontroller import V20CredExRecordIndy, V20CredExRecordLDProof
 from pydantic import BaseModel, Field
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 
 class BasicMessage(BaseModel):

--- a/webhooks/models/topic_payloads.py
+++ b/webhooks/models/topic_payloads.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Optional, TypedDict
+from typing import Dict, List, Literal, Optional
 
 from aries_cloudcontroller import V20CredExRecordIndy, V20CredExRecordLDProof
 from pydantic import BaseModel, Field

--- a/webhooks/services/acapy_events_processor.py
+++ b/webhooks/services/acapy_events_processor.py
@@ -8,7 +8,7 @@ from shared import APIRouter
 from shared.constants import GOVERNANCE_LABEL
 from shared.log_config import get_logger
 from shared.models.endorsement import payload_is_applicable_for_endorser
-from shared.util.rich_parsing import parse_with_error_handling
+from shared.util.rich_parsing import parse_json_with_error_handling
 from webhooks.models import AcaPyWebhookEvent, topic_mapping
 from webhooks.models.conversions import acapy_to_cloudapi_event
 from webhooks.models.redis_payloads import AcaPyRedisEvent
@@ -259,7 +259,7 @@ class AcaPyEventsProcessor:
         Args:
             event_json: The JSON string representation of the ACA-Py event.
         """
-        event = parse_with_error_handling(AcaPyRedisEvent, event_json, logger)
+        event = parse_json_with_error_handling(AcaPyRedisEvent, event_json, logger)
 
         metadata_origin = event.metadata.origin
 

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -5,7 +5,7 @@ from redis import RedisCluster
 
 from shared.models.webhook_events.payloads import CloudApiWebhookEventGeneric
 from shared.services.redis_service import RedisService
-from shared.util.rich_parsing import parse_with_error_handling
+from shared.util.rich_parsing import parse_json_with_error_handling
 
 
 class WebhooksRedisService(RedisService):
@@ -144,7 +144,9 @@ class WebhooksRedisService(RedisService):
         """
         entries = self.get_json_cloudapi_events_by_wallet(wallet_id)
         parsed_entries = [
-            parse_with_error_handling(CloudApiWebhookEventGeneric, entry, self.logger)
+            parse_json_with_error_handling(
+                CloudApiWebhookEventGeneric, entry, self.logger
+            )
             for entry in entries
         ]
         return parsed_entries
@@ -232,7 +234,9 @@ class WebhooksRedisService(RedisService):
             wallet_id, start_timestamp, end_timestamp
         )
         parsed_entries = [
-            parse_with_error_handling(CloudApiWebhookEventGeneric, entry, self.logger)
+            parse_json_with_error_handling(
+                CloudApiWebhookEventGeneric, entry, self.logger
+            )
             for entry in entries
         ]
         return parsed_entries

--- a/webhooks/tests/test_redis_service.py
+++ b/webhooks/tests/test_redis_service.py
@@ -68,7 +68,7 @@ async def test_get_cloudapi_events_by_wallet(mocker):
         redis_service, "get_json_cloudapi_events_by_wallet", return_value=json_entries
     )
     mocker.patch(
-        "shared.util.rich_parsing.parse_with_error_handling",
+        "shared.util.rich_parsing.parse_json_with_error_handling",
         side_effect=expected_events,
     )
 
@@ -156,7 +156,7 @@ async def test_get_cloudapi_events_by_timestamp(mocker):
         return_value=json_entries,
     )
     mocker.patch(
-        "shared.util.rich_parsing.parse_with_error_handling",
+        "shared.util.rich_parsing.parse_json_with_error_handling",
         side_effect=cloudapi_entries,
     )
 


### PR DESCRIPTION
✨ Applies `handle_acapy_call` _everywhere_, so that all acapy method calls are now wrapped with default error handling.
✨ Implement `handle_model_with_validation` which similarly provides automatic error handling for Pydantic validation errors.

The above two methods account for most of the changes in this PR, with the result being that we no longer have any unnecessary stack traces being printed from the test suite.

Other improvements include
- implementation of a new custom exception: CloudApiValueError, replacing `ValueError` which is unhandled by fastapi and raises stack trace. CloudApiValueError extends an HTTPException and now has custom handling.
- I moved some model validator logic which was being done in the routes to rather be part of the model definitions. Namely: JSON-LD and OOB models, 
- Note: `@router.delete("/{connection_id}")` in Connections API now has status_code 204, instead of 200 with {} response.
- I removed the usage of a custom `Did` model from our acapy_wallet module. It was unnecessary as it throws away helpful info included in the ACA-PY `DID` response.
- Added support for a "deleted" state in our CredentialExchange model