### PR TITLE
:sparkles: strip protocol prefix from cred ex id in revocation service

### DIFF
--- a/app/util/credentials.py
+++ b/app/util/credentials.py
@@ -12,6 +12,9 @@ def cred_id_no_version(credential_id: str) -> str:
 
 
 def strip_protocol_prefix(id: str):
+    if id is None:
+        return None
+
     if id.startswith("v1-") or id.startswith("v2-"):
         return id[3:]
     else:


### PR DESCRIPTION
Allows our enriched cred_ex_ids (with v1 / v2 prefix) to be passed to revocation service without raising bad requests