### PR TITLE
Speed up Docker Builds

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -137,7 +137,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=build-${{ matrix.image }}
+          cache-from: |
+            type=gha,scope=build-${{ matrix.image }}
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
           cache-to: type=gha,mode=max,scope=build-${{ matrix.image }}
 
   lint:


### PR DESCRIPTION
* Cache from the `latest` tag
* Skips building images from scratch that had no changes
  * In the future we'll add change detection so we only build images that
  actually need to be built