### PR TITLE
:construction: Upgrade to latest cloudcontroller (openapi v7.5.0)

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 aiohttp~=3.9.2
-aries-cloudcontroller==0.11.0.post4
+git+https://github.com/didx-xyz/aries-cloudcontroller-python@64df6e06d065814bc766394e85bfef9f63628f28
 base58~=2.1.1
 fastapi~=0.110.0
 fastapi_websocket_pubsub~=0.3.8

--- a/dockerfiles/endorser/Dockerfile
+++ b/dockerfiles/endorser/Dockerfile
@@ -5,6 +5,9 @@ COPY shared /shared
 
 WORKDIR /endorser
 
+RUN apt-get -y update
+RUN apt-get -y install git
+
 RUN pip install --no-cache-dir -r requirements.txt -r requirements.dev.txt --upgrade
 
 EXPOSE 3009

--- a/dockerfiles/fastapi/Dockerfile
+++ b/dockerfiles/fastapi/Dockerfile
@@ -5,6 +5,9 @@ COPY shared /shared
 
 WORKDIR /app
 
+RUN apt-get -y update
+RUN apt-get -y install git
+
 RUN pip install --no-cache-dir -r requirements.txt --upgrade
 
 EXPOSE 8000

--- a/dockerfiles/tests/Dockerfile
+++ b/dockerfiles/tests/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.12-slim
 
 WORKDIR /tests
 
+RUN apt-get -y update
+RUN apt-get -y install git
+
 COPY requirements.dev.txt .
 COPY requirements.txt .
 COPY app/requirements.txt app/

--- a/dockerfiles/trustregistry/Dockerfile
+++ b/dockerfiles/trustregistry/Dockerfile
@@ -5,6 +5,9 @@ COPY shared /shared
 
 WORKDIR /trustregistry
 
+RUN apt-get -y update
+RUN apt-get -y install git
+
 RUN pip install --no-cache-dir -r requirements.txt --upgrade
 
 EXPOSE 8001

--- a/dockerfiles/webhooks/Dockerfile
+++ b/dockerfiles/webhooks/Dockerfile
@@ -5,6 +5,9 @@ COPY shared /shared
 
 WORKDIR /webhooks
 
+RUN apt-get -y update
+RUN apt-get -y install git
+
 RUN pip install --no-cache-dir -r requirements.txt --upgrade
 
 EXPOSE 3010

--- a/endorser/requirements.txt
+++ b/endorser/requirements.txt
@@ -1,4 +1,4 @@
-aries-cloudcontroller==0.11.0.post4
+git+https://github.com/didx-xyz/aries-cloudcontroller-python@64df6e06d065814bc766394e85bfef9f63628f28
 dependency-injector-fork~=4.42.1  # https://github.com/ets-labs/python-dependency-injector/pull/765#issuecomment-1915100744
 httpx~=0.27.0
 fastapi~=0.110.0

--- a/webhooks/requirements.txt
+++ b/webhooks/requirements.txt
@@ -1,4 +1,4 @@
-aries-cloudcontroller==0.11.0.post4
+git+https://github.com/didx-xyz/aries-cloudcontroller-python@64df6e06d065814bc766394e85bfef9f63628f28
 dependency-injector-fork~=4.42.1  # https://github.com/ets-labs/python-dependency-injector/pull/765#issuecomment-1915100744
 fastapi~=0.110.0
 fastapi_websocket_pubsub~=0.3.8


### PR DESCRIPTION
Tests the latest upgrade to cloudcontroller -- regenerated using openapi-generator v7.5.0: https://github.com/didx-xyz/aries-cloudcontroller-python/pull/168