### PR TITLE
:wastebasket: Deprecate webhooks endpoint

### DIFF
--- a/app/routes/webhooks.py
+++ b/app/routes/webhooks.py
@@ -12,12 +12,15 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/v1/webhooks", tags=["webhooks"])
 
 
-@router.get("")
+@router.get("", deprecated=True)
 async def get_webhooks_for_wallet(
     # Makes sure the authentication is verified
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> List[CloudApiWebhookEventGeneric]:
     """
+    **Deprecated**: Fetching bulk webhook events is set to be removed.
+    We recommend monitoring webhook events live, using the SSE endpoint instead, or websockets if preferred.
+
     Returns all webhooks per wallet
 
     This implicitly extracts the wallet ID and return only items
@@ -34,13 +37,16 @@ async def get_webhooks_for_wallet(
     return await get_hooks_for_wallet(wallet_id=auth.wallet_id)
 
 
-@router.get("/{topic}")
+@router.get("/{topic}", deprecated=True)
 async def get_webhooks_for_wallet_by_topic(
     topic: CloudApiTopics,
     # Makes sure the authentication is verified
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> List[CloudApiWebhookEventGeneric]:
     """
+    **Deprecated**: Fetching bulk webhook events is set to be removed.
+    We recommend monitoring webhook events live, using the SSE endpoint instead, or websockets if preferred.
+
     Returns the webhooks per wallet per topic
 
     This implicitly extracts the wallet ID and return only items

--- a/app/routes/webhooks.py
+++ b/app/routes/webhooks.py
@@ -14,17 +14,16 @@ router = APIRouter(prefix="/v1/webhooks", tags=["webhooks"])
 
 @router.get("", deprecated=True)
 async def get_webhooks_for_wallet(
-    # Makes sure the authentication is verified
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> List[CloudApiWebhookEventGeneric]:
     """
     **Deprecated**: Fetching bulk webhook events is set to be removed.
     We recommend monitoring webhook events live, using the SSE endpoint instead, or websockets if preferred.
 
-    Returns all webhooks per wallet
+    Returns 100 most recent webhooks for this wallet
 
     This implicitly extracts the wallet ID and return only items
-    belonging to the wallet.
+    belonging to the caller's wallet.
 
     Returns:
     ---------
@@ -40,17 +39,16 @@ async def get_webhooks_for_wallet(
 @router.get("/{topic}", deprecated=True)
 async def get_webhooks_for_wallet_by_topic(
     topic: CloudApiTopics,
-    # Makes sure the authentication is verified
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> List[CloudApiWebhookEventGeneric]:
     """
     **Deprecated**: Fetching bulk webhook events is set to be removed.
     We recommend monitoring webhook events live, using the SSE endpoint instead, or websockets if preferred.
 
-    Returns the webhooks per wallet per topic
+    Returns 100 most recent webhooks for this wallet / topic pair
 
     This implicitly extracts the wallet ID and return only items
-    belonging to the wallet.
+    belonging to the caller's wallet.
 
     Returns:
     ---------

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -20,7 +20,7 @@ async def get_hooks_for_wallet_by_topic(wallet_id: str, topic: CloudApiTopics) -
             ).json()
             return hooks if hooks else []
     except HTTPError as e:
-        bound_logger.exception("HTTP Error caught when fetching webhooks.")
+        bound_logger.error("HTTP Error caught when fetching webhooks: {}.", e)
         raise e
 
 
@@ -35,5 +35,5 @@ async def get_hooks_for_wallet(wallet_id: str) -> List:
             hooks = (await client.get(f"{WEBHOOKS_URL}/webhooks/{wallet_id}")).json()
             return hooks if hooks else []
     except HTTPError as e:
-        bound_logger.exception("HTTP Error caught when fetching webhooks.")
+        bound_logger.error("HTTP Error caught when fetching webhooks: {}.", e)
         raise e

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -10,20 +10,6 @@ from shared.util.rich_async_client import RichAsyncClient
 logger = get_logger(__name__)
 
 
-async def get_hooks_for_wallet_by_topic(wallet_id: str, topic: CloudApiTopics) -> List:
-    bound_logger = logger.bind(body={"wallet_id": wallet_id, "topic": topic})
-    bound_logger.info("Fetching webhooks events from /webhooks/wallet_id/topic")
-    try:
-        async with RichAsyncClient() as client:
-            hooks = (
-                await client.get(f"{WEBHOOKS_URL}/webhooks/{wallet_id}/{topic}")
-            ).json()
-            return hooks if hooks else []
-    except HTTPError as e:
-        bound_logger.error("HTTP Error caught when fetching webhooks: {}.", e)
-        raise e
-
-
 async def get_hooks_for_wallet(wallet_id: str) -> List:
     """
     Gets webhooks for wallet. Only return the first 100 hooks to not overload OpenAPI interface
@@ -33,6 +19,20 @@ async def get_hooks_for_wallet(wallet_id: str) -> List:
     try:
         async with RichAsyncClient() as client:
             hooks = (await client.get(f"{WEBHOOKS_URL}/webhooks/{wallet_id}")).json()
+            return hooks if hooks else []
+    except HTTPError as e:
+        bound_logger.error("HTTP Error caught when fetching webhooks: {}.", e)
+        raise e
+
+
+async def get_hooks_for_wallet_by_topic(wallet_id: str, topic: CloudApiTopics) -> List:
+    bound_logger = logger.bind(body={"wallet_id": wallet_id, "topic": topic})
+    bound_logger.info("Fetching webhooks events from /webhooks/wallet_id/topic")
+    try:
+        async with RichAsyncClient() as client:
+            hooks = (
+                await client.get(f"{WEBHOOKS_URL}/webhooks/{wallet_id}/{topic}")
+            ).json()
             return hooks if hooks else []
     except HTTPError as e:
         bound_logger.error("HTTP Error caught when fetching webhooks: {}.", e)

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -112,11 +112,15 @@ class WebhooksRedisService(RedisService):
 
         Args:
             wallet_id: The identifier of the wallet for which events are retrieved.
-            num: The maximum number of events to return. None returns all.
+            num: The maximum number of events to return. None returns max.
 
         Returns:
             A list of event JSON strings.
         """
+        max = 10000  # Set to some large number to limit maximum number of webhooks returned
+        if not num:
+            num = max
+
         bound_logger = self.logger.bind(body={"wallet_id": wallet_id})
         bound_logger.trace("Fetching entries from redis by wallet id")
 
@@ -124,10 +128,6 @@ class WebhooksRedisService(RedisService):
         if not redis_key:
             bound_logger.debug("No entries found for wallet without matching redis key")
             return []
-
-        if num is None:
-            # Set to some large number to limit maximum number of webhooks returned
-            num = 10000
 
         # Fetch all entries using the full range of scores
         entries: List[bytes] = self.redis.zrevrangebyscore(
@@ -147,7 +147,7 @@ class WebhooksRedisService(RedisService):
 
         Args:
             wallet_id: The identifier of the wallet for which events are retrieved.
-            num: The maximum number of events to return. None returns all.
+            num: The maximum number of events to return. None returns max allowed.
 
         Returns:
             A list of CloudApiWebhookEventGeneric instances.
@@ -170,12 +170,13 @@ class WebhooksRedisService(RedisService):
         Args:
             wallet_id: The identifier of the wallet for which events are retrieved.
             topic: The topic to filter the events by.
-            num: The maximum number of events to return. None returns all.
+            num: The maximum number of events to return. None returns max allowed.
 
         Returns:
             A list of event JSON strings that match the specified topic.
         """
-        entries = self.get_json_cloudapi_events_by_wallet(wallet_id, num=None)  # max
+        # Fetch maximum because we must post-filter to return `num` relevant topic entires
+        entries = self.get_json_cloudapi_events_by_wallet(wallet_id, num=None)
         # Filter the json entry for our requested topic without deserialising
         topic_str = f'"topic":"{topic}"'
         filtered_by_topic = [entry for entry in entries if topic_str in entry]
@@ -197,7 +198,8 @@ class WebhooksRedisService(RedisService):
         Returns:
             A list of CloudApiWebhookEventGeneric instances that match the specified topic.
         """
-        entries = self.get_cloudapi_events_by_wallet(wallet_id, num=None)  # fetch max
+        # Fetch maximum because we must post-filter to return `num` relevant topic entires
+        entries = self.get_cloudapi_events_by_wallet(wallet_id, num=None)
         filtered_by_topic = [entry for entry in entries if topic == entry.topic]
         result = filtered_by_topic[:num] if num else filtered_by_topic
         return result
@@ -317,4 +319,6 @@ class WebhooksRedisService(RedisService):
         if result:
             bound_logger.debug("Successfully wrote endorsement entry to redis.")
         else:
-            bound_logger.warning("Redis key for this endorsement entry is already set.")
+            bound_logger.warning(
+                "Redis key for this endorsement entry is already set."
+            )  #

--- a/webhooks/tests/test_redis_service.py
+++ b/webhooks/tests/test_redis_service.py
@@ -49,14 +49,16 @@ async def test_add_cloudapi_webhook_event():
 @pytest.mark.anyio
 async def test_get_json_cloudapi_events_by_wallet():
     redis_client = Mock()
-    redis_client.zrange = Mock(return_value=[e.encode() for e in json_entries])
+    redis_client.zrevrangebyscore = Mock(
+        return_value=[e.encode() for e in json_entries]
+    )
     redis_service = WebhooksRedisService(redis_client)
     redis_service.match_keys = Mock(return_value=[b"dummy_key"])
 
     events = redis_service.get_json_cloudapi_events_by_wallet(wallet_id)
 
     assert events == json_entries
-    redis_client.zrange.assert_called_once()
+    redis_client.zrevrangebyscore.assert_called_once()
 
 
 @pytest.mark.anyio

--- a/webhooks/web/routers/webhooks.py
+++ b/webhooks/web/routers/webhooks.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/webhooks")
 
 @router.get(
     "/{wallet_id}",
-    summary="Get all webhook events for a wallet ID",
+    summary="Get 100 most recent webhook events for a wallet ID",
     response_model=List[CloudApiWebhookEventGeneric],
 )
 @inject
@@ -27,7 +27,7 @@ async def get_webhooks_by_wallet(
     bound_logger = logger.bind(body={"wallet_id": wallet_id})
     bound_logger.info("GET request received: Fetch all webhook events for wallet")
 
-    data = redis_service.get_cloudapi_events_by_wallet(wallet_id)
+    data = redis_service.get_cloudapi_events_by_wallet(wallet_id, num=100)
 
     if data:
         bound_logger.info("Successfully fetched webhooks events for wallet.")
@@ -38,7 +38,7 @@ async def get_webhooks_by_wallet(
 
 @router.get(
     "/{wallet_id}/{topic}",
-    summary="Get all webhook events for a wallet ID and topic pair",
+    summary="Get 100 most recent webhook events for a wallet ID and topic pair",
     response_model=List[CloudApiWebhookEventGeneric],
 )
 @inject
@@ -53,7 +53,7 @@ async def get_webhooks_by_wallet_and_topic(
     )
 
     data = redis_service.get_cloudapi_events_by_wallet_and_topic(
-        wallet_id=wallet_id, topic=topic
+        wallet_id=wallet_id, topic=topic, num=100
     )
 
     if data:


### PR DESCRIPTION
Marks /webhooks endpoint as deprecated, with comment to recommend SSE / websockets instead.

Refactors fetching logic to ensure maximum of 100 events are returned, so as to not overload responses.