### PR TITLE
:bug: Fix double endorsement

### DIFF
--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -2,7 +2,7 @@ FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.11.0
 
 USER root
 # install redis-events plugin
-RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-03-11#subdirectory=redis_events
+RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-03-25#subdirectory=redis_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -6,7 +6,7 @@ USER root
 RUN pip3 install --no-cache-dir acapy-wallet-groups-plugin==0.7.0
 
 # install redis-events plugin
-RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-03-11#subdirectory=redis_events
+RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-03-25#subdirectory=redis_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/shared/models/endorsement.py
+++ b/shared/models/endorsement.py
@@ -89,6 +89,11 @@ valid_operation_types = [
 
 
 def payload_is_applicable_for_endorser(payload: Dict[str, Any], logger: Logger) -> bool:
+    transaction_id = payload.get("transaction_id")
+    if not transaction_id:
+        logger.warning("No transaction id associated with this endorsement event")
+        return False
+
     state = payload.get("state")
 
     if state == applicable_transaction_state:

--- a/webhooks/services/acapy_events_processor.py
+++ b/webhooks/services/acapy_events_processor.py
@@ -326,7 +326,10 @@ class AcaPyEventsProcessor:
             and payload_is_applicable_for_endorser(payload, logger=bound_logger)
         ):
             logger.info("Forwarding endorsement event for Endorser service")
-            self.redis_service.add_endorsement_event(event_json=webhook_event_json)
+            transaction_id = payload["transaction_id"]  # check has asserted key exists
+            self.redis_service.add_endorsement_event(
+                event_json=webhook_event_json, transaction_id=transaction_id
+            )
 
         # Add data to redis, which publishes to a redis pubsub channel that SseManager listens to
         self.redis_service.add_cloudapi_webhook_event(


### PR DESCRIPTION
Resolves double endorsement issue when running with more than one endorser replica. 

Fixes duplicate webhook events in general! 

Primary change in our custom redis-events plugin: https://github.com/didx-xyz/aries-acapy-plugins/pull/114