### PR TITLE
:lock: Forbid wallet actions if wallet doesn't belong to group

### DIFF
--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -187,7 +187,7 @@ async def delete_tenant_by_id(
             wallet_id=wallet_id,
         )
         if not wallet:
-            bound_logger.error("Bad request: Wallet not found.")
+            bound_logger.info("Bad request: Wallet not found.")
             raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
         # wallet_id is the id of the actor in the trust registry.
@@ -227,7 +227,7 @@ async def get_wallet_auth_token(
             wallet_id=wallet_id,
         )
         if not wallet:
-            bound_logger.error("Bad request: Wallet not found.")
+            bound_logger.info("Bad request: Wallet not found.")
             raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
         bound_logger.debug("Getting auth token for wallet")
@@ -280,7 +280,7 @@ async def get_tenant(
             wallet_id=wallet_id,
         )
         if not wallet:
-            bound_logger.error("Bad request: Wallet not found.")
+            bound_logger.info("Bad request: Wallet not found.")
             raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
     response = tenant_from_wallet_record(wallet)

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -202,7 +202,8 @@ async def delete_tenant_by_id(
             bound_logger.info(
                 "Bad request: Admin cannot act on wallet outside of their group."
             )
-            raise HTTPException(403)
+            # 404 instead of 403, to obscure the existence of wallet_id outside their group
+            raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
         # wallet_id is the id of the actor in the trust registry.
         # This makes it a lot easier to link a tenant to an actor
@@ -249,7 +250,8 @@ async def get_wallet_auth_token(
             bound_logger.info(
                 "Bad request: Admin cannot act on wallet outside of their group."
             )
-            raise HTTPException(403)
+            # 404 instead of 403, to obscure the existence of wallet_id outside their group
+            raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
         bound_logger.debug("Getting auth token for wallet")
         response = await handle_acapy_call(
@@ -291,7 +293,8 @@ async def update_tenant(
             bound_logger.info(
                 "Bad request: Admin cannot act on wallet outside of their group."
             )
-            raise HTTPException(403)
+            # 404 instead of 403, to obscure the existence of wallet_id outside their group
+            raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
         wallet = await handle_tenant_update(
             admin_controller=admin_controller, wallet_id=wallet_id, update_request=body
@@ -327,7 +330,8 @@ async def get_tenant(
             bound_logger.info(
                 "Bad request: Admin cannot act on wallet outside of their group."
             )
-            raise HTTPException(403)
+            # 404 instead of 403, to obscure the existence of wallet_id outside their group
+            raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
 
     response = tenant_from_wallet_record(wallet)
     bound_logger.info("Successfully fetched tenant from wallet record.")

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -301,15 +301,14 @@ async def get_tenants(
     )
 
     async with get_tenant_admin_controller(admin_auth) as admin_controller:
-        if wallet_name:
+        if wallet_name or group_id:
             bound_logger.info("Fetching wallet by wallet name")
             wallets = await handle_acapy_call(
                 logger=bound_logger,
                 acapy_call=admin_controller.multitenancy.get_wallets,
                 wallet_name=wallet_name,
+                group_id=group_id,
             )
-            # TODO: fetching by wallet_name still returns all wallets ... bug in cc or group_id plugin?
-            # Filtering result as workaround:
             if not wallets.results:
                 bound_logger.info("No wallets found.")
                 return []
@@ -322,13 +321,6 @@ async def get_tenants(
             ]
             bound_logger.info("Successfully fetched wallets by wallet name.")
             return response
-        elif group_id:
-            bound_logger.info("Fetching wallets by group_id")
-            wallets = await handle_acapy_call(
-                logger=bound_logger,
-                acapy_call=admin_controller.multitenancy.get_wallets,
-                group_id=group_id,
-            )
         else:
             bound_logger.info("Fetching all wallets")
             wallets = await handle_acapy_call(

--- a/app/routes/admin/tenants.py
+++ b/app/routes/admin/tenants.py
@@ -193,8 +193,8 @@ async def delete_tenant_by_id(
     async with get_tenant_admin_controller(admin_auth) as admin_controller:
         wallet = await get_wallet_and_assert_valid_group(
             admin_controller=admin_controller,
-            group_id=group_id,
             wallet_id=wallet_id,
+            group_id=group_id,
             logger=bound_logger,
         )
 
@@ -231,8 +231,8 @@ async def get_wallet_auth_token(
     async with get_tenant_admin_controller(admin_auth) as admin_controller:
         wallet = await get_wallet_and_assert_valid_group(
             admin_controller=admin_controller,
-            group_id=group_id,
             wallet_id=wallet_id,
+            group_id=group_id,
             logger=bound_logger,
         )
 
@@ -263,8 +263,8 @@ async def update_tenant(
     async with get_tenant_admin_controller(admin_auth) as admin_controller:
         await get_wallet_and_assert_valid_group(
             admin_controller=admin_controller,
-            group_id=group_id,
             wallet_id=wallet_id,
+            group_id=group_id,
             logger=bound_logger,
         )
 
@@ -290,8 +290,8 @@ async def get_tenant(
     async with get_tenant_admin_controller(admin_auth) as admin_controller:
         wallet = await get_wallet_and_assert_valid_group(
             admin_controller=admin_controller,
-            group_id=group_id,
             wallet_id=wallet_id,
+            group_id=group_id,
             logger=bound_logger,
         )
 

--- a/app/routes/sse.py
+++ b/app/routes/sse.py
@@ -35,7 +35,7 @@ look_back_field: float = Query(
     le=MAX_EVENT_AGE_SECONDS,
 )
 
-group_id_field: Optional[str] = Query(
+group_id_query: Optional[str] = Query(
     default=None,
     description="Group ID to which the wallet belongs",
     include_in_schema=False,
@@ -51,7 +51,7 @@ async def get_sse_subscribe_wallet(
     request: Request,
     wallet_id: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> StreamingResponse:
     """
@@ -93,7 +93,7 @@ async def get_sse_subscribe_wallet_topic(
     wallet_id: str,
     topic: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> StreamingResponse:
     """
@@ -139,7 +139,7 @@ async def get_sse_subscribe_event_with_state(
     topic: str,
     desired_state: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> StreamingResponse:
     """
@@ -192,7 +192,7 @@ async def get_sse_subscribe_stream_with_fields(
     field: str,
     field_id: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> StreamingResponse:
     """
@@ -246,7 +246,7 @@ async def get_sse_subscribe_event_with_field_and_state(
     field_id: str,
     desired_state: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> StreamingResponse:
     """

--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -8,7 +8,11 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-group_id_query = Query(default="", description="Group ID to which the wallet belongs")
+group_id_query = Query(
+    default="",
+    description="Group ID to which the wallet belongs",
+    include_in_schema=False,
+)
 
 
 @router.websocket("/v1/ws/")

--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -8,13 +8,13 @@ logger = get_logger(__name__)
 router = APIRouter()
 
 
-group_id_field = Query(default="", description="Group ID to which the wallet belongs")
+group_id_query = Query(default="", description="Group ID to which the wallet belongs")
 
 
 @router.websocket("/v1/ws/")
 async def websocket_endpoint_wallet(
     websocket: WebSocket,
-    group_id: str = group_id_field,
+    group_id: str = group_id_query,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
     logger.info("Received websocket request on group `{}`", group_id)
@@ -27,7 +27,7 @@ async def websocket_endpoint_wallet(
 async def websocket_endpoint_wallet(
     websocket: WebSocket,
     wallet_id: str,
-    group_id: str = group_id_field,
+    group_id: str = group_id_query,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
     logger.info(
@@ -44,7 +44,7 @@ async def websocket_endpoint_wallet(
 async def websocket_endpoint_topic(
     websocket: WebSocket,
     topic: str,
-    group_id: str = group_id_field,
+    group_id: str = group_id_query,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
     logger.info(
@@ -60,7 +60,7 @@ async def websocket_endpoint_wallet_topic(
     websocket: WebSocket,
     wallet_id: str,
     topic: str,
-    group_id: str = group_id_field,
+    group_id: str = group_id_query,
     auth: AcaPyAuthVerified = Depends(websocket_auth),
 ):
     logger.info(

--- a/app/services/onboarding/tenants.py
+++ b/app/services/onboarding/tenants.py
@@ -30,21 +30,11 @@ async def handle_tenant_update(
     bound_logger = logger.bind(body={"wallet_id": wallet_id})
     bound_logger.bind(body=update_request).info("Handling tenant update")
 
-    bound_logger.debug("Retrieving the wallet")
-    wallet = await handle_acapy_call(
-        logger=bound_logger,
-        acapy_call=admin_controller.multitenancy.get_wallet,
-        wallet_id=wallet_id,
-    )
-    if not wallet:
-        bound_logger.info("Bad request: Wallet not found.")
-        raise HTTPException(404, f"Wallet with id `{wallet_id}` not found.")
-
     new_roles = update_request.roles
     new_label = update_request.wallet_label
 
     # See if this wallet belongs to an actor
-    actor = await fetch_actor_by_id(wallet.wallet_id)
+    actor = await fetch_actor_by_id(wallet_id)
     if not actor and new_roles:
         bound_logger.info(
             "Bad request: Tenant not found in trust registry. "

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -466,7 +466,17 @@ async def test_get_tenants_by_wallet_name(tenant_admin_client: RichAsyncClient):
     assert_that(tenants).extracting("wallet_id").contains(wallet_id)
     assert_that(tenants).extracting("group_id").contains(group_id)
 
+    # Does not return when wallet_name = other
     response = await tenant_admin_client.get(f"{TENANTS_BASE_PATH}?wallet_name=other")
+    assert response.status_code == 200
+    tenants = response.json()
+    assert len(tenants) == 0
+    assert tenants == []
+
+    # Does not return when group_id = other
+    response = await tenant_admin_client.get(
+        f"{TENANTS_BASE_PATH}?wallet_name={wallet_name}&group_id=other"
+    )
     assert response.status_code == 200
     tenants = response.json()
     assert len(tenants) == 0

--- a/app/tests/e2e/test_tenants.py
+++ b/app/tests/e2e/test_tenants.py
@@ -17,12 +17,13 @@ TENANTS_BASE_PATH = router.prefix
 
 @pytest.mark.anyio
 async def test_get_wallet_auth_token(tenant_admin_client: RichAsyncClient):
+    group_id = "TestGroup"
     response = await tenant_admin_client.post(
         TENANTS_BASE_PATH,
         json={
             "image_url": "https://image.ca",
             "wallet_label": uuid4().hex,
-            "group_id": "TestGroup",
+            "group_id": group_id,
         },
     )
 
@@ -31,8 +32,21 @@ async def test_get_wallet_auth_token(tenant_admin_client: RichAsyncClient):
     tenant = response.json()
     wallet_id = tenant["wallet_id"]
 
+    # Attempting to access with incorrect wallet_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.get(f"{TENANTS_BASE_PATH}/bad_wallet_id/access-token")
+    assert exc.value.status_code == 404
+
+    # Attempting to access with incorrect group_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.get(
+            f"{TENANTS_BASE_PATH}/{wallet_id}/access-token?group_id=wrong_group"
+        )
+    assert exc.value.status_code == 404
+
+    # Successfully get access-token with correct group_id
     response = await tenant_admin_client.get(
-        f"{TENANTS_BASE_PATH}/{wallet_id}/access-token"
+        f"{TENANTS_BASE_PATH}/{wallet_id}/access-token?group_id={group_id}"
     )
     assert response.status_code == 200
 
@@ -306,13 +320,30 @@ async def test_update_tenant_verifier_to_issuer(
     new_image_url = "https://some-ssi-site.org/image.png"
     new_roles = ["issuer", "verifier"]
 
+    json_request = {
+        "image_url": new_image_url,
+        "wallet_label": new_wallet_label,
+        "roles": new_roles,
+    }
+    # Attempting to update with incorrect wallet_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.put(
+            f"{TENANTS_BASE_PATH}/bad_wallet_id", json=json_request
+        )
+    assert exc.value.status_code == 404
+
+    # Attempting to update with incorrect group_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.put(
+            f"{TENANTS_BASE_PATH}/{verifier_wallet_id}?group_id=wrong_group",
+            json=json_request,
+        )
+    assert exc.value.status_code == 404
+
+    # Successful update with correct group
     update_response = await tenant_admin_client.put(
-        f"{TENANTS_BASE_PATH}/{verifier_wallet_id}",
-        json={
-            "image_url": new_image_url,
-            "wallet_label": new_wallet_label,
-            "roles": new_roles,
-        },
+        f"{TENANTS_BASE_PATH}/{verifier_wallet_id}?group_id={group_id}",
+        json=json_request,
     )
     new_tenant = update_response.json()
     assert_that(new_tenant).has_wallet_id(wallet.wallet_id)
@@ -503,8 +534,21 @@ async def test_get_tenant(tenant_admin_client: RichAsyncClient):
     created_tenant = create_response.json()
     wallet_id = created_tenant["wallet_id"]
 
+    # Attempting to get with incorrect wallet_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.get(f"{TENANTS_BASE_PATH}/bad_wallet_id")
+    assert exc.value.status_code == 404
+
+    # Attempting to get with incorrect group_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.get(
+            f"{TENANTS_BASE_PATH}/{wallet_id}?group_id=wrong_group"
+        )
+    assert exc.value.status_code == 404
+
+    # Successful get with correct group_id
     get_tenant_response = await tenant_admin_client.get(
-        f"{TENANTS_BASE_PATH}/{wallet_id}"
+        f"{TENANTS_BASE_PATH}/{wallet_id}?group_id={group_id}"
     )
     assert get_tenant_response.status_code == 200
     tenant = get_tenant_response.json()
@@ -522,6 +566,7 @@ async def test_get_tenant(tenant_admin_client: RichAsyncClient):
 async def test_delete_tenant(
     tenant_admin_client: RichAsyncClient, tenant_admin_acapy_client: AcaPyClient
 ):
+    group_id = "delete_group"
     wallet_label = uuid4().hex
     response = await tenant_admin_client.post(
         TENANTS_BASE_PATH,
@@ -529,6 +574,7 @@ async def test_delete_tenant(
             "image_url": "https://image.ca",
             "wallet_label": wallet_label,
             "roles": ["verifier"],
+            "group_id": group_id,
         },
     )
 
@@ -540,7 +586,22 @@ async def test_delete_tenant(
     actor = await trust_registry.fetch_actor_by_id(wallet_id)
     assert actor
 
-    response = await tenant_admin_client.delete(f"{TENANTS_BASE_PATH}/{wallet_id}")
+    # Attempting to delete with incorrect wallet_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.delete(f"{TENANTS_BASE_PATH}/bad_wallet_id")
+    assert exc.value.status_code == 404
+
+    # Attempting to delete with incorrect group_id will fail with 404
+    with pytest.raises(HTTPException) as exc:
+        await tenant_admin_client.delete(
+            f"{TENANTS_BASE_PATH}/{wallet_id}?group_id=wrong_group"
+        )
+    assert exc.value.status_code == 404
+
+    # Successful delete with correct group_id:
+    response = await tenant_admin_client.delete(
+        f"{TENANTS_BASE_PATH}/{wallet_id}?group_id={group_id}"
+    )
     assert response.status_code == 200
 
     # Actor doesn't exist any more

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -61,16 +61,16 @@ async def get_wallet_label_from_controller(aries_controller: AcaPyClient) -> str
 
 async def get_wallet_and_assert_valid_group(
     admin_controller: AcaPyClient,
-    group_id: Optional[str],
     wallet_id: str,
+    group_id: Optional[str],
     logger: Logger,
 ) -> WalletRecordWithGroups:
     """Fetch the wallet record for wallet_id, and assert it exists and belongs to group.
 
     Args:
         admin_controller (AcaPyClient): Admin AcaPyClient instance.
-        group_id (Optional[str]): The group_id to assert against.
         wallet_id (str): The wallet_id we want to fetch.
+        group_id (Optional[str]): The group_id to assert against.
         logger (Logger): A logger object.
 
     Raises:
@@ -91,7 +91,7 @@ async def get_wallet_and_assert_valid_group(
         raise WalletNotFoundException(wallet_id=wallet_id)
 
     assert_valid_group(
-        wallet=wallet, group_id=group_id, wallet_id=wallet_id, logger=logger
+        wallet=wallet, wallet_id=wallet_id, group_id=group_id, logger=logger
     )
 
     return wallet
@@ -99,16 +99,16 @@ async def get_wallet_and_assert_valid_group(
 
 def assert_valid_group(
     wallet: WalletRecordWithGroups,
-    group_id: Optional[str],
     wallet_id: str,
+    group_id: Optional[str],
     logger: Logger,
 ) -> None:
     """Assert that wallet record belongs to group, and raise exception if not.
 
     Args:
         wallet (WalletRecordWithGroups): The wallet record to check.
-        group_id (Optional[str]): The group to validate against.
         wallet_id (str): The wallet id for the wallet record.
+        group_id (Optional[str]): The group to validate against.
         logger (Logger): A logger object.
 
     Raises:

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -9,8 +9,8 @@ from app.models.tenants import Tenant
 
 
 def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
-    label: str = wallet_record.settings["default_label"]
-    wallet_name: str = wallet_record.settings["wallet.name"]
+    label: str = wallet_record.settings.get("default_label") or ""
+    wallet_name: str = wallet_record.settings.get("wallet.name") or ""
     image_url: Optional[str] = wallet_record.settings.get("image_url")
     group_id: Optional[str] = wallet_record.settings.get("wallet.group_id")
 

--- a/app/util/tenants.py
+++ b/app/util/tenants.py
@@ -1,11 +1,23 @@
 import base64
 import json
+from logging import Logger
 from typing import Optional
 
 from aries_cloudcontroller import AcaPyClient, WalletRecordWithGroups
+from fastapi import HTTPException
 
 from app.dependencies.acapy_clients import get_tenant_admin_controller
+from app.exceptions import handle_acapy_call
 from app.models.tenants import Tenant
+
+
+class WalletNotFoundException(HTTPException):
+    """Class that represents a wallet was not found"""
+
+    def __init__(self, wallet_id: str) -> None:
+        super().__init__(
+            status_code=404, detail=f"Wallet with id `{wallet_id}` not found."
+        )
 
 
 def tenant_from_wallet_record(wallet_record: WalletRecordWithGroups) -> Tenant:
@@ -45,3 +57,67 @@ async def get_wallet_label_from_controller(aries_controller: AcaPyClient) -> str
         )
     controller_label = controller_wallet_record.settings["default_label"]
     return controller_label
+
+
+async def get_wallet_and_assert_valid_group(
+    admin_controller: AcaPyClient,
+    group_id: Optional[str],
+    wallet_id: str,
+    logger: Logger,
+) -> WalletRecordWithGroups:
+    """Fetch the wallet record for wallet_id, and assert it exists and belongs to group.
+
+    Args:
+        admin_controller (AcaPyClient): Admin AcaPyClient instance.
+        group_id (Optional[str]): The group_id to assert against.
+        wallet_id (str): The wallet_id we want to fetch.
+        logger (Logger): A logger object.
+
+    Raises:
+        HTTPException: If the wallet does not exist or does not belong to group
+
+    Returns:
+        WalletRecordWithGroups: When assertions pass, returns the wallet record.
+    """
+    logger.debug("Retrieving the wallet record for {}", wallet_id)
+    wallet = await handle_acapy_call(
+        logger=logger,
+        acapy_call=admin_controller.multitenancy.get_wallet,
+        wallet_id=wallet_id,
+    )
+
+    if not wallet:
+        logger.info("Bad request: Wallet not found.")
+        raise WalletNotFoundException(wallet_id=wallet_id)
+
+    assert_valid_group(
+        wallet=wallet, group_id=group_id, wallet_id=wallet_id, logger=logger
+    )
+
+    return wallet
+
+
+def assert_valid_group(
+    wallet: WalletRecordWithGroups,
+    group_id: Optional[str],
+    wallet_id: str,
+    logger: Logger,
+) -> None:
+    """Assert that wallet record belongs to group, and raise exception if not.
+
+    Args:
+        wallet (WalletRecordWithGroups): The wallet record to check.
+        group_id (Optional[str]): The group to validate against.
+        wallet_id (str): The wallet id for the wallet record.
+        logger (Logger): A logger object.
+
+    Raises:
+        HTTPException: If the wallet does not belong to the group_id.
+    """
+    if group_id and wallet.settings.get("wallet.group_id") != group_id:
+        logger.info("Bad request: wallet_id does not belong to group_id.")
+
+        # 404 instead of 403, obscure existence of wallet_id outside group
+        raise WalletNotFoundException(wallet_id=wallet_id)
+
+    logger.debug("Wallet {} belongs to group {}.", wallet_id, group_id)

--- a/webhooks/web/routers/sse.py
+++ b/webhooks/web/routers/sse.py
@@ -31,7 +31,7 @@ look_back_field: float = Query(
     le=MAX_EVENT_AGE_SECONDS,
 )
 
-group_id_field: Optional[str] = Query(
+group_id_query: Optional[str] = Query(
     default=None,
     description="Group ID to which the wallet belongs",
 )
@@ -65,7 +65,7 @@ async def sse_subscribe_wallet(
     background_tasks: BackgroundTasks,
     wallet_id: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     """
@@ -136,7 +136,7 @@ async def sse_subscribe_wallet_topic(
     wallet_id: str,
     topic: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     """
@@ -209,7 +209,7 @@ async def sse_subscribe_event_with_state(
     topic: str,
     desired_state: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     bound_logger = logger.bind(
@@ -287,7 +287,7 @@ async def sse_subscribe_stream_with_fields(
     field: str,
     field_id: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     bound_logger = logger.bind(
@@ -363,7 +363,7 @@ async def sse_subscribe_event_with_field_and_state(
     field_id: str,
     desired_state: str,
     look_back: float = look_back_field,
-    group_id: Optional[str] = group_id_field,
+    group_id: Optional[str] = group_id_query,
     sse_manager: SseManager = Depends(Provide[Container.sse_manager]),
 ) -> EventSourceResponse:
     bound_logger = logger.bind(


### PR DESCRIPTION
Now that we are entering the world of tenants belonging to various groups, we should enforce that tenant-admins do not have global privileges, and can only act on wallets in their group.

`group_id` is now a _hidden_ query param added to each tenant route, where we raise a 404 if the wallet attempted to be acted upon does not belong to the tenant-admin's group