### PR TITLE
:adhesive_bandage: disable pubsub notification listener in events processors

### DIFF
--- a/endorser/services/endorsement_processor.py
+++ b/endorser/services/endorsement_processor.py
@@ -40,7 +40,7 @@ class EndorsementProcessor:
         """
         Starts the background tasks for processing endorsement events.
         """
-        self._start_notification_listener()
+        # self._start_notification_listener()  # disable as it is currently unused
         self._tasks.append(
             asyncio.create_task(
                 self._process_endorsement_requests(), name="Process endorsements"
@@ -79,7 +79,11 @@ class EndorsementProcessor:
         """
         logger.debug("Checking if all tasks are running")
 
-        pubsub_thread_running = self._pubsub_thread and self._pubsub_thread.is_alive()
+        # todo: disabling pubsub thread check as it's currently unused and disconnects periodically on test env
+        pubsub_thread_running = (
+            True  # self._pubsub_thread and self._pubsub_thread.is_alive()
+        )
+
         tasks_running = self._tasks and all(not task.done() for task in self._tasks)
 
         if not pubsub_thread_running:

--- a/endorser/tests/test_endorser_processor.py
+++ b/endorser/tests/test_endorser_processor.py
@@ -89,8 +89,10 @@ async def test_are_tasks_running_x(endorsement_processor_mock):
     dummy_done_task.done.return_value = False
     endorsement_processor_mock._tasks = [dummy_done_task]
     # when pubsub thread stops, tasks should be not running
-    endorsement_processor_mock._pubsub_thread.is_alive.return_value = False
-    assert not endorsement_processor_mock.are_tasks_running()
+
+    # todo: uncomment these tests after reimplemented:
+    # endorsement_processor_mock._pubsub_thread.is_alive.return_value = False
+    # assert not endorsement_processor_mock.are_tasks_running()
 
 
 @pytest.mark.anyio

--- a/webhooks/services/acapy_events_processor.py
+++ b/webhooks/services/acapy_events_processor.py
@@ -42,7 +42,7 @@ class AcaPyEventsProcessor:
         """
         Start the background tasks as part of AcaPyEventsProcessor's lifecycle
         """
-        self._start_notification_listener()
+        # self._start_notification_listener()  # disable as it is currently unused
         self._tasks.append(
             asyncio.create_task(
                 self._process_incoming_events(), name="Process incoming events"
@@ -82,7 +82,10 @@ class AcaPyEventsProcessor:
         """
         logger.debug("Checking if all tasks are running")
 
-        pubsub_thread_running = self._pubsub_thread and self._pubsub_thread.is_alive()
+        # todo: disabling pubsub thread check as it's currently unused and disconnects periodically on test env
+        pubsub_thread_running = (
+            True  # self._pubsub_thread and self._pubsub_thread.is_alive()
+        )
         tasks_running = self._tasks and all(not task.done() for task in self._tasks)
 
         if not pubsub_thread_running:

--- a/webhooks/tests/test_acapy_events_processor.py
+++ b/webhooks/tests/test_acapy_events_processor.py
@@ -88,8 +88,10 @@ async def test_are_tasks_running_x(acapy_events_processor_mock):
     dummy_done_task.done.return_value = False
     acapy_events_processor_mock._tasks = [dummy_done_task]
     # when pubsub thread stops, tasks should be not running
-    acapy_events_processor_mock._pubsub_thread.is_alive.return_value = False
-    assert not acapy_events_processor_mock.are_tasks_running()
+
+    # todo: uncomment these tests after reimplemented:
+    # acapy_events_processor_mock._pubsub_thread.is_alive.return_value = False
+    # assert not acapy_events_processor_mock.are_tasks_running()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
pubsub listeners are currently unused in endorsement and acapy events processor. 

The code exists because it will be more elegant to wait for notifications before scanning redis. Currently we just continuously scan redis to avoid missing notifications, because it needs to be confirmed that notifications works reliably with cluster config.

In our test env, the redis pubsub channels disconnect after 1h, for some currently unknown reason, and then healthcheck causes pods to restart. 

This patches that behavior so pubsub connections aren't initialised or checked in healthcheck