### PR TITLE
Add nats jetstream cluster for local dev with persistent storage

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -581,11 +581,63 @@ services:
       governance-multitenant-web:
         condition: service_started
 
+  nats-1:
+    image: nats:alpine
+    ports:
+      - "8222:8222"
+      - "4222:4222"
+    command: "-c /etc/nats/nats.conf --server_name nats-1"
+    volumes:
+      - nats-data-1:/nats-data
+      - ./resources/nats-local.conf:/etc/nats/nats.conf
+    networks:
+      - nats
+    labels:
+      app: nats
+      tier: infra
+    healthcheck:
+      test: ["CMD-SHELL", 'wget -qO- localhost:8222/healthz | grep ''"status":"ok"'' || exit 1']
+      start_period: 30s
+      interval: 10s
+      timeout: 10s
+      retries: 5
+  nats-2:
+    image: nats
+    command: "-c /etc/nats/nats.conf --server_name nats-2"
+    volumes:
+      - nats-data-2:/nats-data
+      - ./resources/nats-local.conf:/etc/nats/nats.conf
+    networks:
+      - nats
+    depends_on:
+      nats-1:
+        condition: service_started
+    labels:
+      app: nats
+      tier: infra
+  nats-3:
+    image: nats
+    command: "-c /etc/nats/nats.conf --server_name nats-3"
+    volumes:
+      - nats-data-3:/nats-data
+      - ./resources/nats-local.conf:/etc/nats/nats.conf
+    networks:
+      - nats
+    depends_on:
+      nats-1:
+        condition: service_started
+    labels:
+      app: nats
+      tier: infra
+
 volumes:
   webserver-cli:
   webserver-ledger:
   nodes-data:
   data:
+  nats-data-1:
+  nats-data-2:
+  nats-data-3:
 
 networks:
   governance-multitenant:
@@ -599,3 +651,4 @@ networks:
       config:
         - subnet: 172.29.0.0/24
           gateway: 172.29.0.1
+  nats:

--- a/resources/nats-local.conf
+++ b/resources/nats-local.conf
@@ -1,0 +1,17 @@
+http_port: 8222
+jetstream {
+    store_dir: "/nats-data"
+}
+cluster {
+  name: cloud-api
+  listen: 0.0.0.0:6222
+  routes: [
+    nats://ruser:T0pS3cr3t@nats-1:6222,
+    nats://ruser:T0pS3cr3t@nats-2:6222,
+    nats://ruser:T0pS3cr3t@nats-3:6222
+  ]
+  authorization {
+      user: ruser // Public default user used in official docker container
+      password: T0pS3cr3t // Public default password used in official docker container
+  }
+}


### PR DESCRIPTION
➕ Adds [NATS Jetstream](https://docs.nats.io/nats-concepts/jetstream) cluster to docker compose for local dev to support durable event streaming