### PR TITLE
:sparkles: Configure SseListeners in tests with retry logic

### DIFF
--- a/app/tests/e2e/issuer/indy/test_v1_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v1_indy.py
@@ -3,11 +3,9 @@ import asyncio
 import pytest
 from assertpy import assert_that
 
-from app.models.tenants import CreateTenantResponse
 from app.routes.definitions import CredentialSchema
 from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
-from app.services.event_handling.sse_listener import SseListener
 from app.tests.util.ecosystem_connections import FaberAliceConnect
 from app.tests.util.webhooks import check_webhook_state
 from app.util.credentials import cred_id_no_version
@@ -242,7 +240,6 @@ async def test_send_credential_request(
 async def test_revoke_credential(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
     credential_definition_id_revocable: str,
     faber_and_alice_connection: FaberAliceConnect,
 ):
@@ -257,10 +254,6 @@ async def test_revoke_credential(
         },
     }
 
-    alice_credentials_listener = SseListener(
-        topic="credentials", wallet_id=alice_tenant.wallet_id
-    )
-
     # create and send credential offer: issuer
     faber_credential_id = (
         await faber_client.post(
@@ -269,10 +262,13 @@ async def test_revoke_credential(
         )
     ).json()["credential_id"]
 
-    payload = await alice_credentials_listener.wait_for_event(
-        field="connection_id",
-        field_id=faber_and_alice_connection.alice_connection_id,
-        desired_state="offer-received",
+    payload = await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "connection_id": faber_and_alice_connection.alice_connection_id,
+            "state": "offer-received",
+        },
     )
 
     alice_credential_id = payload["credential_id"]
@@ -282,10 +278,13 @@ async def test_revoke_credential(
         f"{CREDENTIALS_BASE_PATH}/{alice_credential_id}/request", json={}
     )
 
-    await alice_credentials_listener.wait_for_event(
-        field="credential_id",
-        field_id=alice_credential_id,
-        desired_state="done",
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "credential_id": alice_credential_id,
+            "state": "done",
+        },
     )
 
     cred_id = cred_id_no_version(faber_credential_id)

--- a/app/tests/e2e/issuer/indy/test_v1_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v1_indy.py
@@ -79,8 +79,8 @@ async def test_send_credential_oob_v1(
         client=alice_member_client,
         topic="credentials",
         filter_map={
-            "state": "offer-received",
             "credential_definition_id": credential_definition_id,
+            "state": "offer-received",
         },
     )
 
@@ -127,8 +127,8 @@ async def test_send_credential(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": data["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -163,8 +163,8 @@ async def test_create_offer(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": data["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -196,8 +196,8 @@ async def test_send_credential_request(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -211,8 +211,8 @@ async def test_send_credential_request(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
     )
 
     request_response = await alice_member_client.post(
@@ -223,15 +223,15 @@ async def test_send_credential_request(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-sent"},
         topic="credentials",
+        filter_map={"state": "request-sent"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "request-received"},
         topic="credentials",
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 

--- a/app/tests/e2e/issuer/indy/test_v1_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v1_indy.py
@@ -78,9 +78,9 @@ async def test_send_credential_oob_v1(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "credential_definition_id": credential_definition_id,
-            "state": "offer-received",
         },
     )
 
@@ -126,9 +126,9 @@ async def test_send_credential(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": data["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -162,9 +162,9 @@ async def test_create_offer(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": data["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -195,9 +195,9 @@ async def test_send_credential_request(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -212,7 +212,7 @@ async def test_send_credential_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
     )
 
     request_response = await alice_member_client.post(
@@ -224,14 +224,14 @@ async def test_send_credential_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "request-sent"},
+        state="request-sent",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 
@@ -265,9 +265,9 @@ async def test_revoke_credential(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": faber_and_alice_connection.alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -281,9 +281,9 @@ async def test_revoke_credential(
     await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="done",
         filter_map={
             "credential_id": alice_credential_id,
-            "state": "done",
         },
     )
 

--- a/app/tests/e2e/issuer/indy/test_v2_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v2_indy.py
@@ -122,8 +122,8 @@ async def test_send_credential(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": data["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -158,8 +158,8 @@ async def test_create_offer(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": data["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -191,8 +191,8 @@ async def test_send_credential_request(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -206,8 +206,8 @@ async def test_send_credential_request(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
     )
 
     request_response = await alice_member_client.post(
@@ -218,15 +218,15 @@ async def test_send_credential_request(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-sent"},
         topic="credentials",
+        filter_map={"state": "request-sent"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "request-received"},
         topic="credentials",
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 

--- a/app/tests/e2e/issuer/indy/test_v2_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v2_indy.py
@@ -71,9 +71,9 @@ async def test_send_credential_oob_v2(
     result = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "thread_id": thread_id,
-            "state": "offer-received",
         },
     )
 
@@ -121,9 +121,9 @@ async def test_send_credential(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": data["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -157,9 +157,9 @@ async def test_create_offer(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": data["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -190,9 +190,9 @@ async def test_send_credential_request(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -207,7 +207,7 @@ async def test_send_credential_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
     )
 
     request_response = await alice_member_client.post(
@@ -219,14 +219,14 @@ async def test_send_credential_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "request-sent"},
+        state="request-sent",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 
@@ -260,9 +260,9 @@ async def test_revoke_credential(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": faber_and_alice_connection.alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -276,9 +276,9 @@ async def test_revoke_credential(
     await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="done",
         filter_map={
             "credential_id": alice_credential_id,
-            "state": "done",
         },
     )
 

--- a/app/tests/e2e/issuer/indy/test_v2_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v2_indy.py
@@ -3,13 +3,11 @@ import asyncio
 import pytest
 from assertpy import assert_that
 
-from app.models.tenants import CreateTenantResponse
 from app.routes.definitions import CredentialSchema
 from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
-from app.services.event_handling.sse_listener import SseListener
 from app.tests.util.ecosystem_connections import FaberAliceConnect
-from app.tests.util.webhooks import check_webhook_state, get_wallet_id_from_async_client
+from app.tests.util.webhooks import check_webhook_state
 from app.util.credentials import cred_id_no_version
 from shared import RichAsyncClient
 
@@ -24,9 +22,6 @@ async def test_send_credential_oob_v2(
     credential_definition_id: str,
     alice_member_client: RichAsyncClient,
 ):
-    wallet_id = get_wallet_id_from_async_client(alice_member_client)
-    alice_credentials_listener = SseListener(topic="credentials", wallet_id=wallet_id)
-
     credential = {
         "protocol_version": "v2",
         "indy_credential_detail": {
@@ -73,10 +68,13 @@ async def test_send_credential_oob_v2(
     assert_that(accept_response.status_code).is_equal_to(200)
     assert_that(oob_record).contains("created_at", "oob_id", "invitation")
 
-    result = await alice_credentials_listener.wait_for_event(
-        field="thread_id",
-        field_id=thread_id,
-        desired_state="offer-received",
+    result = await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "thread_id": thread_id,
+            "state": "offer-received",
+        },
     )
 
     assert result["credential_id"]
@@ -237,7 +235,6 @@ async def test_send_credential_request(
 async def test_revoke_credential(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
     credential_definition_id_revocable: str,
     faber_and_alice_connection: FaberAliceConnect,
 ):
@@ -252,10 +249,6 @@ async def test_revoke_credential(
         },
     }
 
-    alice_credentials_listener = SseListener(
-        topic="credentials", wallet_id=alice_tenant.wallet_id
-    )
-
     # create and send credential offer: issuer
     faber_credential_id = (
         await faber_client.post(
@@ -264,10 +257,13 @@ async def test_revoke_credential(
         )
     ).json()["credential_id"]
 
-    payload = await alice_credentials_listener.wait_for_event(
-        field="connection_id",
-        field_id=faber_and_alice_connection.alice_connection_id,
-        desired_state="offer-received",
+    payload = await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "connection_id": faber_and_alice_connection.alice_connection_id,
+            "state": "offer-received",
+        },
     )
 
     alice_credential_id = payload["credential_id"]
@@ -277,10 +273,13 @@ async def test_revoke_credential(
         f"{CREDENTIALS_BASE_PATH}/{alice_credential_id}/request", json={}
     )
 
-    await alice_credentials_listener.wait_for_event(
-        field="credential_id",
-        field_id=alice_credential_id,
-        desired_state="done",
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "credential_id": alice_credential_id,
+            "state": "done",
+        },
     )
 
     cred_id = cred_id_no_version(faber_credential_id)

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -107,8 +107,8 @@ async def test_send_jsonld_key_bbs(
         client=alice_member_client,
         topic="credentials",
         filter_map={
-            "state": "offer-received",
             "connection_id": alice_connection_id,
+            "state": "offer-received",
         },
     )
 
@@ -162,8 +162,8 @@ async def test_send_jsonld_bbs_oob(
         client=alice_member_client,
         topic="connections",
         filter_map={
-            "state": "completed",
             "connection_id": alice_connection_id,
+            "state": "completed",
         },
     )
 
@@ -197,8 +197,8 @@ async def test_send_jsonld_bbs_oob(
         client=alice_member_client,
         topic="credentials",
         filter_map={
-            "state": "offer-received",
             "connection_id": alice_connection_id,
+            "state": "offer-received",
         },
     )
 
@@ -229,16 +229,16 @@ async def test_send_jsonld_request(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
         lookback_time=5,
     )
 
@@ -258,15 +258,15 @@ async def test_send_jsonld_request(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-sent"},
         topic="credentials",
+        filter_map={"state": "request-sent"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "request-received"},
         topic="credentials",
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 
@@ -296,16 +296,16 @@ async def test_issue_jsonld_bbs(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
         lookback_time=5,
     )
 
@@ -325,15 +325,15 @@ async def test_issue_jsonld_bbs(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "done"},
         topic="credentials",
+        filter_map={"state": "done"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "done"},
         topic="credentials",
+        filter_map={"state": "done"},
         lookback_time=5,
     )
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -106,9 +106,9 @@ async def test_send_jsonld_key_bbs(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -161,9 +161,9 @@ async def test_send_jsonld_bbs_oob(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "completed",
         },
     )
 
@@ -196,9 +196,9 @@ async def test_send_jsonld_bbs_oob(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -228,9 +228,9 @@ async def test_send_jsonld_request(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
         lookback_time=5,
     )
@@ -238,7 +238,7 @@ async def test_send_jsonld_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
         lookback_time=5,
     )
 
@@ -259,14 +259,14 @@ async def test_send_jsonld_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "request-sent"},
+        state="request-sent",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 
@@ -295,9 +295,9 @@ async def test_issue_jsonld_bbs(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
         lookback_time=5,
     )
@@ -305,7 +305,7 @@ async def test_issue_jsonld_bbs(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
         lookback_time=5,
     )
 
@@ -326,14 +326,14 @@ async def test_issue_jsonld_bbs(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "done"},
+        state="done",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "done"},
+        state="done",
         lookback_time=5,
     )
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -102,9 +102,9 @@ async def test_send_jsonld_key_ed25519(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -157,9 +157,9 @@ async def test_send_jsonld_oob(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "completed",
         },
     )
 
@@ -194,9 +194,9 @@ async def test_send_jsonld_oob(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -228,9 +228,9 @@ async def test_send_jsonld_request(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
         lookback_time=5,
     )
@@ -238,7 +238,7 @@ async def test_send_jsonld_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
         lookback_time=5,
     )
 
@@ -259,14 +259,14 @@ async def test_send_jsonld_request(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "request-sent"},
+        state="request-sent",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 
@@ -298,9 +298,9 @@ async def test_issue_jsonld_ed(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
         lookback_time=5,
     )
@@ -308,7 +308,7 @@ async def test_issue_jsonld_ed(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
         lookback_time=5,
     )
 
@@ -329,14 +329,14 @@ async def test_issue_jsonld_ed(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "done"},
+        state="done",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "done"},
+        state="done",
         lookback_time=5,
     )
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -103,8 +103,8 @@ async def test_send_jsonld_key_ed25519(
         client=alice_member_client,
         topic="credentials",
         filter_map={
-            "state": "offer-received",
             "connection_id": alice_connection_id,
+            "state": "offer-received",
         },
     )
 
@@ -158,8 +158,8 @@ async def test_send_jsonld_oob(
         client=alice_member_client,
         topic="connections",
         filter_map={
-            "state": "completed",
             "connection_id": alice_connection_id,
+            "state": "completed",
         },
     )
 
@@ -195,8 +195,8 @@ async def test_send_jsonld_oob(
         client=alice_member_client,
         topic="credentials",
         filter_map={
-            "state": "offer-received",
             "connection_id": alice_connection_id,
+            "state": "offer-received",
         },
     )
 
@@ -229,16 +229,16 @@ async def test_send_jsonld_request(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
         lookback_time=5,
     )
 
@@ -258,15 +258,15 @@ async def test_send_jsonld_request(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-sent"},
         topic="credentials",
+        filter_map={"state": "request-sent"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "request-received"},
         topic="credentials",
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 
@@ -299,16 +299,16 @@ async def test_issue_jsonld_ed(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
         lookback_time=5,
     )
 
@@ -328,15 +328,15 @@ async def test_issue_jsonld_ed(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "done"},
         topic="credentials",
+        filter_map={"state": "done"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "done"},
         topic="credentials",
+        filter_map={"state": "done"},
         lookback_time=5,
     )
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -108,8 +108,8 @@ async def test_send_jsonld_credential_sov(
         client=alice_member_client,
         topic="credentials",
         filter_map={
-            "state": "offer-received",
             "connection_id": alice_connection_id,
+            "state": "offer-received",
         },
     )
 
@@ -232,8 +232,8 @@ async def test_send_jsonld_request_sov(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -247,8 +247,8 @@ async def test_send_jsonld_request_sov(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
     )
 
     request_response = await alice_member_client.post(
@@ -259,15 +259,15 @@ async def test_send_jsonld_request_sov(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-sent"},
         topic="credentials",
+        filter_map={"state": "request-sent"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "request-received"},
         topic="credentials",
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 
@@ -301,8 +301,8 @@ async def test_issue_jsonld_sov(
         client=faber_client,
         topic="credentials",
         filter_map={
-            "state": "offer-sent",
             "credential_id": credential_exchange["credential_id"],
+            "state": "offer-sent",
         },
     )
 
@@ -316,8 +316,8 @@ async def test_issue_jsonld_sov(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "offer-received"},
         topic="credentials",
+        filter_map={"state": "offer-received"},
     )
 
     request_response = await alice_member_client.post(
@@ -328,14 +328,14 @@ async def test_issue_jsonld_sov(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "done"},
         topic="credentials",
+        filter_map={"state": "done"},
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
-        filter_map={"state": "done"},
         topic="credentials",
+        filter_map={"state": "done"},
         lookback_time=5,
     )

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -107,9 +107,9 @@ async def test_send_jsonld_credential_sov(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -197,9 +197,7 @@ async def test_send_jsonld_oob_sov(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={
-            "state": "offer-received",
-        },
+        state="offer-received",
     )
 
 
@@ -231,9 +229,9 @@ async def test_send_jsonld_request_sov(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -248,7 +246,7 @@ async def test_send_jsonld_request_sov(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
     )
 
     request_response = await alice_member_client.post(
@@ -260,14 +258,14 @@ async def test_send_jsonld_request_sov(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "request-sent"},
+        state="request-sent",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 
@@ -300,9 +298,9 @@ async def test_issue_jsonld_sov(
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="offer-sent",
         filter_map={
             "credential_id": credential_exchange["credential_id"],
-            "state": "offer-sent",
         },
     )
 
@@ -317,7 +315,7 @@ async def test_issue_jsonld_sov(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "offer-received"},
+        state="offer-received",
     )
 
     request_response = await alice_member_client.post(
@@ -329,13 +327,13 @@ async def test_issue_jsonld_sov(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
-        filter_map={"state": "done"},
+        state="done",
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
-        filter_map={"state": "done"},
+        state="done",
         lookback_time=5,
     )

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -50,8 +50,8 @@ async def test_accept_use_public_did(
         client=meld_co_client,
         topic="connections",
         filter_map={
-            "state": "completed",
             "connection_id": connection_record["connection_id"],
+            "state": "completed",
         },
     )
 
@@ -95,7 +95,7 @@ async def test_accept_use_public_did_between_issuer_and_holder(
         client=alice_member_client,
         topic="connections",
         filter_map={
-            "state": "completed",
             "connection_id": connection_record["connection_id"],
+            "state": "completed",
         },
     )

--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -49,9 +49,9 @@ async def test_accept_use_public_did(
     assert await check_webhook_state(
         client=meld_co_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": connection_record["connection_id"],
-            "state": "completed",
         },
     )
 
@@ -94,8 +94,8 @@ async def test_accept_use_public_did_between_issuer_and_holder(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": connection_record["connection_id"],
-            "state": "completed",
         },
     )

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -44,9 +44,9 @@ async def test_issue_credential_with_save_exchange_record(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": faber_and_alice_connection.alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -60,9 +60,9 @@ async def test_issue_credential_with_save_exchange_record(
     await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="done",
         filter_map={
             "credential_id": alice_credential_id,
-            "state": "done",
         },
     )
 
@@ -151,9 +151,9 @@ async def test_get_cred_exchange_records(
         await check_webhook_state(
             client=alice_member_client,
             topic="credentials",
+            state="done",
             filter_map={
                 "credential_id": cred["credential_id"],
-                "state": "done",
             },
         )
 

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -89,9 +89,9 @@ async def test_accept_invitation(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": connection_record["connection_id"],
-            "state": "completed",
         },
     )
 
@@ -211,9 +211,9 @@ async def test_bob_and_alice_connect(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": connection_record["connection_id"],
-            "state": "completed",
         },
     )
 

--- a/app/tests/e2e/test_connections.py
+++ b/app/tests/e2e/test_connections.py
@@ -90,8 +90,8 @@ async def test_accept_invitation(
         client=alice_member_client,
         topic="connections",
         filter_map={
-            "state": "completed",
             "connection_id": connection_record["connection_id"],
+            "state": "completed",
         },
     )
 
@@ -212,8 +212,8 @@ async def test_bob_and_alice_connect(
         client=alice_member_client,
         topic="connections",
         filter_map={
-            "state": "completed",
             "connection_id": connection_record["connection_id"],
+            "state": "completed",
         },
     )
 

--- a/app/tests/e2e/test_oob.py
+++ b/app/tests/e2e/test_oob.py
@@ -76,8 +76,8 @@ async def test_oob_connect_via_public_did(
         client=bob_member_client,
         topic="connections",
         filter_map={
-            "state": "request-sent",
             "connection_id": bob_oob_record["connection_id"],
+            "state": "request-sent",
         },
     )
 

--- a/app/tests/e2e/test_oob.py
+++ b/app/tests/e2e/test_oob.py
@@ -75,9 +75,9 @@ async def test_oob_connect_via_public_did(
     assert await check_webhook_state(
         client=bob_member_client,
         topic="connections",
+        state="request-sent",
         filter_map={
             "connection_id": bob_oob_record["connection_id"],
-            "state": "request-sent",
         },
     )
 

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -90,7 +90,7 @@ async def test_proof_model_failures(
     await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -7,10 +7,9 @@ from aries_cloudcontroller import (
 )
 from fastapi import HTTPException
 
-from app.models.tenants import CreateTenantResponse
 from app.routes.verifier import router as verifier_router
-from app.services.event_handling.sse_listener import SseListener
 from app.tests.util.ecosystem_connections import AcmeAliceConnect
+from app.tests.util.webhooks import check_webhook_state
 from shared.util.rich_async_client import RichAsyncClient
 
 VERIFIER_BASE_PATH = verifier_router.prefix
@@ -38,14 +37,11 @@ async def test_proof_model_failures(
     acme_acapy_client: AcaPyClient,
     acme_and_alice_connection: AcmeAliceConnect,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
     name: str,
     version: str,
     protocol_version: str,
 ):
-
     acme_connection_id = acme_and_alice_connection.acme_connection_id
-    alice_listener = SseListener(topic="proofs", wallet_id=alice_tenant.wallet_id)
 
     if protocol_version == "v1":
 
@@ -91,8 +87,10 @@ async def test_proof_model_failures(
 
         await acme_acapy_client.present_proof_v2_0.send_request_free(body=request_body)
 
-    await alice_listener.wait_for_state(
-        desired_state="request-received",
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -57,7 +57,7 @@ async def test_proof_revoked_credential(
     await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={"state": "request-received"},
+        state="request-received",
         lookback_time=5,
     )
 
@@ -93,9 +93,9 @@ async def test_proof_revoked_credential(
     await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": alice_proof_exchange_id,
-            "state": "done",
         },
         lookback_time=5,
     )
@@ -103,9 +103,9 @@ async def test_proof_revoked_credential(
     await check_webhook_state(
         client=acme_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": acme_proof_exchange_id,
-            "state": "done",
         },
         lookback_time=5,
     )

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -3,11 +3,10 @@ from typing import List
 
 import pytest
 
-from app.models.tenants import CreateTenantResponse
 from app.routes.issuer import router
 from app.routes.verifier import router as verifier_router
-from app.services.event_handling.sse_listener import SseListener
 from app.tests.util.ecosystem_connections import AcmeAliceConnect
+from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
@@ -22,20 +21,10 @@ async def test_proof_revoked_credential(
         CredentialExchange
     ],
     acme_client: RichAsyncClient,
-    acme_verifier: CreateTenantResponse,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
     acme_and_alice_connection: AcmeAliceConnect,
     protocol_version: str,
 ):
-
-    alice_proofs_listener = SseListener(
-        topic="proofs", wallet_id=alice_tenant.wallet_id
-    )
-    acme_proofs_listener = SseListener(
-        topic="proofs", wallet_id=acme_verifier.wallet_id
-    )
-
     # Get current time
     unix_timestamp = int(time.time())
 
@@ -65,8 +54,12 @@ async def test_proof_revoked_credential(
         )
     ).json()["proof_id"]
 
-    await alice_proofs_listener.wait_for_state(
-        desired_state="request-received",
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        filter_map={
+            "state": "request-received",
+        },
         lookback_time=5,
     )
 
@@ -99,16 +92,23 @@ async def test_proof_revoked_credential(
         },
     )
 
-    await alice_proofs_listener.wait_for_event(
-        field="proof_id",
-        field_id=alice_proof_exchange_id,
-        desired_state="done",
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        filter_map={
+            "proof_id": alice_proof_exchange_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
-    await acme_proofs_listener.wait_for_event(
-        field="proof_id",
-        field_id=acme_proof_exchange_id,
-        desired_state="done",
+
+    await check_webhook_state(
+        client=acme_client,
+        topic="proofs",
+        filter_map={
+            "proof_id": acme_proof_exchange_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
 

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -57,9 +57,7 @@ async def test_proof_revoked_credential(
     await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={
-            "state": "request-received",
-        },
+        filter_map={"state": "request-received"},
         lookback_time=5,
     )
 

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -61,8 +61,8 @@ async def test_accept_proof_request_v1(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-received"},
         topic="proofs",
+        filter_map={"state": "request-received"},
     )
     proof_records_alice = await alice_member_client.get(VERIFIER_BASE_PATH + "/proofs")
     alice_proof_id = proof_records_alice.json()[-1]["proof_id"]
@@ -73,8 +73,11 @@ async def test_accept_proof_request_v1(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-received", "proof_id": alice_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": alice_proof_id,
+            "state": "request-received",
+        },
     )
 
     referent = requested_credentials.json()[-1]["cred_info"]["referent"]
@@ -98,15 +101,21 @@ async def test_accept_proof_request_v1(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "done", "proof_id": alice_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": alice_proof_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=acme_client,
-        filter_map={"state": "done", "proof_id": acme_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": acme_proof_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
 
@@ -749,8 +758,8 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-received"},
         topic="proofs",
+        filter_map={"state": "request-received"},
     )
     proof_records_alice = await alice_member_client.get(VERIFIER_BASE_PATH + "/proofs")
     alice_proof_id = proof_records_alice.json()[-1]["proof_id"]
@@ -761,8 +770,11 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-received", "proof_id": alice_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": alice_proof_id,
+            "state": "request-received",
+        },
     )
 
     referent = requested_credentials.json()[-1]["cred_info"]["referent"]
@@ -786,14 +798,20 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "done", "proof_id": alice_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": alice_proof_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=meld_co_client,
-        filter_map={"state": "done", "proof_id": meld_co_proof_id},
+        filter_map={
+            "proof_id": meld_co_proof_id,
+            "state": "done",
+        },
         topic="proofs",
         lookback_time=5,
     )
@@ -906,8 +924,8 @@ async def test_saving_of_presentation_exchange_records(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-received"},
         topic="proofs",
+        filter_map={"state": "request-received"},
     )
     proof_records_alice = await alice_member_client.get(VERIFIER_BASE_PATH + "/proofs")
     alice_proof_id = proof_records_alice.json()[-1]["proof_id"]
@@ -918,8 +936,8 @@ async def test_saving_of_presentation_exchange_records(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-received", "proof_id": alice_proof_id},
         topic="proofs",
+        filter_map={"state": "request-received", "proof_id": alice_proof_id},
     )
 
     referent = requested_credentials.json()[-1]["cred_info"]["referent"]
@@ -944,15 +962,21 @@ async def test_saving_of_presentation_exchange_records(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "done", "proof_id": alice_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": alice_proof_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=acme_client,
-        filter_map={"state": "done", "proof_id": acme_proof_id},
         topic="proofs",
+        filter_map={
+            "proof_id": acme_proof_id,
+            "state": "done",
+        },
         lookback_time=5,
     )
 

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -62,7 +62,7 @@ async def test_accept_proof_request_v1(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={"state": "request-received"},
+        state="request-received",
     )
     proof_records_alice = await alice_member_client.get(VERIFIER_BASE_PATH + "/proofs")
     alice_proof_id = proof_records_alice.json()[-1]["proof_id"]
@@ -74,9 +74,9 @@ async def test_accept_proof_request_v1(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "request-received",
         },
     )
 
@@ -102,9 +102,9 @@ async def test_accept_proof_request_v1(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "done",
         },
         lookback_time=5,
     )
@@ -112,9 +112,9 @@ async def test_accept_proof_request_v1(
     assert await check_webhook_state(
         client=acme_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": acme_proof_id,
-            "state": "done",
         },
         lookback_time=5,
     )
@@ -168,9 +168,9 @@ async def test_accept_proof_request_oob_v1(
     alice_request_received = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "thread_id": thread_id,
-            "state": "request-received",
         },
     )
 
@@ -205,18 +205,18 @@ async def test_accept_proof_request_oob_v1(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="presentation-sent",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "presentation-sent",
         },
     )
 
     bob_presentation_received = await check_webhook_state(
         client=bob_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "thread_id": thread_id,
-            "state": "done",
         },
     )
     assert bob_presentation_received["role"] == "verifier"
@@ -261,9 +261,9 @@ async def test_accept_proof_request_oob_v2(
     alice_request_received = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "thread_id": thread_id,
-            "state": "request-received",
         },
     )
 
@@ -297,18 +297,18 @@ async def test_accept_proof_request_oob_v2(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="presentation-sent",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "presentation-sent",
         },
     )
 
     bob_presentation_received = await check_webhook_state(
         client=bob_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "thread_id": thread_id,
-            "state": "done",
         },
     )
     assert bob_presentation_received["role"] == "verifier"
@@ -351,9 +351,9 @@ async def test_accept_proof_request_v2(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": acme_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
 
@@ -384,9 +384,9 @@ async def test_accept_proof_request_v2(
     acme_proof_event = await check_webhook_state(
         client=acme_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": acme_proof_id,
-            "state": "done",
         },
     )
     assert acme_proof_event["verified"]
@@ -431,9 +431,9 @@ async def test_send_proof_request(
     alice_connection_event = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": acme_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_connection_event["protocol_version"] == "v1"
@@ -464,9 +464,9 @@ async def test_send_proof_request(
     alice_connection_event = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": acme_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_connection_event["protocol_version"] == "v2"
@@ -495,9 +495,9 @@ async def test_reject_proof_request(
     alice_exchange = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": acme_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_exchange["protocol_version"] == "v1"
@@ -675,9 +675,9 @@ async def test_get_credentials_for_request(
     alice_exchange = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": acme_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_exchange["protocol_version"] == "v1"
@@ -713,9 +713,9 @@ async def test_get_credentials_for_request(
     alice_exchange = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": acme_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_exchange["protocol_version"] == "v2"
@@ -759,7 +759,7 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={"state": "request-received"},
+        state="request-received",
     )
     proof_records_alice = await alice_member_client.get(VERIFIER_BASE_PATH + "/proofs")
     alice_proof_id = proof_records_alice.json()[-1]["proof_id"]
@@ -771,9 +771,9 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "request-received",
         },
     )
 
@@ -799,18 +799,18 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "done",
         },
         lookback_time=5,
     )
 
     assert await check_webhook_state(
         client=meld_co_client,
+        state="done",
         filter_map={
             "proof_id": meld_co_proof_id,
-            "state": "done",
         },
         topic="proofs",
         lookback_time=5,
@@ -856,9 +856,9 @@ async def test_send_proof_request_verifier_has_issuer_role(
     alice_connection_event = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": meld_co_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_connection_event["protocol_version"] == "v1"
@@ -889,9 +889,9 @@ async def test_send_proof_request_verifier_has_issuer_role(
     alice_connection_event = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": meld_co_and_alice_connection.alice_connection_id,
-            "state": "request-received",
         },
     )
     assert alice_connection_event["protocol_version"] == "v2"
@@ -925,7 +925,7 @@ async def test_saving_of_presentation_exchange_records(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={"state": "request-received"},
+        state="request-received",
     )
     proof_records_alice = await alice_member_client.get(VERIFIER_BASE_PATH + "/proofs")
     alice_proof_id = proof_records_alice.json()[-1]["proof_id"]
@@ -937,7 +937,10 @@ async def test_saving_of_presentation_exchange_records(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={"state": "request-received", "proof_id": alice_proof_id},
+        state="request-received",
+        filter_map={
+            "proof_id": alice_proof_id,
+        },
     )
 
     referent = requested_credentials.json()[-1]["cred_info"]["referent"]
@@ -963,9 +966,9 @@ async def test_saving_of_presentation_exchange_records(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": alice_proof_id,
-            "state": "done",
         },
         lookback_time=5,
     )
@@ -973,9 +976,9 @@ async def test_saving_of_presentation_exchange_records(
     assert await check_webhook_state(
         client=acme_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": acme_proof_id,
-            "state": "done",
         },
         lookback_time=5,
     )
@@ -1030,9 +1033,9 @@ async def test_accept_proof_request_verifier_no_public_did(
     await check_webhook_state(
         client=faber_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": issuer_holder_connection_id,
-            "state": "completed",
         },
     )
 
@@ -1057,7 +1060,7 @@ async def test_accept_proof_request_verifier_no_public_did(
     payload = await check_webhook_state(
         client=acme_client,
         topic="connections",
-        filter_map={"state": "completed"},
+        state="completed",
     )
     holder_verifier_connection_id = invitation_response["connection_id"]
     verifier_holder_connection_id = payload["connection_id"]
@@ -1108,9 +1111,9 @@ async def test_accept_proof_request_verifier_no_public_did(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": holder_issuer_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -1125,9 +1128,9 @@ async def test_accept_proof_request_verifier_no_public_did(
     await check_webhook_state(
         client=faber_client,
         topic="credentials",
+        state="done",
         filter_map={
             "credential_id": issuer_credential_exchange_id,
-            "state": "done",
         },
     )
 
@@ -1163,9 +1166,9 @@ async def test_accept_proof_request_verifier_no_public_did(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="request-received",
         filter_map={
             "connection_id": holder_verifier_connection_id,
-            "state": "request-received",
         },
     )
 
@@ -1200,9 +1203,9 @@ async def test_accept_proof_request_verifier_no_public_did(
     event = await check_webhook_state(
         client=acme_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": verifier_proof_exchange_id,
-            "state": "done",
         },
     )
     assert event["verified"]
@@ -1235,9 +1238,7 @@ async def test_get_proof_records(
     await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
-        filter_map={
-            "state": "request-received",
-        },
+        state="request-received",
     )
 
     proof_exc = await alice_member_client.get(f"{VERIFIER_BASE_PATH}/proofs")
@@ -1272,17 +1273,17 @@ async def test_get_proof_records(
     await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": proof_request["proof_id"],
-            "state": "done",
         },
     )
     await check_webhook_state(
         client=meld_co_client,
         topic="proofs",
+        state="done",
         filter_map={
             "proof_id": proof_1["proof_id"],
-            "state": "done",
         },
     )
 

--- a/app/tests/test_util_webhooks.py
+++ b/app/tests/test_util_webhooks.py
@@ -1,0 +1,90 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import HTTPError
+
+from app.tests.util.webhooks import check_webhook_state
+
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture
+def mock_wallet_id(mocker):
+    return mocker.patch(
+        "app.tests.util.webhooks.get_wallet_id_from_async_client",
+        return_value="wallet_id",
+    )
+
+
+@pytest.fixture
+def mock_sse_listener(mocker):
+    mock_listener = AsyncMock()
+    mocker.patch("app.tests.util.webhooks.SseListener", return_value=mock_listener)
+    return mock_listener
+
+
+@pytest.mark.anyio
+async def test_check_webhook_state_success(
+    mock_wallet_id,  # pylint: disable=unused-argument
+    mock_sse_listener,
+):
+    client = MagicMock()
+    topic = "connections"
+    state = "desired_state"
+    filter_map = {"field": "field_id"}
+
+    expected_event = {"event": "details", "state": state}
+    mock_sse_listener.wait_for_event.return_value = expected_event
+
+    result = await check_webhook_state(client, topic, state, filter_map)
+
+    assert result == expected_event
+    mock_sse_listener.wait_for_event.assert_awaited_once_with(
+        field="field",
+        field_id="field_id",
+        desired_state=state,
+        timeout=60,
+        lookback_time=1,
+    )
+
+
+@pytest.mark.anyio
+async def test_check_webhook_state_success_after_retry(
+    mock_wallet_id,  # pylint: disable=unused-argument
+    mock_sse_listener,
+):
+    client = MagicMock()
+    topic = "some_topic"
+    state = "desired_state"
+    filter_map = {"field": "field_id"}
+
+    expected_event = {"event": "details", "state": state}
+    mock_sse_listener.wait_for_event.side_effect = [HTTPError(""), expected_event]
+
+    result = await check_webhook_state(client, topic, state, filter_map, delay=0.01)
+
+    assert result == expected_event
+    assert (
+        mock_sse_listener.wait_for_event.call_count == 2
+    ), "Should have retried once after HTTPError"
+
+
+@pytest.mark.anyio
+async def test_check_webhook_state_fails_after_max_retries(
+    mock_wallet_id,  # pylint: disable=unused-argument
+    mock_sse_listener,
+):
+    client = MagicMock()
+    topic = "some_topic"
+    state = "desired_state"
+    filter_map = {"field": "field_id"}
+
+    mock_sse_listener.wait_for_event.side_effect = HTTPError("")
+
+    with pytest.raises(HTTPError):
+        await check_webhook_state(client, topic, state, filter_map, delay=0.01)
+
+    assert (
+        mock_sse_listener.wait_for_event.call_count == 2
+    ), "Should have retried the max number of times"

--- a/app/tests/util/credentials.py
+++ b/app/tests/util/credentials.py
@@ -37,9 +37,9 @@ async def issue_credential_to_alice(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": faber_and_alice_connection.alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -53,9 +53,9 @@ async def issue_credential_to_alice(
     await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="done",
         filter_map={
             "credential_id": alice_credential_id,
-            "state": "done",
         },
     )
 
@@ -87,9 +87,9 @@ async def meld_co_issue_credential_to_alice(
     payload = await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="offer-received",
         filter_map={
             "connection_id": meld_co_and_alice_connection.alice_connection_id,
-            "state": "offer-received",
         },
     )
 
@@ -103,9 +103,9 @@ async def meld_co_issue_credential_to_alice(
     await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
+        state="done",
         filter_map={
             "credential_id": alice_credential_id,
-            "state": "done",
         },
     )
 
@@ -162,9 +162,9 @@ async def issue_alice_creds_and_revoke_unpublished(
         await check_webhook_state(
             client=alice_member_client,
             topic="credentials",
+            state="done",
             filter_map={
                 "credential_id": cred["credential_id"],
-                "state": "done",
             },
         )
 

--- a/app/tests/util/credentials.py
+++ b/app/tests/util/credentials.py
@@ -3,10 +3,9 @@ from typing import List
 
 import pytest
 
-from app.models.tenants import CreateTenantResponse
 from app.routes.issuer import router
-from app.services.event_handling.sse_listener import SseListener
 from app.tests.util.ecosystem_connections import FaberAliceConnect, MeldCoAliceConnect
+from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
@@ -19,7 +18,6 @@ async def issue_credential_to_alice(
     credential_definition_id: str,
     faber_and_alice_connection: FaberAliceConnect,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
 ) -> CredentialExchange:
     credential = {
         "protocol_version": "v1",
@@ -30,20 +28,19 @@ async def issue_credential_to_alice(
         },
     }
 
-    alice_credentials_listener = SseListener(
-        topic="credentials", wallet_id=alice_tenant.wallet_id
-    )
-
     # create and send credential offer- issuer
     await faber_client.post(
         CREDENTIALS_BASE_PATH,
         json=credential,
     )
 
-    payload = await alice_credentials_listener.wait_for_event(
-        field="connection_id",
-        field_id=faber_and_alice_connection.alice_connection_id,
-        desired_state="offer-received",
+    payload = await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "connection_id": faber_and_alice_connection.alice_connection_id,
+            "state": "offer-received",
+        },
     )
 
     alice_credential_id = payload["credential_id"]
@@ -53,8 +50,13 @@ async def issue_credential_to_alice(
         f"{CREDENTIALS_BASE_PATH}/{alice_credential_id}/request", json={}
     )
 
-    await alice_credentials_listener.wait_for_event(
-        field="credential_id", field_id=alice_credential_id, desired_state="done"
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "credential_id": alice_credential_id,
+            "state": "done",
+        },
     )
 
     return response.json()
@@ -66,7 +68,6 @@ async def meld_co_issue_credential_to_alice(
     meld_co_credential_definition_id: str,
     meld_co_and_alice_connection: MeldCoAliceConnect,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
 ) -> CredentialExchange:
     credential = {
         "protocol_version": "v1",
@@ -77,20 +78,19 @@ async def meld_co_issue_credential_to_alice(
         },
     }
 
-    alice_credentials_listener = SseListener(
-        topic="credentials", wallet_id=alice_tenant.wallet_id
-    )
-
     # create and send credential offer- issuer
     await meld_co_client.post(
         CREDENTIALS_BASE_PATH,
         json=credential,
     )
 
-    payload = await alice_credentials_listener.wait_for_event(
-        field="connection_id",
-        field_id=meld_co_and_alice_connection.alice_connection_id,
-        desired_state="offer-received",
+    payload = await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "connection_id": meld_co_and_alice_connection.alice_connection_id,
+            "state": "offer-received",
+        },
     )
 
     alice_credential_id = payload["credential_id"]
@@ -100,8 +100,13 @@ async def meld_co_issue_credential_to_alice(
         f"{CREDENTIALS_BASE_PATH}/{alice_credential_id}/request", json={}
     )
 
-    await alice_credentials_listener.wait_for_event(
-        field="credential_id", field_id=alice_credential_id, desired_state="done"
+    await check_webhook_state(
+        client=alice_member_client,
+        topic="credentials",
+        filter_map={
+            "credential_id": alice_credential_id,
+            "state": "done",
+        },
     )
 
     return response.json()
@@ -111,7 +116,6 @@ async def meld_co_issue_credential_to_alice(
 async def issue_alice_creds_and_revoke_unpublished(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
-    alice_tenant: CreateTenantResponse,
     credential_definition_id_revocable: str,
     faber_and_alice_connection: FaberAliceConnect,
 ) -> List[CredentialExchange]:
@@ -150,15 +154,18 @@ async def issue_alice_creds_and_revoke_unpublished(
             f"Expected 3 credentials to be issued; only got {num_credentials_returned}"
         )
 
-    listener = SseListener(topic="credentials", wallet_id=alice_tenant.wallet_id)
-
     for cred in alice_cred_ex_response:
         await alice_member_client.post(
             f"{CREDENTIALS_BASE_PATH}/{cred['credential_id']}/request", json={}
         )
-        # add sse listener to wait for credential state "done" for each credential
-        await listener.wait_for_event(
-            field="credential_id", field_id=cred["credential_id"], desired_state="done"
+        # wait for credential state "done" for each credential
+        await check_webhook_state(
+            client=alice_member_client,
+            topic="credentials",
+            filter_map={
+                "credential_id": cred["credential_id"],
+                "state": "done",
+            },
         )
 
     cred_ex_response = (

--- a/app/tests/util/ecosystem_connections.py
+++ b/app/tests/util/ecosystem_connections.py
@@ -136,13 +136,19 @@ async def acme_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": alice_connection_id},
+        filter_map={
+            "connection_id": alice_connection_id,
+            "state": "completed",
+        },
         lookback_time=5,
     )
     assert await check_webhook_state(
         acme_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": acme_connection_id},
+        filter_map={
+            "connection_id": acme_connection_id,
+            "state": "completed",
+        },
         lookback_time=5,
     )
 
@@ -183,13 +189,19 @@ async def faber_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": alice_connection_id},
+        filter_map={
+            "connection_id": alice_connection_id,
+            "state": "completed",
+        },
         lookback_time=5,
     )
     assert await check_webhook_state(
         faber_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": faber_connection_id},
+        filter_map={
+            "connection_id": faber_connection_id,
+            "state": "completed",
+        },
         lookback_time=5,
     )
 
@@ -263,13 +275,19 @@ async def meld_co_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": alice_connection_id},
+        filter_map={
+            "connection_id": alice_connection_id,
+            "state": "completed",
+        },
         lookback_time=5,
     )
     assert await check_webhook_state(
         meld_co_client,
         topic="connections",
-        filter_map={"state": "completed", "connection_id": meld_co_connection_id},
+        filter_map={
+            "connection_id": meld_co_connection_id,
+            "state": "completed",
+        },
         lookback_time=5,
     )
 
@@ -367,8 +385,8 @@ async def alice_bob_connect_multi(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "request-sent"},
         topic="connections",
+        filter_map={"state": "request-sent"},
     )
 
     bob_connection_id = multi_use_invite["multi_use_invitation"]["connection_id"]
@@ -382,14 +400,14 @@ async def alice_bob_connect_multi(
 
     assert await check_webhook_state(
         client=alice_member_client,
-        filter_map={"state": "completed"},
         topic="connections",
+        filter_map={"state": "completed"},
         lookback_time=5,
     )
     assert await check_webhook_state(
         client=bob_member_client,
-        filter_map={"state": "completed"},
         topic="connections",
+        filter_map={"state": "completed"},
         lookback_time=5,
     )
 

--- a/app/tests/util/ecosystem_connections.py
+++ b/app/tests/util/ecosystem_connections.py
@@ -59,13 +59,13 @@ async def bob_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
-        filter_map={"state": "completed"},
+        state="completed",
         lookback_time=5,
     )
     assert await check_webhook_state(
         bob_member_client,
         topic="connections",
-        filter_map={"state": "completed"},
+        state="completed",
         lookback_time=5,
     )
 
@@ -107,9 +107,9 @@ async def acme_and_alice_connection(
         payload = await check_webhook_state(
             client=acme_client,
             topic="connections",
+            state="completed",
             filter_map={
                 "their_label": alice_label,
-                "state": "completed",
             },
         )
 
@@ -136,18 +136,18 @@ async def acme_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "completed",
         },
         lookback_time=5,
     )
     assert await check_webhook_state(
         acme_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": acme_connection_id,
-            "state": "completed",
         },
         lookback_time=5,
     )
@@ -189,18 +189,18 @@ async def faber_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "completed",
         },
         lookback_time=5,
     )
     assert await check_webhook_state(
         faber_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": faber_connection_id,
-            "state": "completed",
         },
         lookback_time=5,
     )
@@ -246,9 +246,9 @@ async def meld_co_and_alice_connection(
         payload = await check_webhook_state(
             client=meld_co_client,
             topic="connections",
+            state="completed",
             filter_map={
                 "their_label": alice_label,
-                "state": "completed",
             },
         )
 
@@ -275,18 +275,18 @@ async def meld_co_and_alice_connection(
     assert await check_webhook_state(
         alice_member_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": alice_connection_id,
-            "state": "completed",
         },
         lookback_time=5,
     )
     assert await check_webhook_state(
         meld_co_client,
         topic="connections",
+        state="completed",
         filter_map={
             "connection_id": meld_co_connection_id,
-            "state": "completed",
         },
         lookback_time=5,
     )
@@ -386,7 +386,7 @@ async def alice_bob_connect_multi(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
-        filter_map={"state": "request-sent"},
+        state="request-sent",
     )
 
     bob_connection_id = multi_use_invite["multi_use_invitation"]["connection_id"]
@@ -401,13 +401,13 @@ async def alice_bob_connect_multi(
     assert await check_webhook_state(
         client=alice_member_client,
         topic="connections",
-        filter_map={"state": "completed"},
+        state="completed",
         lookback_time=5,
     )
     assert await check_webhook_state(
         client=bob_member_client,
         topic="connections",
-        filter_map={"state": "completed"},
+        state="completed",
         lookback_time=5,
     )
 

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -30,6 +30,8 @@ async def check_webhook_state(
     filter_map: Optional[Dict[str, str]] = None,
     max_duration: int = 60,
     lookback_time: int = 1,
+    max_tries: int = 2,
+    delay: float = 0.5,
 ) -> Dict[str, Any]:
     assert max_duration >= 0, "Poll duration cannot be negative"
 
@@ -41,8 +43,6 @@ async def check_webhook_state(
     # Retry logic in case of disconnect errors (don't retry on timeout errors)
     event = None
     attempt = 0
-    max_tries = 2
-    delay = 0.5
 
     while not event and attempt < max_tries:
         try:

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -56,6 +56,6 @@ async def check_webhook_state(
         )
 
     if event:
-        return True
+        return event
     else:
         raise Exception(f"Could not satisfy webhook filter: `{filter_map}`.")


### PR DESCRIPTION
Replaces usages of SseListeners in tests with the helper "check_webhook_state" method. 

Implemented some basic retry logic in this helper method. Currently configured to retry on HTTP disconnects once.