### PR TITLE
✅ Remove sleeps from public did tests

### DIFF
--- a/app/tests/e2e/issuer/test_connections_use_public_did.py
+++ b/app/tests/e2e/issuer/test_connections_use_public_did.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from assertpy import assert_that
 
@@ -16,7 +14,6 @@ async def test_accept_use_public_did(
     faber_client: RichAsyncClient,  # issuer has public did
     meld_co_client: RichAsyncClient,  # also has public did
 ):
-    time.sleep(5)  # sleep to allow ledger op to register public did ...
     invite_json = CreateInvitation(use_public_did=True).model_dump()
 
     response = await faber_client.post(
@@ -61,7 +58,6 @@ async def test_accept_use_public_did_between_issuer_and_holder(
     faber_client: RichAsyncClient,  # issuer has public did
     alice_member_client: RichAsyncClient,  # no public did
 ):
-    time.sleep(10)  # sleep to allow ledger op to register public did ...
     invite_json = CreateInvitation(use_public_did=True).model_dump()
 
     response = await faber_client.post(

--- a/app/tests/e2e/test_oob.py
+++ b/app/tests/e2e/test_oob.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from aries_cloudcontroller import AcaPyClient
 from assertpy import assert_that
@@ -63,8 +61,6 @@ async def test_oob_connect_via_public_did(
     bob_member_client: RichAsyncClient,
     faber_acapy_client: AcaPyClient,
 ):
-    time.sleep(4)  # Todo replace with listener
-
     faber_public_did = await faber_acapy_client.wallet.get_public_did()
     connect_response = await bob_member_client.post(
         OOB_BASE_PATH + "/connect-public-did",

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -1,5 +1,4 @@
 import json
-import time
 
 import pytest
 from aries_cloudcontroller import (


### PR DESCRIPTION
Previously, sleeps were added to tests using public dids, because the ledger would take some time to reflect. Now the sleeps are no longer necessary