### PR TITLE
📝 Update tenant-admin Swagger docs to include CloudAPI description

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -117,7 +117,7 @@ def routes_for_role(role: str) -> list:
 
 
 def cloud_api_description(role: str) -> str:
-    if role in ("governance", "tenant", "*"):
+    if role in ("governance", "tenant", "tenant-admin", "*"):
         return cloud_api_docs_description
     else:
         return default_docs_description


### PR DESCRIPTION
Our `cloud_api_docs_description` for the Swagger docs was not being printed for the tenant-admin route. This patches that