### PR TITLE
:sparkles: obfuscate secret data from webhook logs

### DIFF
--- a/app/util/retry_method.py
+++ b/app/util/retry_method.py
@@ -77,7 +77,7 @@ async def coroutine_with_retry_until_value(
                     return result
 
             if attempt + 1 < max_attempts:
-                logger.info(
+                logger.debug(
                     (
                         "Coroutine returned {} instead of expected {} "
                         "(attempt {}). Retrying in {} seconds..."

--- a/shared/log_config.py
+++ b/shared/log_config.py
@@ -10,6 +10,7 @@ FILE_LOG_LEVEL = os.getenv("FILE_LOG_LEVEL", "DEBUG").upper()
 ENABLE_FILE_LOGGING = os.getenv("ENABLE_FILE_LOGGING", "").upper() == "TRUE"
 DISABLE_COLORIZE_LOGS = os.getenv("DISABLE_COLORIZE_LOGS", "").upper() == "TRUE"
 ENABLE_SERIALIZE_LOGS = os.getenv("ENABLE_SERIALIZE_LOGS", "").upper() == "TRUE"
+LOGURU_DIAGNOSE = os.getenv("LOGURU_DIAGNOSE", "").upper() == "TRUE"
 
 colorize = not DISABLE_COLORIZE_LOGS
 serialize = ENABLE_SERIALIZE_LOGS
@@ -130,6 +131,7 @@ def get_logger(name: str):
         logger_.add(
             sys.stdout,
             level=STDOUT_LOG_LEVEL,
+            diagnose=True,  # for local dev
             format=formatter,
             colorize=colorize,
         )
@@ -137,6 +139,7 @@ def get_logger(name: str):
         logger_.add(
             sys.stdout,
             level=STDOUT_LOG_LEVEL,
+            diagnose=LOGURU_DIAGNOSE,  # default = disabled for serialized logs
             format=_serialize_record,  # Use our custom serialization formatter
         )
 
@@ -149,6 +152,7 @@ def get_logger(name: str):
                 retention="7 days",  # keep logs for up to 7 days
                 enqueue=True,  # asynchronous
                 level=FILE_LOG_LEVEL,
+                diagnose=True,
                 format=formatter_builder("blue"),
                 serialize=serialize,
             )

--- a/shared/services/redis_service.py
+++ b/shared/services/redis_service.py
@@ -203,7 +203,7 @@ class RedisService:
 
         return collected_keys
 
-    def match_keys(self, match_pattern: str = "*") -> List[str]:
+    def match_keys(self, match_pattern: str = "*") -> List[bytes]:
         """
         Fetches keys from all Redis cluster nodes matching the pattern.
 

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -68,7 +68,7 @@ class WebhooksRedisService(RedisService):
                 "More than one redis key found for wallet: {}", wallet_id
             )
 
-        result = list_keys[0]
+        result = list_keys[0].decode()
         self.logger.debug("Returning matched key: {}.", result)
         return result
 

--- a/webhooks/tests/test_redis_service.py
+++ b/webhooks/tests/test_redis_service.py
@@ -51,7 +51,7 @@ async def test_get_json_cloudapi_events_by_wallet():
     redis_client = Mock()
     redis_client.zrange = Mock(return_value=[e.encode() for e in json_entries])
     redis_service = WebhooksRedisService(redis_client)
-    redis_service.match_keys = Mock(return_value=["dummy_key"])
+    redis_service.match_keys = Mock(return_value=[b"dummy_key"])
 
     events = redis_service.get_json_cloudapi_events_by_wallet(wallet_id)
 
@@ -128,7 +128,7 @@ async def test_get_json_cloudapi_events_by_timestamp():
     redis_client.zrangebyscore = Mock(return_value=[e.encode() for e in json_entries])
 
     redis_service = WebhooksRedisService(redis_client)
-    expected_key = f"{redis_service.cloudapi_redis_prefix}:{wallet_id}"
+    expected_key = f"{redis_service.cloudapi_redis_prefix}:{wallet_id}".encode()
 
     redis_service.match_keys = Mock(return_value=[expected_key])
 


### PR DESCRIPTION
Two webhook event topics were identified to possibly contain sensitive data:
`endorsement` events, and `issue_credential_v2_0_indy` events.

Endorsements can either contain a `messages_attach`, or `signature_response` object in the payload, which contains a json string that references a `master_secret` value. The exact nature of this value, and whether it is truly sensitive data, is not yet fully known, but for simplicity we redact these values from logs.

Similarly, `issue_credential_v2_0_indy` events contain a `master_secret_blinding_data` field in the `cred_request_metadata`. For simplicity, we redact these values as well.

Lastly, loguru sinks take a `diagnose` field, which impacts whether values are printed in exception stack traces or not. To prevent sensitive data from leaking in exceptions, we set this to be False by default, for serialised logging only. 