### PR TITLE
:sparkles: Add `group_id` query parameter to SSE endpoints

### DIFF
--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -128,7 +128,7 @@ async def get_sse_subscribe_event_with_state(
         "GET request received: Subscribe to wallet events by topic and desired state"
     )
 
-    verify_wallet_access(auth, wallet_id, group_id)
+    verify_wallet_access(auth, wallet_id)
 
     return StreamingResponse(
         sse_subscribe_event_with_state(


### PR DESCRIPTION
Add group_id query parameter for the tenant-web / tenant-admin-web SSE endpoints, and forward group_id param as part of the request to the webhooks service