### PR TITLE
:sparkles: add group_id to websocket subscriptions

### DIFF
--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, WebSocket
+from fastapi import APIRouter, Depends, Query, WebSocket
 
 from app.dependencies.auth import AcaPyAuthVerified
 from app.services.websocket import handle_websocket, websocket_auth
@@ -8,24 +8,39 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
+group_id_field = Query(default="", description="Group ID to which the wallet belongs")
+
+
 @router.websocket("/v1/ws/topic/{topic}")
 async def websocket_endpoint_topic(
     websocket: WebSocket,
     topic: str,
+    group_id: str = group_id_field,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
-    logger.info("Received websocket request on topic `{}`", topic)
-    await handle_websocket(websocket, wallet_id="", topic=topic, auth=auth)
+    logger.info(
+        "Received websocket request on group `{}` and topic `{}`", group_id, topic
+    )
+    await handle_websocket(
+        websocket, group_id=group_id, wallet_id="", topic=topic, auth=auth
+    )
 
 
 @router.websocket("/v1/ws/{wallet_id}")
 async def websocket_endpoint_wallet(
     websocket: WebSocket,
     wallet_id: str,
+    group_id: str = group_id_field,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
-    logger.info("Received websocket request on wallet id `{}`", wallet_id)
-    await handle_websocket(websocket, wallet_id=wallet_id, topic="", auth=auth)
+    logger.info(
+        "Received websocket request on group `{}` and wallet id `{}`",
+        group_id,
+        wallet_id,
+    )
+    await handle_websocket(
+        websocket, group_id=group_id, wallet_id=wallet_id, topic="", auth=auth
+    )
 
 
 @router.websocket("/v1/ws/{wallet_id}/{topic}")
@@ -33,9 +48,15 @@ async def websocket_endpoint_wallet_topic(
     websocket: WebSocket,
     wallet_id: str,
     topic: str,
+    group_id: str = group_id_field,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
     logger.info(
-        "Received websocket request on wallet id `{}` and topic `{}`", wallet_id, topic
+        "Received websocket request for group `{}`, wallet id `{}`, and topic `{}`",
+        group_id,
+        wallet_id,
+        topic,
     )
-    await handle_websocket(websocket, wallet_id=wallet_id, topic=topic, auth=auth)
+    await handle_websocket(
+        websocket, group_id=group_id, wallet_id=wallet_id, topic=topic, auth=auth
+    )

--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -11,21 +11,6 @@ router = APIRouter()
 group_id_field = Query(default="", description="Group ID to which the wallet belongs")
 
 
-@router.websocket("/v1/ws/topic/{topic}")
-async def websocket_endpoint_topic(
-    websocket: WebSocket,
-    topic: str,
-    group_id: str = group_id_field,
-    auth: AcaPyAuthVerified = Depends(websocket_auth),
-):
-    logger.info(
-        "Received websocket request on group `{}` and topic `{}`", group_id, topic
-    )
-    await handle_websocket(
-        websocket, group_id=group_id, wallet_id="", topic=topic, auth=auth
-    )
-
-
 @router.websocket("/v1/ws/{wallet_id}")
 async def websocket_endpoint_wallet(
     websocket: WebSocket,
@@ -40,6 +25,21 @@ async def websocket_endpoint_wallet(
     )
     await handle_websocket(
         websocket, group_id=group_id, wallet_id=wallet_id, topic="", auth=auth
+    )
+
+
+@router.websocket("/v1/ws/topic/{topic}")
+async def websocket_endpoint_topic(
+    websocket: WebSocket,
+    topic: str,
+    group_id: str = group_id_field,
+    auth: AcaPyAuthVerified = Depends(websocket_auth),
+):
+    logger.info(
+        "Received websocket request on group `{}` and topic `{}`", group_id, topic
+    )
+    await handle_websocket(
+        websocket, group_id=group_id, wallet_id="", topic=topic, auth=auth
     )
 
 

--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -17,10 +17,7 @@ async def websocket_endpoint_wallet(
     group_id: str = group_id_field,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
-    logger.info(
-        "Received websocket request on group `{}`",
-        group_id,
-    )
+    logger.info("Received websocket request on group `{}`", group_id)
     await handle_websocket(
         websocket, group_id=group_id, wallet_id="", topic="", auth=auth
     )

--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -11,6 +11,21 @@ router = APIRouter()
 group_id_field = Query(default="", description="Group ID to which the wallet belongs")
 
 
+@router.websocket("/v1/ws/")
+async def websocket_endpoint_wallet(
+    websocket: WebSocket,
+    group_id: str = group_id_field,
+    auth: AcaPyAuthVerified = Depends(websocket_auth),
+):
+    logger.info(
+        "Received websocket request on group `{}`",
+        group_id,
+    )
+    await handle_websocket(
+        websocket, group_id=group_id, wallet_id="", topic="", auth=auth
+    )
+
+
 @router.websocket("/v1/ws/{wallet_id}")
 async def websocket_endpoint_wallet(
     websocket: WebSocket,

--- a/app/services/event_handling/websocket_manager.py
+++ b/app/services/event_handling/websocket_manager.py
@@ -20,22 +20,23 @@ class WebsocketManager:
 
     @staticmethod
     async def subscribe(
-        websocket: WebSocket, wallet_id: str = "", topic: str = ""
+        websocket: WebSocket,
+        *,
+        group_id: str = "",
+        wallet_id: str = "",
+        topic: str = "",
     ) -> str:
         """
         Subscribe a websocket connection to a specific topic.
         Returns a string representing a unique ID for this client
         """
 
-        if wallet_id and topic:
-            subscribed_topic = f"{topic}-{wallet_id}"
-        elif wallet_id:
-            subscribed_topic = wallet_id
-        elif topic:
-            subscribed_topic = topic
-        else:
-            logger.error("Subscribe requires `topic` or `wallet_id` in request.")
-            return
+        subscribed_topic = group_id  # general prefix
+
+        if wallet_id:
+            subscribed_topic += f":{wallet_id}"
+        if topic:
+            subscribed_topic += f":{topic}"
 
         async def callback(data: str, _: str) -> None:
             """

--- a/app/services/event_handling/websocket_manager.py
+++ b/app/services/event_handling/websocket_manager.py
@@ -37,10 +37,9 @@ class WebsocketManager:
             logger.error("Subscribe requires `topic` or `wallet_id` in request.")
             return
 
-        async def callback(data: str, topic: str) -> None:
+        async def callback(data: str, _: str) -> None:
             """
             Callback function for handling received webhook events.
-            Note: PubSubClient expects a topic argument in callback
             """
             await websocket.send_text(data)
 

--- a/app/services/websocket.py
+++ b/app/services/websocket.py
@@ -43,7 +43,7 @@ async def handle_websocket(
     wallet_id: str,
     topic: str,
     auth: AcaPyAuthVerified,
-):
+) -> None:
     bound_logger = logger.bind(body={"wallet_id": wallet_id, "topic": topic})
     bound_logger.debug("Accepting websocket")
     await websocket.accept()
@@ -62,6 +62,14 @@ async def handle_websocket(
         await websocket.send_text("Unauthorized")
         await websocket.close(code=1008)
         bound_logger.info("Unauthorized WebSocket connection closed")
+        return
+
+    if not group_id and not wallet_id and not topic:
+        bound_logger.debug("Notifying one of group, wallet, or topic must be specified")
+        await websocket.send_text("One of group, wallet, or topic must be specified")
+        await websocket.close(code=1008)
+        bound_logger.info("Closed WebSocket connection with bad request")
+        return
 
     uuid = None
     try:

--- a/app/services/websocket.py
+++ b/app/services/websocket.py
@@ -38,6 +38,8 @@ async def websocket_auth(
 
 async def handle_websocket(
     websocket: WebSocket,
+    *,
+    group_id: str,
     wallet_id: str,
     topic: str,
     auth: AcaPyAuthVerified,
@@ -64,7 +66,9 @@ async def handle_websocket(
     uuid = None
     try:
         # Subscribe the WebSocket connection to the wallet / topic
-        uuid = await WebsocketManager.subscribe(websocket, wallet_id, topic)
+        uuid = await WebsocketManager.subscribe(
+            websocket, group_id=group_id, wallet_id=wallet_id, topic=topic
+        )
 
         # Keep the connection open until the client disconnects
         while True:

--- a/app/tests/services/event_handling/test_websocket_manager.py
+++ b/app/tests/services/event_handling/test_websocket_manager.py
@@ -26,8 +26,11 @@ async def test_subscribe_wallet_id_and_topic(
     websocket = AsyncMock(spec=WebSocket)
     wallet_id = "test_wallet_id"
     topic = "test_topic"
+    group_id = "group"
 
-    await WebsocketManager.subscribe(websocket, wallet_id=wallet_id, topic=topic)
+    await WebsocketManager.subscribe(
+        websocket, group_id=group_id, wallet_id=wallet_id, topic=topic
+    )
 
     # Ensure `subscribe` was called once
     mock_pubsub_client.assert_called_once()

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -173,12 +173,15 @@ class SseManager:
             if isinstance(message_data, bytes):
                 message_data = message_data.decode("utf-8")
 
-            wallet_id, timestamp_ns_str = message_data.split(":")
+            group_id, wallet_id, timestamp_ns_str = message_data.split(":")
             timestamp_ns = int(timestamp_ns_str)
 
             # Fetch the event with the exact timestamp from the sorted set
             json_events = self.redis_service.get_json_cloudapi_events_by_timestamp(
-                wallet_id, timestamp_ns, timestamp_ns
+                group_id=group_id,
+                wallet_id=wallet_id,
+                start_timestamp=timestamp_ns,
+                end_timestamp=timestamp_ns,
             )
 
             for json_event in json_events:
@@ -196,6 +199,7 @@ class SseManager:
                     # Doing it here makes websockets stateless as well
                     await publish_event_on_websocket(
                         event_json=json_event,
+                        group_id=group_id,
                         wallet_id=wallet_id,
                         topic=topic,
                     )

--- a/webhooks/tests/test_sse_manager.py
+++ b/webhooks/tests/test_sse_manager.py
@@ -118,7 +118,7 @@ async def test_listen_for_new_events(
     pubsub_mock.subscribe = Mock()
     pubsub_mock.get_message = Mock(
         side_effect=chain(
-            [{"data": b"wallet1:123456789"}],  # First message
+            [{"data": b"group:wallet1:123456789"}],  # First message
             repeat(None),  # Keep returning None indefinitely
         )
     )

--- a/webhooks/web/routers/websocket.py
+++ b/webhooks/web/routers/websocket.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter
 from fastapi_websocket_pubsub import PubSubEndpoint
 
 from shared.log_config import get_logger
-from shared.models.webhook_events import WEBHOOK_TOPIC_ALL
 
 logger = get_logger(__name__)
 
@@ -13,21 +12,28 @@ endpoint.register_route(router, "/pubsub")
 
 
 async def publish_event_on_websocket(
-    event_json: str, wallet_id: str, topic: str
+    event_json: str, group_id: str, wallet_id: str, topic: str
 ) -> None:
     """
     Publish the webhook to websocket subscribers on the following topics:
-        - current wallet id
-        - topic of the event
-        - topic and wallet id combined as topic-wallet_id
-        - 'all' topic, which allows to subscribe to all published events
+        - for the group_id
+        - for the group_id - wallet_id pair
+        - for the group_id - topic pair
+        - for the group_id - wallet_id - topic combo
 
     Args:
         event_json (str): Webhook event serialized as json
+        group_id (str): The group_id that wallet belongs to
         wallet_id (str): The wallet_id for this event
         topic (str): The cloudapi topic for the event
     """
+    group_wallet = f"{group_id}:{wallet_id}"
+    group_topic = f"{group_id}:{topic}"
+    group_wallet_topic = f"{group_id}:{wallet_id}:{topic}"
 
-    publish_topics = [topic, wallet_id, f"{topic}-{wallet_id}", WEBHOOK_TOPIC_ALL]
+    publish_topics = [group_wallet, group_topic, group_wallet_topic]
+    if group_id:  # don't publish on empty string if group_id is blank
+        publish_topics += [group_id]
+
     logger.trace("Publishing event on websocket: {}", event_json)
     await endpoint.publish(topics=publish_topics, data=event_json)


### PR DESCRIPTION
Modified internal websocket publish-topics to support group_id.

`group_id` is now an optional query parameter for websocket endpoints

:sparkles: Additional route:
- `@router.websocket("/v1/ws/")`
- Takes group_id as query param and subscribes to all wallets in group