### PR TITLE
:adhesive_bandage: Invalidate proof if no associated schema_ids found

### DIFF
--- a/app/routes/websocket_endpoint.py
+++ b/app/routes/websocket_endpoint.py
@@ -16,7 +16,7 @@ group_id_query = Query(
 
 
 @router.websocket("/v1/ws/")
-async def websocket_endpoint_wallet(
+async def websocket_endpoint(
     websocket: WebSocket,
     group_id: str = group_id_query,
     auth: AcaPyAuthVerified = Depends(websocket_auth),

--- a/app/tests/services/verifier/test_verifier_utils.py
+++ b/app/tests/services/verifier/test_verifier_utils.py
@@ -547,6 +547,43 @@ async def test_assert_valid_prover_x_invalid_schemas(
 
 
 @pytest.mark.anyio
+async def test_assert_valid_prover_x_no_schemas(
+    mock_agent_controller: AcaPyClient,
+):
+    conn_record = ConnRecord(
+        connection_id=pres_exchange.connection_id, their_public_did="xxx"
+    )
+
+    verifier = mock(Verifier)
+
+    when(verifier).get_proof_record(
+        controller=mock_agent_controller, proof_id=pres_exchange.proof_id
+    ).thenReturn(to_async(pres_exchange))
+    when(mock_agent_controller.connection).get_connection(
+        conn_id=pres_exchange.connection_id
+    ).thenReturn(to_async(conn_record))
+
+    with patch(
+        "app.util.acapy_verifier_utils.get_actor", return_value=sample_actor
+    ), patch(
+        "app.util.acapy_verifier_utils.get_schema_ids",
+        return_value=[],
+    ):
+        with pytest.raises(
+            CloudApiException,
+            match="Presentation is using schemas not registered in trust registry",
+        ):
+            await assert_valid_prover(
+                aries_controller=mock_agent_controller,
+                presentation=AcceptProofRequest(
+                    proof_id=pres_exchange.proof_id,
+                    indy_presentation_spec=indy_pres_spec,
+                ),
+                verifier=verifier,
+            )
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("protocol_version", ["v1", "v2"])
 async def test_assert_valid_prover_x_no_connection_id(
     mock_agent_controller: AcaPyClient, protocol_version: str

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -122,6 +122,9 @@ async def assert_valid_prover(
             presentation=presentation.indy_presentation_spec,
         )
 
+        if not schema_ids:
+            bound_logger.warning("No schema_ids associated with proof request.")
+
         # Verify the schemas are actually in the list from TR
         if not await are_valid_schemas(schema_ids=schema_ids):
             raise CloudApiException(
@@ -197,6 +200,9 @@ async def assert_valid_verifier(
 
 
 async def are_valid_schemas(schema_ids: List[str]) -> bool:
+    if not schema_ids:
+        return False
+
     schemas_from_tr = await fetch_schemas()
     schemas_ids_from_tr = [schema["id"] for schema in schemas_from_tr]
     schemas_valid_list = [id in schemas_ids_from_tr for id in schema_ids]

--- a/trustregistry/registry/registry_schemas.py
+++ b/trustregistry/registry/registry_schemas.py
@@ -44,9 +44,9 @@ async def register_schema(
                 id=schema_id.schema_id,
             ),
         )
-    except crud.SchemaAlreadyExistsException:
+    except crud.SchemaAlreadyExistsException as e:
         bound_logger.info("Bad request: Schema already exists.")
-        raise HTTPException(status_code=405, detail="Schema already exists.")
+        raise HTTPException(status_code=405, detail="Schema already exists.") from e
 
     return create_schema_res
 
@@ -82,12 +82,12 @@ async def update_schema(
             schema=new_schema,
             schema_id=schema_id,
         )
-    except crud.SchemaDoesNotExistException:
+    except crud.SchemaDoesNotExistException as e:
         bound_logger.info("Bad request: Schema not found.")
         raise HTTPException(
             status_code=405,
             detail="Schema not found.",
-        )
+        ) from e
 
     return update_schema_res
 
@@ -98,12 +98,12 @@ async def get_schema(schema_id: str, db_session: Session = Depends(get_db)) -> S
     bound_logger.info("GET request received: Fetch schema")
     try:
         schema = crud.get_schema_by_id(db_session, schema_id=schema_id)
-    except crud.SchemaDoesNotExistException:
+    except crud.SchemaDoesNotExistException as e:
         bound_logger.info("Bad request: Schema not found.")
         raise HTTPException(
             status_code=404,
             detail=f"Schema with id {schema_id} not found.",
-        )
+        ) from e
 
     return schema
 
@@ -114,12 +114,12 @@ async def remove_schema(schema_id: str, db_session: Session = Depends(get_db)) -
     bound_logger.info("DELETE request received: Delete schema")
     try:
         crud.delete_schema(db_session, schema_id=schema_id)
-    except crud.SchemaDoesNotExistException:
+    except crud.SchemaDoesNotExistException as e:
         bound_logger.info("Bad request: Schema not found.")
         raise HTTPException(
             status_code=404,
             detail="Schema not found.",
-        )
+        ) from e
 
 
 def _get_schema_attrs(schema_id: SchemaID) -> List[str]:


### PR DESCRIPTION
Minor fix, handling the potential case that no schema_ids are found to be associated with an indy proof request. Should never happen, but now we log a warning and invalidate such cases.

Includes some minor fixes for code scanning warnings (re-raising exceptions and fix shadowed method name)