### PR TITLE
:adhesive_bandage: Fix WebSocket callback function

### DIFF
--- a/app/services/event_handling/websocket_manager.py
+++ b/app/services/event_handling/websocket_manager.py
@@ -38,10 +38,11 @@ class WebsocketManager:
         if topic:
             subscribed_topic += f":{topic}"
 
-        async def callback(data: str, _: str) -> None:
+        async def callback(data: str, topic: str) -> None:
             """
             Callback function for handling received webhook events.
             """
+            logger.debug("Handling Websocket callback on topic: {}", topic)
             await websocket.send_text(data)
 
         client = PubSubClient()


### PR DESCRIPTION
`callback` requires the keyword: topic, which was removed as it's unused in the scope of the function. Whoops :see_no_evil: