### PR TITLE
Test trust registry endpoints

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -294,7 +294,7 @@ jobs:
           coverage combine
           coverage report
       - name: Generate XML coverage report
-        run: coverage xml --omit="*/test_*,*/tests/*"
+        run: coverage xml
       - name: Upload coverage to Codacy
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml
         env:

--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -294,7 +294,7 @@ jobs:
           coverage combine
           coverage report
       - name: Generate XML coverage report
-        run: coverage xml
+        run: coverage xml --omit="*/test_*,*/tests/*"
       - name: Upload coverage to Codacy
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml
         env:

--- a/trustregistry/tests/test_registry_actors.py
+++ b/trustregistry/tests/test_registry_actors.py
@@ -30,13 +30,13 @@ async def test_register_actor():
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "exeption, status_code", [(ActorAlreadyExistsException, 409), (Exception, 500)]
+    "exception, status_code", [(ActorAlreadyExistsException, 409), (Exception, 500)]
 )
-async def test_register_actor_x(exeption, status_code):
+async def test_register_actor_x(exception, status_code):
 
     with patch("trustregistry.registry.registry_actors.crud.create_actor") as mock_crud:
         actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
-        mock_crud.side_effect = exeption()
+        mock_crud.side_effect = exception()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.register_actor(actor)
 

--- a/trustregistry/tests/test_registry_actors.py
+++ b/trustregistry/tests/test_registry_actors.py
@@ -156,7 +156,7 @@ async def test_delete_actor():
         mock_crud.return_value = None
         result = await registry_actors.remove_actor("1")
         mock_crud.assert_called_once()
-        assert result == None
+        assert result is None
 
 
 @pytest.mark.anyio

--- a/trustregistry/tests/test_registry_actors.py
+++ b/trustregistry/tests/test_registry_actors.py
@@ -102,7 +102,7 @@ async def test_get_actor_by_did_x():
         mock_crud.side_effect = ActorDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.get_actor_by_did("did:sov:1234")
-        
+
         mock_crud.assert_called_once()
         assert ex.value.status_code == 404
 

--- a/trustregistry/tests/test_registry_actors.py
+++ b/trustregistry/tests/test_registry_actors.py
@@ -39,8 +39,9 @@ async def test_register_actor_x(exeption, status_code):
         mock_crud.side_effect = exeption()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.register_actor(actor)
-            mock_crud.assert_called_once()
-            assert ex.status_code == status_code
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == status_code
 
 
 @pytest.mark.anyio
@@ -59,8 +60,10 @@ async def test_update_actor(actor_id, actor):
         if actor_id != actor.id:
             with pytest.raises(HTTPException) as ex:
                 await registry_actors.update_actor(actor_id, actor)
-                mock_crud.assert_not_called()
-                assert ex.status_code == 400
+
+            mock_crud.assert_not_called()
+            assert ex.value.status_code == 400
+
         else:
             result = await registry_actors.update_actor(actor_id, actor)
             mock_crud.assert_called_once()
@@ -74,8 +77,9 @@ async def test_update_actor_x():
         mock_crud.side_effect = ActorDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.update_actor("1", actor)
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404
 
 
 @pytest.mark.anyio
@@ -98,8 +102,9 @@ async def test_get_actor_by_did_x():
         mock_crud.side_effect = ActorDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.get_actor_by_did("did:sov:1234")
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+        
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404
 
 
 @pytest.mark.anyio
@@ -122,8 +127,9 @@ async def test_get_actor_by_id_x():
         mock_crud.side_effect = ActorDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.get_actor_by_id("1")
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404
 
 
 @pytest.mark.anyio
@@ -146,8 +152,9 @@ async def test_get_actor_by_name_x():
         mock_crud.side_effect = ActorDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.get_actor_by_name("Alice")
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404
 
 
 @pytest.mark.anyio
@@ -165,5 +172,6 @@ async def test_delete_actor_x():
         mock_crud.side_effect = ActorDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_actors.remove_actor("1")
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404

--- a/trustregistry/tests/test_registry_actors.py
+++ b/trustregistry/tests/test_registry_actors.py
@@ -1,0 +1,169 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.exceptions import HTTPException
+
+from shared.models.trustregistry import Actor
+from trustregistry.crud import ActorAlreadyExistsException, ActorDoesNotExistException
+from trustregistry.registry import registry_actors
+
+
+@pytest.mark.anyio
+async def test_get_actors():
+    with patch("trustregistry.registry.registry_actors.crud.get_actors") as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.return_value = [actor]
+        result = await registry_actors.get_actors()
+        mock_crud.assert_called_once()
+        assert result == [actor]
+
+
+@pytest.mark.anyio
+async def test_register_actor():
+    with patch("trustregistry.registry.registry_actors.crud.create_actor") as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.return_value = actor
+        result = await registry_actors.register_actor(actor)
+        mock_crud.assert_called_once()
+        assert result == actor
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "exeption, status_code", [(ActorAlreadyExistsException, 409), (Exception, 500)]
+)
+async def test_register_actor_x(exeption, status_code):
+
+    with patch("trustregistry.registry.registry_actors.crud.create_actor") as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.side_effect = exeption()
+        with pytest.raises(HTTPException) as ex:
+            await registry_actors.register_actor(actor)
+            mock_crud.assert_called_once()
+            assert ex.status_code == status_code
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "actor_id, actor",
+    [
+        ("1", Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")),
+        ("2", Actor(id="1", name="Bob", roles=["role"], did="did:sov:5678")),
+    ],
+)
+async def test_update_actor(actor_id, actor):
+    with patch("trustregistry.registry.registry_actors.crud.update_actor") as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.return_value = actor
+
+        if actor_id != actor.id:
+            with pytest.raises(HTTPException) as ex:
+                await registry_actors.update_actor(actor_id, actor)
+                mock_crud.assert_not_called()
+                assert ex.status_code == 400
+        else:
+            result = await registry_actors.update_actor(actor_id, actor)
+            mock_crud.assert_called_once()
+            assert result == actor
+
+
+@pytest.mark.anyio
+async def test_update_actor_x():
+    with patch("trustregistry.registry.registry_actors.crud.update_actor") as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.side_effect = ActorDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_actors.update_actor("1", actor)
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_actor_by_did():
+    with patch(
+        "trustregistry.registry.registry_actors.crud.get_actor_by_did"
+    ) as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.return_value = actor
+        result = await registry_actors.get_actor_by_did("did:sov:1234")
+        mock_crud.assert_called_once()
+        assert result == actor
+
+
+@pytest.mark.anyio
+async def test_get_actor_by_did_x():
+    with patch(
+        "trustregistry.registry.registry_actors.crud.get_actor_by_did"
+    ) as mock_crud:
+        mock_crud.side_effect = ActorDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_actors.get_actor_by_did("did:sov:1234")
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_actor_by_id():
+    with patch(
+        "trustregistry.registry.registry_actors.crud.get_actor_by_id"
+    ) as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.return_value = actor
+        result = await registry_actors.get_actor_by_id("1")
+        mock_crud.assert_called_once()
+        assert result == actor
+
+
+@pytest.mark.anyio
+async def test_get_actor_by_id_x():
+    with patch(
+        "trustregistry.registry.registry_actors.crud.get_actor_by_id"
+    ) as mock_crud:
+        mock_crud.side_effect = ActorDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_actors.get_actor_by_id("1")
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_actor_by_name():
+    with patch(
+        "trustregistry.registry.registry_actors.crud.get_actor_by_name"
+    ) as mock_crud:
+        actor = Actor(id="1", name="Alice", roles=["role"], did="did:sov:1234")
+        mock_crud.return_value = actor
+        result = await registry_actors.get_actor_by_name("Alice")
+        mock_crud.assert_called_once()
+        assert result == actor
+
+
+@pytest.mark.anyio
+async def test_get_actor_by_name_x():
+    with patch(
+        "trustregistry.registry.registry_actors.crud.get_actor_by_name"
+    ) as mock_crud:
+        mock_crud.side_effect = ActorDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_actors.get_actor_by_name("Alice")
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_delete_actor():
+    with patch("trustregistry.registry.registry_actors.crud.delete_actor") as mock_crud:
+        mock_crud.return_value = None
+        result = await registry_actors.remove_actor("1")
+        mock_crud.assert_called_once()
+        assert result == None
+
+
+@pytest.mark.anyio
+async def test_delete_actor_x():
+    with patch("trustregistry.registry.registry_actors.crud.delete_actor") as mock_crud:
+        mock_crud.side_effect = ActorDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_actors.remove_actor("1")
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404

--- a/trustregistry/tests/test_registry_schema.py
+++ b/trustregistry/tests/test_registry_schema.py
@@ -164,7 +164,7 @@ async def test_remove_schema():
             "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
         )
         mock_crud.assert_called_once()
-        result is None
+        assert result is None
 
 
 @pytest.mark.anyio

--- a/trustregistry/tests/test_registry_schema.py
+++ b/trustregistry/tests/test_registry_schema.py
@@ -160,8 +160,11 @@ async def test_remove_schema():
             id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
         )
         mock_crud.return_value = schema
-        await registry_schemas.remove_schema("WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0")
+        result = await registry_schemas.remove_schema(
+            "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+        )
         mock_crud.assert_called_once()
+        result is None
 
 
 @pytest.mark.anyio

--- a/trustregistry/tests/test_registry_schema.py
+++ b/trustregistry/tests/test_registry_schema.py
@@ -1,0 +1,178 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi.exceptions import HTTPException
+
+from shared.models.trustregistry import Schema
+from trustregistry.crud import SchemaAlreadyExistsException, SchemaDoesNotExistException
+from trustregistry.registry import registry_schemas
+
+
+@pytest.mark.anyio
+async def test_get_schemas():
+    with patch("trustregistry.registry.registry_schemas.crud.get_schemas") as mock_crud:
+        schema = Schema(
+            did="WgWxqztrNooG92RXvxSTWv",
+            name="schema_name",
+            version="1.0",
+            id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+        )
+        mock_crud.return_value = [schema]
+        result = await registry_schemas.get_schemas()
+        mock_crud.assert_called_once()
+        assert result == [schema]
+
+
+@pytest.mark.anyio
+async def test_register_schema():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.create_schema"
+    ) as mock_crud:
+        schema_id = registry_schemas.SchemaID(
+            schema_id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+        )
+        schema = Schema(
+            did="WgWxqztrNooG92RXvxSTWv",
+            name="schema_name",
+            version="1.0",
+            id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+        )
+        mock_crud.return_value = schema
+
+        result = await registry_schemas.register_schema(schema_id)
+        mock_crud.assert_called_once()
+        assert result == schema
+
+
+@pytest.mark.anyio
+async def test_register_schema_x():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.create_schema"
+    ) as mock_crud:
+        schema_id = registry_schemas.SchemaID(
+            schema_id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+        )
+        mock_crud.side_effect = SchemaAlreadyExistsException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_schemas.register_schema(schema_id)
+            mock_crud.assert_called_once()
+            assert ex.status_code == 405
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "schema_id, new_schema_id",
+    [
+        (
+            "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+            registry_schemas.SchemaID(
+                schema_id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.1"
+            ),
+        ),
+        (
+            "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.1",
+            registry_schemas.SchemaID(
+                schema_id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.1"
+            ),
+        ),
+    ],
+)
+async def test_update_schema(schema_id, new_schema_id):
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.update_schema"
+    ) as mock_crud:
+        schema = Schema(
+            did="WgWxqztrNooG92RXvxSTWv",
+            name="schema_name",
+            version="1.0",
+            id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+        )
+        if schema_id == new_schema_id.schema_id:
+            with pytest.raises(HTTPException) as ex:
+                await registry_schemas.update_schema(schema_id, new_schema_id)
+                mock_crud.assert_not_called()
+                assert ex.status_code == 400
+        else:
+            mock_crud.return_value = schema
+            result = await registry_schemas.update_schema(schema_id, new_schema_id)
+            mock_crud.assert_called_once()
+            assert result == schema
+
+
+@pytest.mark.anyio
+async def test_update_schema_x():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.update_schema"
+    ) as mock_crud:
+        schema_id = "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+        new_schema_id = registry_schemas.SchemaID(
+            schema_id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.1"
+        )
+        mock_crud.side_effect = SchemaDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_schemas.update_schema(schema_id, new_schema_id)
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_schema_by_id():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.get_schema_by_id"
+    ) as mock_crud:
+        schema = Schema(
+            did="WgWxqztrNooG92RXvxSTWv",
+            name="schema_name",
+            version="1.0",
+            id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+        )
+        mock_crud.return_value = schema
+        result = await registry_schemas.get_schema(
+            "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+        )
+        mock_crud.assert_called_once()
+        assert result == schema
+
+
+@pytest.mark.anyio
+async def test_get_schema_by_id_x():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.get_schema_by_id"
+    ) as mock_crud:
+        mock_crud.side_effect = SchemaDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_schemas.get_schema(
+                "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+            )
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_remove_schema():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.delete_schema"
+    ) as mock_crud:
+        schema = Schema(
+            did="WgWxqztrNooG92RXvxSTWv",
+            name="schema_name",
+            version="1.0",
+            id="WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0",
+        )
+        mock_crud.return_value = schema
+        await registry_schemas.remove_schema("WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0")
+        mock_crud.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_remove_schema_x():
+    with patch(
+        "trustregistry.registry.registry_schemas.crud.delete_schema"
+    ) as mock_crud:
+        mock_crud.side_effect = SchemaDoesNotExistException()
+        with pytest.raises(HTTPException) as ex:
+            await registry_schemas.remove_schema(
+                "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
+            )
+            mock_crud.assert_called_once()
+            assert ex.status_code == 404

--- a/trustregistry/tests/test_registry_schema.py
+++ b/trustregistry/tests/test_registry_schema.py
@@ -55,8 +55,9 @@ async def test_register_schema_x():
         mock_crud.side_effect = SchemaAlreadyExistsException()
         with pytest.raises(HTTPException) as ex:
             await registry_schemas.register_schema(schema_id)
-            mock_crud.assert_called_once()
-            assert ex.status_code == 405
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 405
 
 
 @pytest.mark.anyio
@@ -90,8 +91,9 @@ async def test_update_schema(schema_id, new_schema_id):
         if schema_id == new_schema_id.schema_id:
             with pytest.raises(HTTPException) as ex:
                 await registry_schemas.update_schema(schema_id, new_schema_id)
-                mock_crud.assert_not_called()
-                assert ex.status_code == 400
+
+            mock_crud.assert_not_called()
+            assert ex.value.status_code == 400
         else:
             mock_crud.return_value = schema
             result = await registry_schemas.update_schema(schema_id, new_schema_id)
@@ -111,8 +113,9 @@ async def test_update_schema_x():
         mock_crud.side_effect = SchemaDoesNotExistException()
         with pytest.raises(HTTPException) as ex:
             await registry_schemas.update_schema(schema_id, new_schema_id)
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 405
 
 
 @pytest.mark.anyio
@@ -144,8 +147,9 @@ async def test_get_schema_by_id_x():
             await registry_schemas.get_schema(
                 "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
             )
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404
 
 
 @pytest.mark.anyio
@@ -177,5 +181,6 @@ async def test_remove_schema_x():
             await registry_schemas.remove_schema(
                 "WgWxqztrNooG92RXvxSTWv:2:schema_name:1.0"
             )
-            mock_crud.assert_called_once()
-            assert ex.status_code == 404
+
+        mock_crud.assert_called_once()
+        assert ex.value.status_code == 404


### PR DESCRIPTION
Add unit tests for trust registry endpoints

One line in `trustregistry/registry/registry_actors.py`  (line 54) that I am not able to test. Looks like pydantic wont allow to happen