### PR TITLE
:sparkles: Validate wallet_id belongs to group_id in SSE subscriptions

### DIFF
--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -173,7 +173,7 @@ class SseManager:
             if isinstance(message_data, bytes):
                 message_data = message_data.decode("utf-8")
 
-            wallet_id, group_id, timestamp_ns_str = message_data.split(":")
+            wallet_id, timestamp_ns_str = message_data.split(":")
             timestamp_ns = int(timestamp_ns_str)
 
             # Fetch the event with the exact timestamp from the sorted set

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -173,15 +173,12 @@ class SseManager:
             if isinstance(message_data, bytes):
                 message_data = message_data.decode("utf-8")
 
-            group_id, wallet_id, timestamp_ns_str = message_data.split(":")
+            wallet_id, group_id, timestamp_ns_str = message_data.split(":")
             timestamp_ns = int(timestamp_ns_str)
 
             # Fetch the event with the exact timestamp from the sorted set
             json_events = self.redis_service.get_json_cloudapi_events_by_timestamp(
-                wallet_id=wallet_id,
-                start_timestamp=timestamp_ns,
-                end_timestamp=timestamp_ns,
-                group_id=group_id,
+                wallet_id, timestamp_ns, timestamp_ns
             )
 
             for json_event in json_events:
@@ -201,11 +198,10 @@ class SseManager:
                         event_json=json_event,
                         wallet_id=wallet_id,
                         topic=topic,
-                        group_id=group_id,
                     )
                 except ValidationError as e:
                     error_message = (
-                        "Could not parse json event retrieved from redis "
+                        "Could not parse json event retreived from redis "
                         f"into a `CloudApiWebhookEventGeneric`. Error: `{str(e)}`."
                     )
                     logger.error(error_message)
@@ -250,7 +246,6 @@ class SseManager:
             # Wait for an event to be added to the incoming events queue
             event: CloudApiWebhookEventGeneric = await self.incoming_events.get()
             wallet = event.wallet_id
-            group_id = event.group_id
             topic = event.topic
 
             # Process the event into the per-wallet queues

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -173,7 +173,7 @@ class SseManager:
             if isinstance(message_data, bytes):
                 message_data = message_data.decode("utf-8")
 
-            wallet_id, timestamp_ns_str = message_data.split(":")
+            wallet_id, group_id, timestamp_ns_str = message_data.split(":")
             timestamp_ns = int(timestamp_ns_str)
 
             # Fetch the event with the exact timestamp from the sorted set

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -470,6 +470,11 @@ class SseManager:
             # Wait for a while between cleanup operations
             await asyncio.sleep(QUEUE_CLEANUP_PERIOD)
 
+    def check_wallet_belongs_to_group(self, wallet_id: str, group_id: str) -> bool:
+        return self.redis_service.check_wallet_belongs_to_group(
+            wallet_id=wallet_id, group_id=group_id
+        )
+
 
 async def _copy_queue(
     queue: asyncio.Queue, maxsize: int = MAX_QUEUE_SIZE

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -173,12 +173,15 @@ class SseManager:
             if isinstance(message_data, bytes):
                 message_data = message_data.decode("utf-8")
 
-            wallet_id, group_id, timestamp_ns_str = message_data.split(":")
+            group_id, wallet_id, timestamp_ns_str = message_data.split(":")
             timestamp_ns = int(timestamp_ns_str)
 
             # Fetch the event with the exact timestamp from the sorted set
             json_events = self.redis_service.get_json_cloudapi_events_by_timestamp(
-                wallet_id, timestamp_ns, timestamp_ns
+                wallet_id=wallet_id,
+                start_timestamp=timestamp_ns,
+                end_timestamp=timestamp_ns,
+                group_id=group_id,
             )
 
             for json_event in json_events:
@@ -198,10 +201,11 @@ class SseManager:
                         event_json=json_event,
                         wallet_id=wallet_id,
                         topic=topic,
+                        group_id=group_id,
                     )
                 except ValidationError as e:
                     error_message = (
-                        "Could not parse json event retreived from redis "
+                        "Could not parse json event retrieved from redis "
                         f"into a `CloudApiWebhookEventGeneric`. Error: `{str(e)}`."
                     )
                     logger.error(error_message)
@@ -246,6 +250,7 @@ class SseManager:
             # Wait for an event to be added to the incoming events queue
             event: CloudApiWebhookEventGeneric = await self.incoming_events.get()
             wallet = event.wallet_id
+            group_id = event.group_id
             topic = event.topic
 
             # Process the event into the per-wallet queues

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -476,8 +476,9 @@ class SseManager:
             valid_wallet_group = self.redis_service.check_wallet_belongs_to_group(
                 wallet_id=wallet_id, group_id=group_id
             )
-            attempt += 1
-            await asyncio.sleep(delay)
+            if not valid_wallet_group:
+                attempt += 1
+                await asyncio.sleep(delay)
 
         return valid_wallet_group
 

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -465,10 +465,21 @@ class SseManager:
             # Wait for a while between cleanup operations
             await asyncio.sleep(QUEUE_CLEANUP_PERIOD)
 
-    def check_wallet_belongs_to_group(self, wallet_id: str, group_id: str) -> bool:
-        return self.redis_service.check_wallet_belongs_to_group(
-            wallet_id=wallet_id, group_id=group_id
-        )
+    async def check_wallet_belongs_to_group(
+        self, wallet_id: str, group_id: str, max_checks: int = 10, delay: float = 0.1
+    ) -> bool:
+        # We offer some grace window, in case SSE connection is attempted before any webhooks exist
+        # So we will retry checking `max_checks` times, with `delay` sleep in between
+        valid_wallet_group = False
+        attempt = 1
+        while not valid_wallet_group and attempt <= max_checks:
+            valid_wallet_group = self.redis_service.check_wallet_belongs_to_group(
+                wallet_id=wallet_id, group_id=group_id
+            )
+            attempt += 1
+            await asyncio.sleep(delay)
+
+        return valid_wallet_group
 
 
 async def _copy_queue(

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -332,6 +332,32 @@ class WebhooksRedisService(RedisService):
         if result:
             bound_logger.debug("Successfully wrote endorsement entry to redis.")
         else:
-            bound_logger.warning(
-                "Redis key for this endorsement entry is already set."
-            )  #
+            bound_logger.warning("Redis key for this endorsement entry is already set.")
+
+        self.logger.trace("Successfully wrote endorsement entry to redis.")
+
+    def check_wallet_belongs_to_group(self, wallet_id: str, group_id: str) -> bool:
+        """
+        Return a boolean indicating that the wallet_id belongs to the group_id or not
+        """
+        self.logger.trace("Checking if wallet belongs to group, based on redis keys")
+
+        wallet_group_key = self.get_cloudapi_event_redis_key(wallet_id, group_id)
+        self.logger.debug("Fetching redis keys matching pattern: {}", wallet_group_key)
+        list_keys = self.match_keys(wallet_group_key)
+
+        if not list_keys:
+            self.logger.debug(
+                "No redis keys found matching the pattern: {}.", wallet_group_key
+            )
+            return False
+
+        if len(list_keys) > 1:
+            self.logger.warning(
+                "More than one redis key found for pattern: {}", wallet_group_key
+            )
+
+        self.logger.debug(
+            "Validated that wallet {} belongs to group {}.", wallet_id, group_id
+        )
+        return True

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -207,11 +207,7 @@ class WebhooksRedisService(RedisService):
         return result
 
     def get_json_cloudapi_events_by_timestamp(
-        self,
-        wallet_id: str,
-        start_timestamp: float,
-        end_timestamp: float = "+inf",
-        group_id: Optional[str] = None,
+        self, wallet_id: str, start_timestamp: float, end_timestamp: float = "+inf"
     ) -> List[str]:
         """
         Retrieve all CloudAPI webhook event JSON strings for a specified wallet ID within a timestamp range.
@@ -227,17 +223,10 @@ class WebhooksRedisService(RedisService):
         bound_logger = self.logger.bind(body={"wallet_id": wallet_id})
         bound_logger.debug("Fetching entries from redis by timestamp for wallet")
 
-        if group_id:
-            redis_key = self.get_cloudapi_event_redis_key(
-                wallet_id=wallet_id, group_id=group_id
-            )
-        else:
-            redis_key = self.get_cloudapi_event_redis_key_unknown_group(wallet_id)
-            if not redis_key:
-                bound_logger.debug(
-                    "No entries found for wallet without matching redis key"
-                )
-                return []
+        redis_key = self.get_cloudapi_event_redis_key_unknown_group(wallet_id)
+        if not redis_key:
+            bound_logger.debug("No entries found for wallet without matching redis key")
+            return []
 
         entries: List[bytes] = self.redis.zrangebyscore(
             redis_key, min=start_timestamp, max=end_timestamp

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -207,7 +207,11 @@ class WebhooksRedisService(RedisService):
         return result
 
     def get_json_cloudapi_events_by_timestamp(
-        self, wallet_id: str, start_timestamp: float, end_timestamp: float = "+inf"
+        self,
+        wallet_id: str,
+        start_timestamp: float,
+        end_timestamp: float = "+inf",
+        group_id: Optional[str] = None,
     ) -> List[str]:
         """
         Retrieve all CloudAPI webhook event JSON strings for a specified wallet ID within a timestamp range.
@@ -223,10 +227,17 @@ class WebhooksRedisService(RedisService):
         bound_logger = self.logger.bind(body={"wallet_id": wallet_id})
         bound_logger.debug("Fetching entries from redis by timestamp for wallet")
 
-        redis_key = self.get_cloudapi_event_redis_key_unknown_group(wallet_id)
-        if not redis_key:
-            bound_logger.debug("No entries found for wallet without matching redis key")
-            return []
+        if group_id:
+            redis_key = self.get_cloudapi_event_redis_key(
+                wallet_id=wallet_id, group_id=group_id
+            )
+        else:
+            redis_key = self.get_cloudapi_event_redis_key_unknown_group(wallet_id)
+            if not redis_key:
+                bound_logger.debug(
+                    "No entries found for wallet without matching redis key"
+                )
+                return []
 
         entries: List[bytes] = self.redis.zrangebyscore(
             redis_key, min=start_timestamp, max=end_timestamp

--- a/webhooks/services/webhooks_redis_serivce.py
+++ b/webhooks/services/webhooks_redis_serivce.py
@@ -89,17 +89,15 @@ class WebhooksRedisService(RedisService):
             timestamp_ns: The timestamp (in nanoseconds) of when the event was saved.
         """
         bound_logger = self.logger.bind(
-            body={"group_id": group_id, "wallet_id": wallet_id, "event": event_json}
+            body={"wallet_id": wallet_id, "group_id": group_id, "event": event_json}
         )
         bound_logger.trace("Write entry to redis")
 
         # Use the current timestamp as the score for the sorted set
-        redis_key = self.get_cloudapi_event_redis_key(
-            wallet_id=wallet_id, group_id=group_id
-        )
+        redis_key = self.get_cloudapi_event_redis_key(wallet_id, group_id)
         self.redis.zadd(redis_key, {event_json: timestamp_ns})
 
-        broadcast_message = f"{group_id}:{wallet_id}:{timestamp_ns}"
+        broadcast_message = f"{wallet_id}:{timestamp_ns}"
         # publish that a new event has been added
         bound_logger.trace("Publish message on pubsub channel: {}", broadcast_message)
         self.redis.publish(self.sse_event_pubsub_channel, broadcast_message)

--- a/webhooks/tests/test_redis_service.py
+++ b/webhooks/tests/test_redis_service.py
@@ -189,3 +189,27 @@ async def test_get_all_cloudapi_wallet_ids():
 
     assert set(wallet_ids) == set(expected_wallet_ids)
     assert redis_client.scan.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_check_wallet_belongs_to_group():
+    valid_group_id = "abc"
+    match_keys_result = [f"cloudapi:group:{valid_group_id}:{wallet_id}".encode()]
+
+    redis_client = Mock()
+
+    redis_service = WebhooksRedisService(redis_client)
+    redis_service.match_keys = Mock(return_value=match_keys_result)
+
+    valid = redis_service.check_wallet_belongs_to_group(
+        wallet_id=wallet_id, group_id=valid_group_id
+    )
+
+    assert valid is True
+
+    redis_service.match_keys = Mock(return_value=[])
+    valid = redis_service.check_wallet_belongs_to_group(
+        wallet_id=wallet_id, group_id="invalid_group_id"
+    )
+
+    assert valid is False

--- a/webhooks/tests/test_sse_manager.py
+++ b/webhooks/tests/test_sse_manager.py
@@ -296,7 +296,9 @@ async def test_cleanup_cache(sse_manager):  # pylint: disable=redefined-outer-na
 
 
 @pytest.mark.anyio
-async def test_check_wallet_belongs_to_group_immediate_success(sse_manager):
+async def test_check_wallet_belongs_to_group_immediate_success(
+    sse_manager,  # pylint: disable=redefined-outer-name
+):
     sse_manager.redis_service.check_wallet_belongs_to_group = Mock(return_value=True)
 
     result = await sse_manager.check_wallet_belongs_to_group(
@@ -310,7 +312,9 @@ async def test_check_wallet_belongs_to_group_immediate_success(sse_manager):
 
 
 @pytest.mark.anyio
-async def test_check_wallet_belongs_to_group_eventual_success(sse_manager):
+async def test_check_wallet_belongs_to_group_eventual_success(
+    sse_manager,  # pylint: disable=redefined-outer-name
+):
     side_effects = [False] * 3 + [True]  # Fails 3 times, then succeeds
     sse_manager.redis_service.check_wallet_belongs_to_group = Mock(
         side_effect=side_effects
@@ -325,7 +329,9 @@ async def test_check_wallet_belongs_to_group_eventual_success(sse_manager):
 
 
 @pytest.mark.anyio
-async def test_check_wallet_belongs_to_group_failure(sse_manager):
+async def test_check_wallet_belongs_to_group_failure(
+    sse_manager,  # pylint: disable=redefined-outer-name
+):
     sse_manager.redis_service.check_wallet_belongs_to_group = Mock(return_value=False)
 
     result = await sse_manager.check_wallet_belongs_to_group(

--- a/webhooks/tests/test_sse_manager.py
+++ b/webhooks/tests/test_sse_manager.py
@@ -296,6 +296,47 @@ async def test_cleanup_cache(sse_manager):  # pylint: disable=redefined-outer-na
 
 
 @pytest.mark.anyio
+async def test_check_wallet_belongs_to_group_immediate_success(sse_manager):
+    sse_manager.redis_service.check_wallet_belongs_to_group = Mock(return_value=True)
+
+    result = await sse_manager.check_wallet_belongs_to_group(
+        wallet_id="wallet123", group_id="group456"
+    )
+
+    sse_manager.redis_service.check_wallet_belongs_to_group.assert_called_once_with(
+        wallet_id="wallet123", group_id="group456"
+    )
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_check_wallet_belongs_to_group_eventual_success(sse_manager):
+    side_effects = [False] * 3 + [True]  # Fails 3 times, then succeeds
+    sse_manager.redis_service.check_wallet_belongs_to_group = Mock(
+        side_effect=side_effects
+    )
+
+    result = await sse_manager.check_wallet_belongs_to_group(
+        wallet_id="wallet123", group_id="group456", delay=0.01
+    )
+
+    assert sse_manager.redis_service.check_wallet_belongs_to_group.call_count == 4
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_check_wallet_belongs_to_group_failure(sse_manager):
+    sse_manager.redis_service.check_wallet_belongs_to_group = Mock(return_value=False)
+
+    result = await sse_manager.check_wallet_belongs_to_group(
+        wallet_id="wallet123", group_id="group456", delay=0.01
+    )
+
+    assert sse_manager.redis_service.check_wallet_belongs_to_group.call_count == 10
+    assert result is False
+
+
+@pytest.mark.anyio
 async def test_copy_queue():
     # Create a queue with some items
     original_queue = asyncio.Queue()

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Optional
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import BackgroundTasks, Depends, Query, Request
@@ -29,6 +29,11 @@ lookback_time_field = Query(
     ),
 )
 
+group_id_field = Query(
+    default=None,
+    description="Group ID to which the wallet belongs",
+)
+
 
 async def check_disconnection(request: Request, stop_event: asyncio.Event) -> None:
     while not stop_event.is_set():
@@ -49,6 +54,7 @@ async def sse_subscribe_wallet(
     background_tasks: BackgroundTasks,
     wallet_id: str,
     lookback_time: int = lookback_time_field,
+    group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     """
@@ -108,6 +114,7 @@ async def sse_subscribe_wallet_topic(
     wallet_id: str,
     topic: str,
     lookback_time: int = lookback_time_field,
+    group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     """
@@ -168,6 +175,7 @@ async def sse_subscribe_event_with_state(
     topic: str,
     desired_state: str,
     lookback_time: int = lookback_time_field,
+    group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     bound_logger = logger.bind(
@@ -234,6 +242,7 @@ async def sse_subscribe_stream_with_fields(
     field: str,
     field_id: str,
     lookback_time: int = lookback_time_field,
+    group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     bound_logger = logger.bind(
@@ -298,6 +307,7 @@ async def sse_subscribe_event_with_field_and_state(
     field_id: str,
     desired_state: str,
     lookback_time: int = lookback_time_field,
+    group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     bound_logger = logger.bind(

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -30,7 +30,7 @@ lookback_time_field = Query(
 )
 
 
-async def check_disconnection(request: Request, stop_event: asyncio.Event):
+async def check_disconnection(request: Request, stop_event: asyncio.Event) -> None:
     while not stop_event.is_set():
         if await request.is_disconnected():
             logger.debug("SSE check_disconnection: request has disconnected.")
@@ -50,7 +50,7 @@ async def sse_subscribe_wallet(
     wallet_id: str,
     lookback_time: int = lookback_time_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
-):
+) -> EventSourceResponse:
     """
     Subscribe to server-side events for a specific wallet ID.
 
@@ -109,7 +109,7 @@ async def sse_subscribe_wallet_topic(
     topic: str,
     lookback_time: int = lookback_time_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
-):
+) -> EventSourceResponse:
     """
     Subscribe to server-side events for a specific topic and wallet ID.
 
@@ -169,7 +169,7 @@ async def sse_subscribe_event_with_state(
     desired_state: str,
     lookback_time: int = lookback_time_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
-):
+) -> EventSourceResponse:
     bound_logger = logger.bind(
         body={"wallet_id": wallet_id, "topic": topic, "desired_state": desired_state}
     )
@@ -235,7 +235,7 @@ async def sse_subscribe_stream_with_fields(
     field_id: str,
     lookback_time: int = lookback_time_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
-):
+) -> EventSourceResponse:
     bound_logger = logger.bind(
         body={"wallet_id": wallet_id, "topic": topic, field: field_id}
     )
@@ -299,7 +299,7 @@ async def sse_subscribe_event_with_field_and_state(
     desired_state: str,
     lookback_time: int = lookback_time_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
-):
+) -> EventSourceResponse:
     bound_logger = logger.bind(
         body={
             "wallet_id": wallet_id,

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -35,6 +35,15 @@ group_id_field = Query(
 )
 
 
+class BadGroupIdException(HTTPException):
+    """Custom exception when group_id is specified and no events exist on redis"""
+
+    def __init__(self):
+        super().__init__(
+            status_code=404, detail="No events found for this wallet/group combination"
+        )
+
+
 async def check_disconnection(request: Request, stop_event: asyncio.Event) -> None:
     while not stop_event.is_set():
         if await request.is_disconnected():
@@ -72,9 +81,7 @@ async def sse_subscribe_wallet(
     if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
-        raise HTTPException(
-            status_code=403, detail="Wallet ID not a member of this group"
-        )
+        raise BadGroupIdException()
 
     async def event_stream() -> AsyncGenerator[str, None]:
         stop_event = asyncio.Event()
@@ -140,9 +147,7 @@ async def sse_subscribe_wallet_topic(
     if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
-        raise HTTPException(
-            status_code=403, detail="Wallet ID not a member of this group"
-        )
+        raise BadGroupIdException()
 
     async def event_stream() -> AsyncGenerator[str, None]:
         stop_event = asyncio.Event()
@@ -210,9 +215,7 @@ async def sse_subscribe_event_with_state(
     if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
-        raise HTTPException(
-            status_code=403, detail="Wallet ID not a member of this group"
-        )
+        raise BadGroupIdException()
 
     async def event_stream() -> AsyncGenerator[str, None]:
         stop_event = asyncio.Event()
@@ -289,9 +292,7 @@ async def sse_subscribe_stream_with_fields(
     if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
-        raise HTTPException(
-            status_code=403, detail="Wallet ID not a member of this group"
-        )
+        raise BadGroupIdException()
 
     async def event_stream() -> AsyncGenerator[str, None]:
         stop_event = asyncio.Event()
@@ -367,9 +368,7 @@ async def sse_subscribe_event_with_field_and_state(
     if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
-        raise HTTPException(
-            status_code=403, detail="Wallet ID not a member of this group"
-        )
+        raise BadGroupIdException()
 
     async def event_stream() -> AsyncGenerator[str, None]:
         stop_event = asyncio.Event()

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -69,7 +69,7 @@ async def sse_subscribe_wallet(
         "SSE: GET request received: Subscribe to wallet events on all topics"
     )
 
-    if group_id and not sse_manager.check_wallet_belongs_to_group(
+    if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
         raise HTTPException(
@@ -137,7 +137,7 @@ async def sse_subscribe_wallet_topic(
     )
     bound_logger.info("SSE: GET request received: Subscribe to wallet events by topic")
 
-    if group_id and not sse_manager.check_wallet_belongs_to_group(
+    if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
         raise HTTPException(
@@ -207,7 +207,7 @@ async def sse_subscribe_event_with_state(
         "waiting for specific state"
     )
 
-    if group_id and not sse_manager.check_wallet_belongs_to_group(
+    if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
         raise HTTPException(
@@ -286,7 +286,7 @@ async def sse_subscribe_stream_with_fields(
         "only events with specific field-id pairs"
     )
 
-    if group_id and not sse_manager.check_wallet_belongs_to_group(
+    if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
         raise HTTPException(
@@ -364,7 +364,7 @@ async def sse_subscribe_event_with_field_and_state(
         "waiting for payload with field-id pair and specific state"
     )
 
-    if group_id and not sse_manager.check_wallet_belongs_to_group(
+    if group_id and not await sse_manager.check_wallet_belongs_to_group(
         wallet_id=wallet_id, group_id=group_id
     ):
         raise HTTPException(

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncGenerator, Optional
+from typing import AsyncGenerator, Optional
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import BackgroundTasks, Depends, HTTPException, Query, Request

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Generator
+from typing import Any, AsyncGenerator
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import BackgroundTasks, Depends, Query, Request
@@ -63,7 +63,7 @@ async def sse_subscribe_wallet(
         "SSE: GET request received: Subscribe to wallet events on all topics"
     )
 
-    async def event_stream() -> Generator[str, Any, None]:
+    async def event_stream() -> AsyncGenerator[str, Any, None]:
         stop_event = asyncio.Event()
         event_generator_wrapper: EventGeneratorWrapper = (
             await sse_manager.sse_event_stream(
@@ -121,7 +121,7 @@ async def sse_subscribe_wallet_topic(
     bound_logger = logger.bind(body={"wallet_id": wallet_id, "topic": topic})
     bound_logger.info("SSE: GET request received: Subscribe to wallet events by topic")
 
-    async def event_stream() -> Generator[str, Any, None]:
+    async def event_stream() -> AsyncGenerator[str, Any, None]:
         stop_event = asyncio.Event()
         event_generator_wrapper: EventGeneratorWrapper = (
             await sse_manager.sse_event_stream(
@@ -178,7 +178,7 @@ async def sse_subscribe_event_with_state(
         "waiting for specific state"
     )
 
-    async def event_stream():
+    async def event_stream() -> AsyncGenerator[str, Any, None]:
         stop_event = asyncio.Event()
         event_generator_wrapper: EventGeneratorWrapper = (
             await sse_manager.sse_event_stream(
@@ -244,7 +244,7 @@ async def sse_subscribe_stream_with_fields(
         "only events with specific field-id pairs"
     )
 
-    async def event_stream():
+    async def event_stream() -> AsyncGenerator[str, Any, None]:
         stop_event = asyncio.Event()
         event_generator_wrapper: EventGeneratorWrapper = (
             await sse_manager.sse_event_stream(
@@ -313,7 +313,7 @@ async def sse_subscribe_event_with_field_and_state(
         "waiting for payload with field-id pair and specific state"
     )
 
-    async def event_stream():
+    async def event_stream() -> AsyncGenerator[str, Any, None]:
         stop_event = asyncio.Event()
         event_generator_wrapper: EventGeneratorWrapper = (
             await sse_manager.sse_event_stream(

--- a/webhooks/web/routers/websocket.py
+++ b/webhooks/web/routers/websocket.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from fastapi import APIRouter
 from fastapi_websocket_pubsub import PubSubEndpoint
 
@@ -15,7 +13,7 @@ endpoint.register_route(router, "/pubsub")
 
 
 async def publish_event_on_websocket(
-    event_json: str, wallet_id: str, topic: str, group_id: Optional[str] = None
+    event_json: str, wallet_id: str, topic: str
 ) -> None:
     """
     Publish the webhook to websocket subscribers on the following topics:
@@ -28,7 +26,6 @@ async def publish_event_on_websocket(
         event_json (str): Webhook event serialized as json
         wallet_id (str): The wallet_id for this event
         topic (str): The cloudapi topic for the event
-        group_id (Optional[str]): The group_id that the wallet belongs to
     """
 
     publish_topics = [topic, wallet_id, f"{topic}-{wallet_id}", WEBHOOK_TOPIC_ALL]

--- a/webhooks/web/routers/websocket.py
+++ b/webhooks/web/routers/websocket.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import APIRouter
 from fastapi_websocket_pubsub import PubSubEndpoint
 
@@ -13,7 +15,7 @@ endpoint.register_route(router, "/pubsub")
 
 
 async def publish_event_on_websocket(
-    event_json: str, wallet_id: str, topic: str
+    event_json: str, wallet_id: str, topic: str, group_id: Optional[str] = None
 ) -> None:
     """
     Publish the webhook to websocket subscribers on the following topics:
@@ -26,6 +28,7 @@ async def publish_event_on_websocket(
         event_json (str): Webhook event serialized as json
         wallet_id (str): The wallet_id for this event
         topic (str): The cloudapi topic for the event
+        group_id (Optional[str]): The group_id that the wallet belongs to
     """
 
     publish_topics = [topic, wallet_id, f"{topic}-{wallet_id}", WEBHOOK_TOPIC_ALL]


### PR DESCRIPTION
Adds assertion logic to SSE routes, so that if a group_id exists in the query parameters. we assert using redis keys that the wallet does in fact belong to that group. We raise a 403 otherwise.