### PR TITLE
:construction_worker: Roll back sonarcloud to last working version

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,9 +30,9 @@ name: SonarCloud analysis
 
 on:
   push:
-    branches: [ "development", master ]
+    branches: ["development", "master"]
   pull_request:
-    branches: [ "development" ]
+    branches: ["development"]
   workflow_dispatch:
 
 permissions:
@@ -45,10 +45,10 @@ jobs:
     steps:
       - name: Analyze with SonarCloud
 
-        uses: SonarSource/sonarcloud-github-action@v2.1.1
+        uses: SonarSource/sonarcloud-github-action@v2.0.2
         env:
-          GITHUB_TOKEN: ${{ github.token }}  # Needed to get PR information
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}   # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
+          GITHUB_TOKEN: ${{ github.token }} # Needed to get PR information
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # Generate a token on Sonarcloud.io, add it to the secrets of this repo with the name SONAR_TOKEN (Settings > Secrets > Actions > add new repository secret)
         with:
           # Additional arguments for the sonarcloud scanner
           args:


### PR DESCRIPTION
Code-scanning in the GitHub security tools has stopped working since the upgrade to v2.1.0
Rolling back to v2.0.2 to try resolve that