### PR TITLE
:sparkles: add `look_back` query param to SSE routes

### DIFF
--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -35,7 +35,7 @@ look_back_field: float = Query(
     le=MAX_EVENT_AGE_SECONDS,
 )
 
-group_id_field = Query(
+group_id_field: Optional[str] = Query(
     default=None,
     description="Group ID to which the wallet belongs",
     include_in_schema=False,
@@ -43,7 +43,9 @@ group_id_field = Query(
 
 
 @router.get(
-    "/{wallet_id}", response_class=StreamingResponse, name="Subscribe to Wallet Events"
+    "/{wallet_id}",
+    response_class=StreamingResponse,
+    name="Subscribe to Wallet Events",
 )
 async def get_sse_subscribe_wallet(
     request: Request,
@@ -51,7 +53,7 @@ async def get_sse_subscribe_wallet(
     look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
-):
+) -> StreamingResponse:
     """
     Subscribe to server-side events for a specific wallet ID.
 
@@ -93,7 +95,7 @@ async def get_sse_subscribe_wallet_topic(
     look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
-):
+) -> StreamingResponse:
     """
     Subscribe to server-side events for a specific wallet ID and topic.
 
@@ -139,7 +141,7 @@ async def get_sse_subscribe_event_with_state(
     look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
-):
+) -> StreamingResponse:
     """
     Subscribe to server-side events for a specific wallet ID and topic,
     and wait for an event that matches the desired state.
@@ -192,7 +194,7 @@ async def get_sse_subscribe_stream_with_fields(
     look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
-):
+) -> StreamingResponse:
     """
     Subscribe to server-side events for a specific wallet ID and topic, and
     filter the events for payloads containing a specific field and field ID pair.
@@ -246,7 +248,7 @@ async def get_sse_subscribe_event_with_field_and_state(
     look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
-):
+) -> StreamingResponse:
     """
     Wait for a desired state to be reached for some event for this wallet and topic,
     filtering for payloads that contain `field:field_id`.

--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -36,6 +36,7 @@ look_back_field: float = Query(
 group_id_field = Query(
     default=None,
     description="Group ID to which the wallet belongs",
+    include_in_schema=False,
 )
 
 

--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -27,10 +27,12 @@ look_back_field: float = Query(
     default=MAX_EVENT_AGE_SECONDS,
     description=(
         "The duration in seconds to look back in time, defining the window of additional webhook events that should "
-        "be included before the initial connection of the stream. The default value will include events up to "
-        f"{MAX_EVENT_AGE_SECONDS} seconds ago. "
-        "Setting to 0 means only events after connection is established will be returned."
+        "be included, prior to the initial connection of the stream. The default value will include events up to "
+        f"{MAX_EVENT_AGE_SECONDS} seconds ago, and represents the maximum value for this setting. "
+        "Setting to 0 means only events after the connection is established will be returned."
     ),
+    ge=0.0,
+    le=MAX_EVENT_AGE_SECONDS,
 )
 
 group_id_field = Query(

--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -55,7 +55,8 @@ async def get_sse_subscribe_wallet(
     """
     Subscribe to server-side events for a specific wallet ID.
 
-    Args:
+    Parameters:
+    -----------
         wallet_id: The ID of the wallet subscribing to the events.
         look_back: Specifies the look back window in seconds, to include events before connection established.
     """
@@ -96,7 +97,8 @@ async def get_sse_subscribe_wallet_topic(
     """
     Subscribe to server-side events for a specific wallet ID and topic.
 
-    Args:
+    Parameters:
+    -----------
         wallet_id: The ID of the wallet subscribing to the events.
         topic: The topic to which the wallet is subscribing.
         look_back: Specifies the look back window in seconds, to include events before connection established.
@@ -142,7 +144,8 @@ async def get_sse_subscribe_event_with_state(
     Subscribe to server-side events for a specific wallet ID and topic,
     and wait for an event that matches the desired state.
 
-    Args:
+    Parameters:
+    -----------
         wallet_id: The ID of the wallet subscribing to the events.
         topic: The topic to which the wallet is subscribing.
         desired_state: The desired state to be reached.
@@ -194,7 +197,8 @@ async def get_sse_subscribe_stream_with_fields(
     Subscribe to server-side events for a specific wallet ID and topic, and
     filter the events for payloads containing a specific field and field ID pair.
 
-    Args:
+    Parameters:
+    -----------
         wallet_id: The ID of the wallet subscribing to the events.
         topic: The topic to which the wallet is subscribing.
         field: The field to which the wallet is subscribing.
@@ -247,7 +251,8 @@ async def get_sse_subscribe_event_with_field_and_state(
     Wait for a desired state to be reached for some event for this wallet and topic,
     filtering for payloads that contain `field:field_id`.
 
-    Args:
+    Parameters:
+    -----------
         wallet_id: The ID of the wallet subscribing to the events.
         topic: The topic to which the wallet is subscribing.
         field: The field to which the wallet is subscribing.

--- a/app/services/event_handling/sse.py
+++ b/app/services/event_handling/sse.py
@@ -4,6 +4,7 @@ from fastapi import Request
 from httpx import HTTPError, Response, Timeout
 
 from shared import WEBHOOKS_URL
+from shared.constants import MAX_EVENT_AGE_SECONDS
 from shared.log_config import get_logger
 from shared.util.rich_async_client import RichAsyncClient
 
@@ -25,7 +26,11 @@ async def yield_lines_with_disconnect_check(
 
 
 async def sse_subscribe_wallet(
-    *, request: Request, group_id: Optional[str], wallet_id: str
+    *,
+    request: Request,
+    group_id: Optional[str],
+    wallet_id: str,
+    look_back: float = MAX_EVENT_AGE_SECONDS,
 ) -> AsyncGenerator[str, None]:
     """
     Subscribe to server-side events for a specific wallet ID.
@@ -34,8 +39,20 @@ async def sse_subscribe_wallet(
         group_id: The group to which the wallet belongs.
         wallet_id: The ID of the wallet subscribing to the events.
     """
-    bound_logger = logger.bind(body={"group_id": group_id, "wallet_id": wallet_id})
-    params = {"group_id": group_id} if group_id else None
+    bound_logger = logger.bind(
+        body={
+            "group_id": group_id,
+            "wallet_id": wallet_id,
+            "look_back": look_back,
+        }
+    )
+
+    # Required param
+    params = {"look_back": look_back}
+
+    if group_id:  # Optional param
+        params["group_id"] = group_id
+
     try:
         async with RichAsyncClient(timeout=default_timeout) as client:
             bound_logger.debug("Connecting stream to /sse/wallet_id")
@@ -50,7 +67,12 @@ async def sse_subscribe_wallet(
 
 
 async def sse_subscribe_wallet_topic(
-    *, request: Request, group_id: Optional[str], wallet_id: str, topic: str
+    *,
+    request: Request,
+    group_id: Optional[str],
+    wallet_id: str,
+    topic: str,
+    look_back: float = MAX_EVENT_AGE_SECONDS,
 ) -> AsyncGenerator[str, None]:
     """
     Subscribe to server-side events for a specific wallet ID and topic.
@@ -61,9 +83,20 @@ async def sse_subscribe_wallet_topic(
         topic: The topic to which the wallet is subscribing.
     """
     bound_logger = logger.bind(
-        body={"group_id": group_id, "wallet_id": wallet_id, "topic": topic}
+        body={
+            "group_id": group_id,
+            "wallet_id": wallet_id,
+            "topic": topic,
+            "look_back": look_back,
+        }
     )
-    params = {"group_id": group_id} if group_id else None
+
+    # Required param
+    params = {"look_back": look_back}
+
+    if group_id:  # Optional param
+        params["group_id"] = group_id
+
     try:
         async with RichAsyncClient(timeout=default_timeout) as client:
             bound_logger.debug("Connecting stream to /sse/wallet_id/topic")
@@ -84,6 +117,7 @@ async def sse_subscribe_event_with_state(
     wallet_id: str,
     topic: str,
     desired_state: str,
+    look_back: float = MAX_EVENT_AGE_SECONDS,
 ) -> AsyncGenerator[str, None]:
     """
     Subscribe to server-side events for a specific wallet ID and topic.
@@ -100,9 +134,16 @@ async def sse_subscribe_event_with_state(
             "wallet_id": wallet_id,
             "topic": topic,
             "state": desired_state,
+            "look_back": look_back,
         }
     )
-    params = {"group_id": group_id} if group_id else None
+
+    # Required param
+    params = {"look_back": look_back}
+
+    if group_id:  # Optional param
+        params["group_id"] = group_id
+
     try:
         async with RichAsyncClient(timeout=event_timeout) as client:
             bound_logger.debug(
@@ -128,6 +169,7 @@ async def sse_subscribe_stream_with_fields(
     topic: str,
     field: str,
     field_id: str,
+    look_back: float = MAX_EVENT_AGE_SECONDS,
 ) -> AsyncGenerator[str, None]:
     """
     Subscribe to server-side events for a specific wallet ID and topic.
@@ -145,9 +187,16 @@ async def sse_subscribe_stream_with_fields(
             "wallet_id": wallet_id,
             "topic": topic,
             field: field_id,
+            "look_back": look_back,
         }
     )
-    params = {"group_id": group_id} if group_id else None
+
+    # Required param
+    params = {"look_back": look_back}
+
+    if group_id:  # Optional param
+        params["group_id"] = group_id
+
     try:
         async with RichAsyncClient(timeout=default_timeout) as client:
             bound_logger.debug(
@@ -174,6 +223,7 @@ async def sse_subscribe_event_with_field_and_state(
     field: str,
     field_id: str,
     desired_state: str,
+    look_back: float = MAX_EVENT_AGE_SECONDS,
 ) -> AsyncGenerator[str, None]:
     """
     Subscribe to server-side events for a specific wallet ID and topic.
@@ -193,9 +243,16 @@ async def sse_subscribe_event_with_field_and_state(
             "topic": topic,
             field: field_id,
             "state": desired_state,
+            "look_back": look_back,
         }
     )
-    params = {"group_id": group_id} if group_id else None
+
+    # Required param
+    params = {"look_back": look_back}
+
+    if group_id:  # Optional param
+        params["group_id"] = group_id
+
     try:
         async with RichAsyncClient(timeout=event_timeout) as client:
             bound_logger.debug(

--- a/app/tests/e2e/issuer/indy/test_v1_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v1_indy.py
@@ -225,14 +225,14 @@ async def test_send_credential_request(
         client=alice_member_client,
         topic="credentials",
         state="request-sent",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
 

--- a/app/tests/e2e/issuer/indy/test_v2_indy.py
+++ b/app/tests/e2e/issuer/indy/test_v2_indy.py
@@ -220,14 +220,14 @@ async def test_send_credential_request(
         client=alice_member_client,
         topic="credentials",
         state="request-sent",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -232,14 +232,14 @@ async def test_send_jsonld_request(
         filter_map={
             "credential_id": credential_exchange["credential_id"],
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
-        lookback_time=5,
+        look_back=5,
     )
 
     await asyncio.sleep(0.2)  # credential may take moment to reflect after webhook
@@ -260,14 +260,14 @@ async def test_send_jsonld_request(
         client=alice_member_client,
         topic="credentials",
         state="request-sent",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
 
@@ -299,14 +299,14 @@ async def test_issue_jsonld_bbs(
         filter_map={
             "credential_id": credential_exchange["credential_id"],
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
-        lookback_time=5,
+        look_back=5,
     )
 
     await asyncio.sleep(0.2)  # credential may take moment to reflect after webhook
@@ -327,14 +327,14 @@ async def test_issue_jsonld_bbs(
         client=alice_member_client,
         topic="credentials",
         state="done",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="done",
-        lookback_time=5,
+        look_back=5,
     )
 
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -232,14 +232,14 @@ async def test_send_jsonld_request(
         filter_map={
             "credential_id": credential_exchange["credential_id"],
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
-        lookback_time=5,
+        look_back=5,
     )
 
     await asyncio.sleep(0.2)  # credential may take moment to reflect after webhook
@@ -260,14 +260,14 @@ async def test_send_jsonld_request(
         client=alice_member_client,
         topic="credentials",
         state="request-sent",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
 
@@ -302,14 +302,14 @@ async def test_issue_jsonld_ed(
         filter_map={
             "credential_id": credential_exchange["credential_id"],
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
-        lookback_time=5,
+        look_back=5,
     )
 
     await asyncio.sleep(0.2)  # credential may take moment to reflect after webhook
@@ -330,14 +330,14 @@ async def test_issue_jsonld_ed(
         client=alice_member_client,
         topic="credentials",
         state="done",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="done",
-        lookback_time=5,
+        look_back=5,
     )
 
 

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -259,14 +259,14 @@ async def test_send_jsonld_request_sov(
         client=alice_member_client,
         topic="credentials",
         state="request-sent",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
 
@@ -328,12 +328,12 @@ async def test_issue_jsonld_sov(
         client=alice_member_client,
         topic="credentials",
         state="done",
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
         client=faber_client,
         topic="credentials",
         state="done",
-        lookback_time=5,
+        look_back=5,
     )

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -91,7 +91,7 @@ async def test_proof_model_failures(
         client=alice_member_client,
         topic="proofs",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
     # Get proof exchange id

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -58,7 +58,7 @@ async def test_proof_revoked_credential(
         client=alice_member_client,
         topic="proofs",
         state="request-received",
-        lookback_time=5,
+        look_back=5,
     )
 
     # Get proof exchange id
@@ -97,7 +97,7 @@ async def test_proof_revoked_credential(
         filter_map={
             "proof_id": alice_proof_exchange_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     await check_webhook_state(
@@ -107,7 +107,7 @@ async def test_proof_revoked_credential(
         filter_map={
             "proof_id": acme_proof_exchange_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     # Check proof

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -106,7 +106,7 @@ async def test_accept_proof_request_v1(
         filter_map={
             "proof_id": alice_proof_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
@@ -116,7 +116,7 @@ async def test_accept_proof_request_v1(
         filter_map={
             "proof_id": acme_proof_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     result = response.json()
@@ -803,7 +803,7 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
         filter_map={
             "proof_id": alice_proof_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
@@ -813,7 +813,7 @@ async def test_accept_proof_request_v1_verifier_has_issuer_role(
             "proof_id": meld_co_proof_id,
         },
         topic="proofs",
-        lookback_time=5,
+        look_back=5,
     )
 
     result = response.json()
@@ -970,7 +970,7 @@ async def test_saving_of_presentation_exchange_records(
         filter_map={
             "proof_id": alice_proof_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     assert await check_webhook_state(
@@ -980,7 +980,7 @@ async def test_saving_of_presentation_exchange_records(
         filter_map={
             "proof_id": acme_proof_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     result = response.json()

--- a/app/tests/routes/test_sse.py
+++ b/app/tests/routes/test_sse.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -9,9 +10,9 @@ from app.routes.sse import (
     get_sse_subscribe_wallet,
     get_sse_subscribe_wallet_topic,
 )
+from shared.constants import MAX_EVENT_AGE_SECONDS
 
 wallet_id = "some_wallet"
-group_id = "some_group_id"
 topic = "some_topic"
 field = "some_field"
 field_id = "some_field_id"
@@ -35,10 +36,14 @@ def mock_verify_wallet_access():
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_get_sse_subscribe_wallet(
     mock_request,  # pylint: disable=redefined-outer-name
     mock_auth,  # pylint: disable=redefined-outer-name
     mock_verify_wallet_access,  # pylint: disable=redefined-outer-name
+    group_id: Optional[str],
+    look_back: float,
 ):
     # Mock sse_subscribe_wallet function to not actually attempt to connect to an SSE stream
     sse_subscribe_wallet_mock = Mock()
@@ -48,6 +53,7 @@ async def test_get_sse_subscribe_wallet(
         response = await get_sse_subscribe_wallet(
             request=mock_request,
             wallet_id=wallet_id,
+            look_back=look_back,
             group_id=group_id,
             auth=mock_auth,
         )
@@ -60,14 +66,19 @@ async def test_get_sse_subscribe_wallet(
         request=mock_request,
         group_id=group_id,
         wallet_id=wallet_id,
+        look_back=look_back,
     )
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_get_sse_subscribe_wallet_topic(
     mock_request,  # pylint: disable=redefined-outer-name
     mock_auth,  # pylint: disable=redefined-outer-name
     mock_verify_wallet_access,  # pylint: disable=redefined-outer-name
+    group_id: Optional[str],
+    look_back: float,
 ):
     # Mock sse_subscribe_wallet_topic function to not actually attempt to connect to an SSE stream
     sse_subscribe_wallet_topic_mock = Mock()
@@ -79,8 +90,9 @@ async def test_get_sse_subscribe_wallet_topic(
         response = await get_sse_subscribe_wallet_topic(
             request=mock_request,
             wallet_id=wallet_id,
-            group_id=group_id,
             topic=topic,
+            look_back=look_back,
+            group_id=group_id,
             auth=mock_auth,
         )
 
@@ -93,14 +105,19 @@ async def test_get_sse_subscribe_wallet_topic(
         group_id=group_id,
         topic=topic,
         wallet_id=wallet_id,
+        look_back=look_back,
     )
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_get_sse_subscribe_event_with_state(
     mock_request,  # pylint: disable=redefined-outer-name
     mock_auth,  # pylint: disable=redefined-outer-name
     mock_verify_wallet_access,  # pylint: disable=redefined-outer-name
+    group_id: Optional[str],
+    look_back: float,
 ):
     # Mock sse_subscribe_event_with_state function to not actually attempt to connect to an SSE stream
     sse_subscribe_event_with_state_mock = Mock()
@@ -113,9 +130,10 @@ async def test_get_sse_subscribe_event_with_state(
         response = await get_sse_subscribe_event_with_state(
             request=mock_request,
             wallet_id=wallet_id,
-            group_id=group_id,
             topic=topic,
             desired_state=state,
+            look_back=look_back,
+            group_id=group_id,
             auth=mock_auth,
         )
 
@@ -129,14 +147,19 @@ async def test_get_sse_subscribe_event_with_state(
         group_id=group_id,
         topic=topic,
         desired_state=state,
+        look_back=look_back,
     )
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_get_sse_subscribe_stream_with_fields(
     mock_request,  # pylint: disable=redefined-outer-name
     mock_auth,  # pylint: disable=redefined-outer-name
     mock_verify_wallet_access,  # pylint: disable=redefined-outer-name
+    group_id: Optional[str],
+    look_back: float,
 ):
     # Mock sse_subscribe_stream_with_fields function to not actually attempt to connect to an SSE stream
     sse_subscribe_stream_with_fields_mock = Mock()
@@ -149,10 +172,11 @@ async def test_get_sse_subscribe_stream_with_fields(
         response = await get_sse_subscribe_stream_with_fields(
             request=mock_request,
             wallet_id=wallet_id,
-            group_id=group_id,
             topic=topic,
             field=field,
             field_id=field_id,
+            look_back=look_back,
+            group_id=group_id,
             auth=mock_auth,
         )
 
@@ -167,14 +191,19 @@ async def test_get_sse_subscribe_stream_with_fields(
         topic=topic,
         field=field,
         field_id=field_id,
+        look_back=look_back,
     )
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_get_sse_subscribe_event_with_field_and_state(
     mock_request,  # pylint: disable=redefined-outer-name
     mock_auth,  # pylint: disable=redefined-outer-name
     mock_verify_wallet_access,  # pylint: disable=redefined-outer-name
+    group_id: Optional[str],
+    look_back: float,
 ):
     # Mock sse_subscribe_event_with_field_and_state function to not actually attempt to connect to an SSE stream
     sse_subscribe_event_with_field_and_state_mock = Mock()
@@ -187,11 +216,12 @@ async def test_get_sse_subscribe_event_with_field_and_state(
         response = await get_sse_subscribe_event_with_field_and_state(
             request=mock_request,
             wallet_id=wallet_id,
-            group_id=group_id,
             topic=topic,
             field=field,
             field_id=field_id,
             desired_state=state,
+            look_back=look_back,
+            group_id=group_id,
             auth=mock_auth,
         )
 
@@ -207,4 +237,5 @@ async def test_get_sse_subscribe_event_with_field_and_state(
         field=field,
         field_id=field_id,
         desired_state=state,
+        look_back=look_back,
     )

--- a/app/tests/services/event_handling/test_sse.py
+++ b/app/tests/services/event_handling/test_sse.py
@@ -13,7 +13,7 @@ from app.services.event_handling.sse import (
     sse_subscribe_wallet_topic,
     yield_lines_with_disconnect_check,
 )
-from shared.constants import WEBHOOKS_URL
+from shared.constants import MAX_EVENT_AGE_SECONDS, WEBHOOKS_URL
 from shared.util.rich_async_client import RichAsyncClient
 
 wallet_id = "some_wallet"
@@ -149,12 +149,18 @@ async def test_sse_subscribe_wallet_exception(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_sse_subscribe_wallet_success(
     configured_async_context_manager_mock,  # pylint: disable=redefined-outer-name
     mock_request,  # pylint: disable=redefined-outer-name
     patch_yield_lines_with_disconnect_check,  # pylint: disable=redefined-outer-name
     group_id: Optional[str],
+    look_back: float,
 ):
+    expected_params = {"look_back": look_back}
+    if group_id:  # Optional param
+        expected_params["group_id"] = group_id
+
     with patch.object(
         RichAsyncClient,
         "stream",
@@ -163,7 +169,10 @@ async def test_sse_subscribe_wallet_success(
         # Execute the sse_subscribe_wallet and collect results
         results = []
         async for line in sse_subscribe_wallet(
-            request=mock_request, group_id=group_id, wallet_id=wallet_id
+            request=mock_request,
+            group_id=group_id,
+            wallet_id=wallet_id,
+            look_back=look_back,
         ):
             results.append(line)
 
@@ -177,7 +186,7 @@ async def test_sse_subscribe_wallet_success(
         mock_stream.assert_called_with(
             "GET",
             f"{WEBHOOKS_URL}/sse/{wallet_id}",
-            params={"group_id": group_id} if group_id else None,
+            params=expected_params,
         )
 
 
@@ -210,12 +219,18 @@ async def test_sse_subscribe_wallet_topic_exception(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_sse_subscribe_wallet_topic_success(
     configured_async_context_manager_mock,  # pylint: disable=redefined-outer-name
     mock_request,  # pylint: disable=redefined-outer-name
     patch_yield_lines_with_disconnect_check,  # pylint: disable=redefined-outer-name
     group_id: Optional[str],
+    look_back: float,
 ):
+    expected_params = {"look_back": look_back}
+    if group_id:  # Optional param
+        expected_params["group_id"] = group_id
+
     with patch.object(
         RichAsyncClient,
         "stream",
@@ -224,7 +239,11 @@ async def test_sse_subscribe_wallet_topic_success(
         # Execute the sse_subscribe_wallet_topic and collect results
         results = []
         async for line in sse_subscribe_wallet_topic(
-            request=mock_request, group_id=group_id, wallet_id=wallet_id, topic=topic
+            request=mock_request,
+            group_id=group_id,
+            wallet_id=wallet_id,
+            topic=topic,
+            look_back=look_back,
         ):
             results.append(line)
 
@@ -238,7 +257,7 @@ async def test_sse_subscribe_wallet_topic_success(
         mock_stream.assert_called_with(
             "GET",
             f"{WEBHOOKS_URL}/sse/{wallet_id}/{topic}",
-            params={"group_id": group_id} if group_id else None,
+            params=expected_params,
         )
 
 
@@ -272,12 +291,18 @@ async def test_sse_subscribe_event_with_state_exception(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_sse_subscribe_event_with_state_success(
     configured_async_context_manager_mock,  # pylint: disable=redefined-outer-name
     mock_request,  # pylint: disable=redefined-outer-name
     patch_yield_lines_with_disconnect_check,  # pylint: disable=redefined-outer-name
     group_id: Optional[str],
+    look_back: float,
 ):
+    expected_params = {"look_back": look_back}
+    if group_id:  # Optional param
+        expected_params["group_id"] = group_id
+
     with patch.object(
         RichAsyncClient,
         "stream",
@@ -291,6 +316,7 @@ async def test_sse_subscribe_event_with_state_success(
             wallet_id=wallet_id,
             topic=topic,
             desired_state=state,
+            look_back=look_back,
         ):
             results.append(line)
 
@@ -304,7 +330,7 @@ async def test_sse_subscribe_event_with_state_success(
         mock_stream.assert_called_with(
             "GET",
             f"{WEBHOOKS_URL}/sse/{wallet_id}/{topic}/{state}",
-            params={"group_id": group_id} if group_id else None,
+            params=expected_params,
         )
 
 
@@ -339,12 +365,18 @@ async def test_sse_subscribe_stream_with_fields_exception(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_sse_subscribe_stream_with_fields_success(
     configured_async_context_manager_mock,  # pylint: disable=redefined-outer-name
     mock_request,  # pylint: disable=redefined-outer-name
     patch_yield_lines_with_disconnect_check,  # pylint: disable=redefined-outer-name
     group_id: Optional[str],
+    look_back: float,
 ):
+    expected_params = {"look_back": look_back}
+    if group_id:  # Optional param
+        expected_params["group_id"] = group_id
+
     with patch.object(
         RichAsyncClient,
         "stream",
@@ -359,6 +391,7 @@ async def test_sse_subscribe_stream_with_fields_success(
             topic=topic,
             field=field,
             field_id=field_id,
+            look_back=look_back,
         ):
             results.append(line)
 
@@ -372,7 +405,7 @@ async def test_sse_subscribe_stream_with_fields_success(
         mock_stream.assert_called_with(
             "GET",
             f"{WEBHOOKS_URL}/sse/{wallet_id}/{topic}/{field}/{field_id}",
-            params={"group_id": group_id} if group_id else None,
+            params=expected_params,
         )
 
 
@@ -408,12 +441,18 @@ async def test_sse_subscribe_event_with_field_and_state_exception(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("group_id", [None, "some_group"])
+@pytest.mark.parametrize("look_back", [MAX_EVENT_AGE_SECONDS, 0.0])
 async def test_sse_subscribe_event_with_field_and_state_success(
     configured_async_context_manager_mock,  # pylint: disable=redefined-outer-name
     mock_request,  # pylint: disable=redefined-outer-name
     patch_yield_lines_with_disconnect_check,  # pylint: disable=redefined-outer-name
     group_id: Optional[str],
+    look_back: float,
 ):
+    expected_params = {"look_back": look_back}
+    if group_id:  # Optional param
+        expected_params["group_id"] = group_id
+
     with patch.object(
         RichAsyncClient,
         "stream",
@@ -429,6 +468,7 @@ async def test_sse_subscribe_event_with_field_and_state_success(
             field=field,
             field_id=field_id,
             desired_state=state,
+            look_back=look_back,
         ):
             results.append(line)
 
@@ -439,8 +479,9 @@ async def test_sse_subscribe_event_with_field_and_state_success(
 
         # Additionally, assert that the stream was opened with the correct parameters
         configured_async_context_manager_mock.__aenter__.assert_called()
+
         mock_stream.assert_called_with(
             "GET",
             f"{WEBHOOKS_URL}/sse/{wallet_id}/{topic}/{field}/{field_id}/{state}",
-            params={"group_id": group_id} if group_id else None,
+            params=expected_params,
         )

--- a/app/tests/test_util_webhooks.py
+++ b/app/tests/test_util_webhooks.py
@@ -44,7 +44,7 @@ async def test_check_webhook_state_wait_for_event_success(
         field_id="field_id",
         desired_state=state,
         timeout=60,
-        lookback_time=1,
+        look_back=1,
     )
 
 
@@ -107,7 +107,7 @@ async def test_check_webhook_state_wait_for_state_success(
     mock_sse_listener.wait_for_state.assert_awaited_once_with(
         desired_state=state,
         timeout=60,
-        lookback_time=1,
+        look_back=1,
     )
 
 

--- a/app/tests/util/ecosystem_connections.py
+++ b/app/tests/util/ecosystem_connections.py
@@ -60,13 +60,13 @@ async def bob_and_alice_connection(
         alice_member_client,
         topic="connections",
         state="completed",
-        lookback_time=5,
+        look_back=5,
     )
     assert await check_webhook_state(
         bob_member_client,
         topic="connections",
         state="completed",
-        lookback_time=5,
+        look_back=5,
     )
 
     return BobAliceConnect(
@@ -140,7 +140,7 @@ async def acme_and_alice_connection(
         filter_map={
             "connection_id": alice_connection_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
     assert await check_webhook_state(
         acme_client,
@@ -149,7 +149,7 @@ async def acme_and_alice_connection(
         filter_map={
             "connection_id": acme_connection_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     return AcmeAliceConnect(
@@ -193,7 +193,7 @@ async def faber_and_alice_connection(
         filter_map={
             "connection_id": alice_connection_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
     assert await check_webhook_state(
         faber_client,
@@ -202,7 +202,7 @@ async def faber_and_alice_connection(
         filter_map={
             "connection_id": faber_connection_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     return FaberAliceConnect(
@@ -279,7 +279,7 @@ async def meld_co_and_alice_connection(
         filter_map={
             "connection_id": alice_connection_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
     assert await check_webhook_state(
         meld_co_client,
@@ -288,7 +288,7 @@ async def meld_co_and_alice_connection(
         filter_map={
             "connection_id": meld_co_connection_id,
         },
-        lookback_time=5,
+        look_back=5,
     )
 
     return MeldCoAliceConnect(
@@ -402,13 +402,13 @@ async def alice_bob_connect_multi(
         client=alice_member_client,
         topic="connections",
         state="completed",
-        lookback_time=5,
+        look_back=5,
     )
     assert await check_webhook_state(
         client=bob_member_client,
         topic="connections",
         state="completed",
-        lookback_time=5,
+        look_back=5,
     )
 
     return BobAliceConnect(

--- a/app/tests/util/sse_listener.py
+++ b/app/tests/util/sse_listener.py
@@ -31,7 +31,7 @@ class SseListener:
         self.topic = topic
 
     async def wait_for_state(
-        self, desired_state, timeout: int = DEFAULT_LISTENER_TIMEOUT, lookback_time=1
+        self, desired_state, timeout: int = DEFAULT_LISTENER_TIMEOUT, look_back=1
     ) -> Dict[str, Any]:
         """
         Start listening for SSE events. When an event is received that matches the specified parameters.
@@ -41,7 +41,7 @@ class SseListener:
         timeout = Timeout(timeout)
         async with RichAsyncClient(timeout=timeout) as client:
             async with client.stream(
-                "GET", url, params={"lookback_time": lookback_time}
+                "GET", url, params={"look_back": look_back}
             ) as response:
                 async for line in response.aiter_lines():
                     if line.startswith("data: "):
@@ -60,7 +60,7 @@ class SseListener:
         field_id,
         desired_state,
         timeout: int = DEFAULT_LISTENER_TIMEOUT,
-        lookback_time=1,
+        look_back=1,
     ) -> Dict[str, Any]:
         """
         Start listening for SSE events. When an event is received that matches the specified parameters.
@@ -70,7 +70,7 @@ class SseListener:
         timeout = Timeout(timeout)
         async with RichAsyncClient(timeout=timeout) as client:
             async with client.stream(
-                "GET", url, params={"lookback_time": lookback_time}
+                "GET", url, params={"look_back": look_back}
             ) as response:
                 async for line in response.aiter_lines():
                     if line.startswith("data: "):

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -29,7 +29,7 @@ async def check_webhook_state(
     state: str,
     filter_map: Optional[Dict[str, str]] = None,
     max_duration: int = 60,
-    look_back: int = 1,
+    look_back: float = 1,
     max_tries: int = 2,
     delay: float = 0.5,
 ) -> Dict[str, Any]:

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -29,7 +29,7 @@ async def check_webhook_state(
     state: str,
     filter_map: Optional[Dict[str, str]] = None,
     max_duration: int = 60,
-    lookback_time: int = 1,
+    look_back: int = 1,
     max_tries: int = 2,
     delay: float = 0.5,
 ) -> Dict[str, Any]:
@@ -61,14 +61,14 @@ async def check_webhook_state(
                     field_id=field_id,
                     desired_state=state,
                     timeout=max_duration,
-                    lookback_time=lookback_time + attempt,  # Increase per attempt
+                    look_back=look_back + attempt,  # Increase per attempt
                 )
             else:
                 bound_logger.info("Waiting for event with state {}", state)
                 event = await listener.wait_for_state(
                     desired_state=state,
                     timeout=max_duration,
-                    lookback_time=lookback_time + attempt,  # Increase per attempt
+                    look_back=look_back + attempt,  # Increase per attempt
                 )
         except SseListenerTimeout:
             bound_logger.error(

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -45,7 +45,7 @@ LEDGER_TYPE: str = "von"
 LEDGER_REGISTRATION_URL = os.getenv("LEDGER_REGISTRATION_URL", f"{url}:9000/register")
 
 # Sse manager
-MAX_EVENT_AGE_SECONDS = int(os.getenv("MAX_EVENT_AGE_SECONDS", "30"))
+MAX_EVENT_AGE_SECONDS = float(os.getenv("MAX_EVENT_AGE_SECONDS", "30"))
 MAX_QUEUE_SIZE = int(os.getenv("MAX_QUEUE_SIZE", "200"))
 QUEUE_CLEANUP_PERIOD = int(os.getenv("QUEUE_CLEANUP_PERIOD", "60"))
 CLIENT_QUEUE_POLL_PERIOD = float(os.getenv("CLIENT_QUEUE_POLL_PERIOD", "0.2"))

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -291,7 +291,7 @@ class SseManager:
         wallet: str,
         topic: str,
         stop_event: asyncio.Event,
-        look_back: int = MAX_EVENT_AGE_SECONDS,
+        look_back: float = MAX_EVENT_AGE_SECONDS,
         duration: int = 0,
     ) -> EventGeneratorWrapper:
         """
@@ -355,7 +355,7 @@ class SseManager:
         wallet: str,
         topic: str,
         client_queue: asyncio.Queue,
-        look_back: int = MAX_EVENT_AGE_SECONDS,
+        look_back: float = MAX_EVENT_AGE_SECONDS,
     ) -> NoReturn:
         logger.trace(
             "SSE Manager: start _populate_client_queue for wallet `{}` and topic `{}`",

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -291,7 +291,7 @@ class SseManager:
         wallet: str,
         topic: str,
         stop_event: asyncio.Event,
-        lookback_time: int = MAX_EVENT_AGE_SECONDS,
+        look_back: int = MAX_EVENT_AGE_SECONDS,
         duration: int = 0,
     ) -> EventGeneratorWrapper:
         """
@@ -301,7 +301,7 @@ class SseManager:
             wallet: The ID of the wallet subscribing to the topic.
             topic: The topic for which to create the event stream.
             stop_event: An asyncio.Event to signal a stop request
-            lookback_time: Duration (s) to look back for older events. 0 means from now
+            look_back: Duration (s) to look back for older events. 0 means from now
             duration: Timeout duration in seconds. 0 means no timeout.
         """
         client_queue = asyncio.Queue()
@@ -311,7 +311,7 @@ class SseManager:
                 wallet=wallet,
                 topic=topic,
                 client_queue=client_queue,
-                lookback_time=lookback_time,
+                look_back=look_back,
             )
         )
 
@@ -355,7 +355,7 @@ class SseManager:
         wallet: str,
         topic: str,
         client_queue: asyncio.Queue,
-        lookback_time: int = MAX_EVENT_AGE_SECONDS,
+        look_back: int = MAX_EVENT_AGE_SECONDS,
     ) -> NoReturn:
         logger.trace(
             "SSE Manager: start _populate_client_queue for wallet `{}` and topic `{}`",
@@ -365,7 +365,7 @@ class SseManager:
         event_log = []  # to keep track of events already added for this client queue
 
         now = time.time()
-        since_timestamp = now - lookback_time
+        since_timestamp = now - look_back
         while True:
             if topic == WEBHOOK_TOPIC_ALL:
                 for topic_key in self.lifo_cache[wallet].keys():

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -20,16 +20,18 @@ router = APIRouter(
     tags=["sse"],
 )
 
-look_back_field = Query(
+look_back_field: float = Query(
     default=MAX_EVENT_AGE_SECONDS,
     description=(
         "Duration in seconds to look back in time to include past events "
         f"(default is the max event age stored in SSE: {MAX_EVENT_AGE_SECONDS} seconds). "
         "Setting to 0 means only events after connection is established will be returned"
     ),
+    ge=0,
+    le=MAX_EVENT_AGE_SECONDS,
 )
 
-group_id_field = Query(
+group_id_field: Optional[str] = Query(
     default=None,
     description="Group ID to which the wallet belongs",
 )
@@ -73,7 +75,13 @@ async def sse_subscribe_wallet(
         wallet_id: The ID of the wallet subscribing to the events.
         sse_manager: The SSEManager instance managing the server-sent events.
     """
-    bound_logger = logger.bind(body={"wallet_id": wallet_id, "group_id": group_id})
+    bound_logger = logger.bind(
+        body={
+            "wallet_id": wallet_id,
+            "group_id": group_id,
+            "look_back": look_back,
+        }
+    )
     bound_logger.info(
         "SSE: GET request received: Subscribe to wallet events on all topics"
     )
@@ -140,7 +148,12 @@ async def sse_subscribe_wallet_topic(
         sse_manager: The SSEManager instance managing the server-sent events.
     """
     bound_logger = logger.bind(
-        body={"wallet_id": wallet_id, "group_id": group_id, "topic": topic}
+        body={
+            "wallet_id": wallet_id,
+            "group_id": group_id,
+            "topic": topic,
+            "look_back": look_back,
+        }
     )
     bound_logger.info("SSE: GET request received: Subscribe to wallet events by topic")
 
@@ -205,6 +218,7 @@ async def sse_subscribe_event_with_state(
             "group_id": group_id,
             "topic": topic,
             "desired_state": desired_state,
+            "look_back": look_back,
         }
     )
     bound_logger.info(
@@ -282,6 +296,7 @@ async def sse_subscribe_stream_with_fields(
             "group_id": group_id,
             "topic": topic,
             field: field_id,
+            "look_back": look_back,
         }
     )
     bound_logger.info(
@@ -358,6 +373,7 @@ async def sse_subscribe_event_with_field_and_state(
             "topic": topic,
             field: field_id,
             "desired_state": desired_state,
+            "look_back": look_back,
         }
     )
     bound_logger.info(

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -62,7 +62,7 @@ async def sse_subscribe_wallet(
     request: Request,
     background_tasks: BackgroundTasks,
     wallet_id: str,
-    look_back: int = look_back_field,
+    look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -127,7 +127,7 @@ async def sse_subscribe_wallet_topic(
     background_tasks: BackgroundTasks,
     wallet_id: str,
     topic: str,
-    look_back: int = look_back_field,
+    look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -195,7 +195,7 @@ async def sse_subscribe_event_with_state(
     wallet_id: str,
     topic: str,
     desired_state: str,
-    look_back: int = look_back_field,
+    look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -272,7 +272,7 @@ async def sse_subscribe_stream_with_fields(
     topic: str,
     field: str,
     field_id: str,
-    look_back: int = look_back_field,
+    look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -347,7 +347,7 @@ async def sse_subscribe_event_with_field_and_state(
     field: str,
     field_id: str,
     desired_state: str,
-    look_back: int = look_back_field,
+    look_back: float = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -20,10 +20,10 @@ router = APIRouter(
     tags=["sse"],
 )
 
-lookback_time_field = Query(
+look_back_field = Query(
     default=MAX_EVENT_AGE_SECONDS,
     description=(
-        "Duration in seconds to lookback in time to include past events "
+        "Duration in seconds to look back in time to include past events "
         f"(default is the max event age stored in SSE: {MAX_EVENT_AGE_SECONDS} seconds). "
         "Setting to 0 means only events after connection is established will be returned"
     ),
@@ -62,7 +62,7 @@ async def sse_subscribe_wallet(
     request: Request,
     background_tasks: BackgroundTasks,
     wallet_id: str,
-    lookback_time: int = lookback_time_field,
+    look_back: int = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -89,7 +89,7 @@ async def sse_subscribe_wallet(
             await sse_manager.sse_event_stream(
                 wallet=wallet_id,
                 topic=WEBHOOK_TOPIC_ALL,
-                lookback_time=lookback_time,
+                look_back=look_back,
                 stop_event=stop_event,
             )
         )
@@ -127,7 +127,7 @@ async def sse_subscribe_wallet_topic(
     background_tasks: BackgroundTasks,
     wallet_id: str,
     topic: str,
-    lookback_time: int = lookback_time_field,
+    look_back: int = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -155,7 +155,7 @@ async def sse_subscribe_wallet_topic(
             await sse_manager.sse_event_stream(
                 wallet=wallet_id,
                 topic=topic,
-                lookback_time=lookback_time,
+                look_back=look_back,
                 stop_event=stop_event,
             )
         )
@@ -195,7 +195,7 @@ async def sse_subscribe_event_with_state(
     wallet_id: str,
     topic: str,
     desired_state: str,
-    lookback_time: int = lookback_time_field,
+    look_back: int = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -223,7 +223,7 @@ async def sse_subscribe_event_with_state(
             await sse_manager.sse_event_stream(
                 wallet=wallet_id,
                 topic=topic,
-                lookback_time=lookback_time,
+                look_back=look_back,
                 stop_event=stop_event,
                 duration=SSE_TIMEOUT,
             )
@@ -272,7 +272,7 @@ async def sse_subscribe_stream_with_fields(
     topic: str,
     field: str,
     field_id: str,
-    lookback_time: int = lookback_time_field,
+    look_back: int = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -300,7 +300,7 @@ async def sse_subscribe_stream_with_fields(
             await sse_manager.sse_event_stream(
                 wallet=wallet_id,
                 topic=topic,
-                lookback_time=lookback_time,
+                look_back=look_back,
                 stop_event=stop_event,
                 duration=SSE_TIMEOUT,
             )
@@ -347,7 +347,7 @@ async def sse_subscribe_event_with_field_and_state(
     field: str,
     field_id: str,
     desired_state: str,
-    lookback_time: int = lookback_time_field,
+    look_back: int = look_back_field,
     group_id: Optional[str] = group_id_field,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
@@ -376,7 +376,7 @@ async def sse_subscribe_event_with_field_and_state(
             await sse_manager.sse_event_stream(
                 wallet=wallet_id,
                 topic=topic,
-                lookback_time=lookback_time,
+                look_back=look_back,
                 stop_event=stop_event,
                 duration=SSE_TIMEOUT,
             )


### PR DESCRIPTION
Internal changes: 
- `lookback_time` renamed to `look_back`
- changed from float to int
- updated tests

External changes:
- `look_back` now an available query param on SSE routes
- `group_id` query param is now hidden from swagger docs (because it shouldn't be set)