### PR TITLE
:bug: fix ValidationError exception handling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routes.wallet import dids as wallet_dids
 from app.routes.wallet import jws as wallet_jws
 from app.routes.wallet import sd_jws as wallet_sd_jws
 from app.services.event_handling.websocket_manager import WebsocketManager
+from app.util.extract_validation_error import extract_validation_error_msg
 from shared.exceptions import CloudApiValueError
 from shared.log_config import get_logger
 
@@ -172,7 +173,7 @@ async def universal_exception_handler(_: Request, exception: Exception) -> JSONR
 
     if isinstance(exception, pydantic.ValidationError):
         return JSONResponse(
-            {"detail": exception.errors(), **stacktrace},
+            {"detail": extract_validation_error_msg(exception), **stacktrace},
             status_code=422,
         )
 


### PR DESCRIPTION
Pydantic validation errors may not be serializable, causing a 500 to be raised when attempting to handle a 422. This PR extracts the error message from the pydantic validation error as a string, resolve that.