### PR TITLE
Don't write Pytest Coverage unless PR

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -633,12 +633,17 @@ jobs:
           require_passed_tests: true
 
       - name: Pytest coverage comment
-        if: ${{ github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run-tests != 'false') }}
+        if: (
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.run-tests != 'false')
+          )
         uses: MishaKav/pytest-coverage-comment@v1.1.51
         with:
           pytest-coverage-path: ./test_coverage.txt
           junitxml-path: ./test_output.xml
           create-new-comment: true
+          # Resolves `Warning: Your comment is too long (maximum is 65536 characters), coverage report will not be added.`
+          hide-report: ${{ github.event_name != 'pull_request' }}
 
       - name: Helmfile destroy pytest
         uses: helmfile/helmfile-action@v1.8.0


### PR DESCRIPTION
* Don't automatically write the Pytest Coverage comment unless it's a PR
  * Resolves `Error: HttpError: Resource not accessible by integration`
* If it's not a PR, then hide the report
  * Resolves `Warning: Your comment is too long (maximum is 65536 characters), coverage report will not be added.`