### PR TITLE
Make the latest docker tag condition more concise

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
-            type=raw,value=latest,enable=${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+            type=raw,value=latest,enable=${{ github.event.repository.default_branch == github.ref_name }}
             type=sha,prefix=pr-${{ github.event.pull_request.number }}-,priority=601,enable=${{ github.event_name == 'pull_request' }}
             type=sha,prefix={{branch}}-,priority=601,enable=${{ github.event_name == 'push' && github.ref_type == 'branch' }}
             type=ref,event=branch,priority=600


### PR DESCRIPTION
If we use `github.ref_name` then we don't need to do the string formatting