### PR TITLE
🎨 update revoke credential request body and ✅ add tests with auto-publish true

### DIFF
--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -65,7 +65,6 @@ class CreateOffer(CredentialWithProtocol):
 
 class RevokeCredential(BaseModel):
     credential_exchange_id: str
-    credential_definition_id: Optional[str] = None
     auto_publish_on_ledger: Optional[bool] = False
 
 

--- a/app/models/issuer.py
+++ b/app/models/issuer.py
@@ -65,7 +65,7 @@ class CreateOffer(CredentialWithProtocol):
 
 class RevokeCredential(BaseModel):
     credential_exchange_id: str
-    auto_publish_on_ledger: Optional[bool] = False
+    auto_publish_on_ledger: bool = False
 
 
 class PublishRevocationsRequest(BaseModel):

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -308,7 +308,8 @@ async def revoke_credential(
     -----------
         body: RevokeCredential
             - credential_exchange_id (str): The ID associated with the credential exchange that should be revoked.
-            - auto_publish_on_ledger (bool): (True) publish revocation to ledger immediately, or (default, False) mark it pending
+            - auto_publish_on_ledger (bool): (True) publish revocation to ledger immediately, or
+                (default, False) mark it pending
 
 
     Returns:

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -306,8 +306,10 @@ async def revoke_credential(
 
     Parameters:
     -----------
-        credential_exchange_id: str
-            The credential exchange id
+        body: RevokeCredential
+            - credential_exchange_id (str): The ID associated with the credential exchange that should be revoked.
+            - auto_publish_on_ledger (bool): (True) publish revocation to ledger immediately, or (default, False) mark it pending
+
 
     Returns:
     --------

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -322,7 +322,6 @@ async def revoke_credential(
         await revocation_registry.revoke_credential(
             controller=aries_controller,
             credential_exchange_id=body.credential_exchange_id,
-            credential_definition_id=body.credential_definition_id,
             auto_publish_to_ledger=body.auto_publish_on_ledger,
         )
 

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -77,10 +77,7 @@ async def revoke_credential(
     Args:
         controller (AcaPyClient): aca-py client
         credential_exchange_id (str): The credential exchange ID.
-        credential_definition_id (str): The credential definition ID.
-        auto_publish_to_ledger (bool): Whether to directly publish the revocation to the ledger.
-            This should only be true when invoked by an endorser.
-            Default is False
+        auto_publish_to_ledger (bool): (True) publish revocation to ledger immediately, or (default, False) mark it pending
 
     Raises:
         Exception: When the credential could not be revoked

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -69,7 +69,6 @@ async def get_active_revocation_registry_for_credential(
 async def revoke_credential(
     controller: AcaPyClient,
     credential_exchange_id: str,
-    credential_definition_id: str = None,
     auto_publish_to_ledger: bool = False,
 ) -> None:
     """
@@ -92,7 +91,6 @@ async def revoke_credential(
     bound_logger = logger.bind(
         body={
             "credential_exchange_id": credential_exchange_id,
-            "credential_definition_id": credential_definition_id,
             "auto_publish_to_ledger": auto_publish_to_ledger,
         }
     )

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -57,7 +57,8 @@ async def get_active_revocation_registry_for_credential(
             result,
         )
         raise CloudApiException(
-            f"Error retrieving revocation registry for credential with ID `{credential_definition_id}`."
+            "Error retrieving revocation registry for credential with ID "
+            f"`{credential_definition_id}`."
         )
 
     bound_logger.info(
@@ -77,7 +78,8 @@ async def revoke_credential(
     Args:
         controller (AcaPyClient): aca-py client
         credential_exchange_id (str): The credential exchange ID.
-        auto_publish_to_ledger (bool): (True) publish revocation to ledger immediately, or (default, False) mark it pending
+        auto_publish_to_ledger (bool): (True) publish revocation to ledger immediately,
+            or (default, False) mark it pending
 
     Raises:
         Exception: When the credential could not be revoked
@@ -246,7 +248,8 @@ async def get_credential_revocation_record(
             "Unexpected type returned from get_revocation_status: `{}`.", result
         )
         raise CloudApiException(
-            f"Error retrieving revocation status for credential exchange ID `{credential_exchange_id}`."
+            "Error retrieving revocation status for credential exchange ID "
+            f"`{credential_exchange_id}`."
         )
 
     result = result.result
@@ -281,8 +284,7 @@ async def get_credential_definition_id_from_exchange_id(
         credential_definition_id = cred_ex_record.credential_definition_id
     except CloudApiException as err1:
         bound_logger.info(
-            "An Exception was caught while getting v1 record. The error message is: '{}'",
-            err1.detail,
+            "An Exception was caught while getting v1 record: '{}'", err1.detail
         )
         try:
             bound_logger.info("Trying to get v2 records")
@@ -298,20 +300,20 @@ async def get_credential_definition_id_from_exchange_id(
                 [
                     rev_reg_parts[2],
                     "3",
-                    "CL",  # NOTE: Potentially replace this with other possible signature type in future
+                    "CL",  # NOTE: update this with other signature types in future
                     rev_reg_parts[-4],
                     rev_reg_parts[-1],
                 ]
             )
         except CloudApiException as err2:
             bound_logger.info(
-                "An Exception was caught while getting v2 record. The error message is: '{}'",
+                "An Exception was caught while getting v2 record: '{}'",
                 err2.detail,
             )
             return
         except Exception:
             bound_logger.exception(
-                "Exception caught while constructing credential_definition_id from record."
+                "Exception caught while constructing cred def id from record."
             )
             return
 
@@ -351,19 +353,25 @@ async def validate_rev_reg_ids(
                 rev_reg_id=rev_reg_id,
             )
             if rev_reg_result.result is None:
-                message = f"Bad request: Failed to retrieve revocation registry '{rev_reg_id}'."
+                message = (
+                    "Bad request: Failed to retrieve revocation registry "
+                    f"'{rev_reg_id}'."
+                )
                 bound_logger.info(message)
                 raise CloudApiException(message, status_code=404)
 
             pending_pub = rev_reg_result.result.pending_pub
 
             if pending_pub is None:
-                message = f"Bad request: No pending publications found for revocation registry '{rev_reg_id}'."
+                message = (
+                    "Bad request: No pending publications found for "
+                    f"revocation registry '{rev_reg_id}'."
+                )
                 bound_logger.info(message)
                 raise CloudApiException(message, status_code=404)
 
             bound_logger.debug(
-                "Got the following pending publications for revocation registry '{}': {}",
+                "Got the following pending publications for rev registry '{}': {}",
                 rev_reg_id,
                 pending_pub,
             )
@@ -384,11 +392,14 @@ async def validate_rev_reg_ids(
                 raise CloudApiException(message, e.status_code) from e
             else:
                 bound_logger.error(
-                    "An Exception was caught while validating rev_reg_id. The error message is: '{}'.",
+                    "An Exception was caught while validating rev_reg_id: '{}'.",
                     e.detail,
                 )
                 raise CloudApiException(
-                    f"An error occurred while validating requested revocation registry credential map: '{e.detail}'.",
+                    (
+                        "An error occurred while validating requested "
+                        f"revocation registry credential map: '{e.detail}'."
+                    ),
                     e.status_code,
                 ) from e
 

--- a/app/tests/e2e/conftest.py
+++ b/app/tests/e2e/conftest.py
@@ -14,10 +14,11 @@ from app.services.trust_registry.actors import (
 )
 from app.tests.fixtures.credentials import (
     get_or_issue_regression_cred_revoked,
-    issue_alice_creds_and_revoke_published,
-    issue_alice_creds_and_revoke_unpublished,
+    issue_alice_creds,
     issue_credential_to_alice,
     meld_co_issue_credential_to_alice,
+    revoke_alice_creds,
+    revoke_alice_creds_and_publish,
 )
 from app.tests.fixtures.definitions import (
     credential_definition_id,

--- a/app/tests/e2e/test_revocation.py
+++ b/app/tests/e2e/test_revocation.py
@@ -20,11 +20,9 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 )
 async def test_clear_pending_revokes(
     faber_client: RichAsyncClient,
-    issue_alice_creds_and_revoke_unpublished: List[CredentialExchange],
+    revoke_alice_creds: List[CredentialExchange],
 ):
-    faber_cred_ex_id = issue_alice_creds_and_revoke_unpublished[
-        0
-    ].credential_exchange_id
+    faber_cred_ex_id = revoke_alice_creds[0].credential_exchange_id
     revocation_record_response = await faber_client.get(
         f"{CREDENTIALS_BASE_PATH}/revocation/record"
         + "?credential_exchange_id="
@@ -54,7 +52,7 @@ async def test_clear_pending_revokes(
 
     assert revocation_registry_credential_map == {}
 
-    for cred in issue_alice_creds_and_revoke_unpublished:
+    for cred in revoke_alice_creds:
         rev_record = (
             await faber_client.get(
                 f"{CREDENTIALS_BASE_PATH}/revocation/record"
@@ -77,7 +75,7 @@ async def test_clear_pending_revokes(
 @pytest.mark.anyio
 async def test_clear_pending_revokes_no_map(
     faber_client: RichAsyncClient,
-    issue_alice_creds_and_revoke_unpublished: List[CredentialExchange],
+    revoke_alice_creds: List[CredentialExchange],
 ):
     clear_revoke_response = (
         await faber_client.post(
@@ -88,7 +86,7 @@ async def test_clear_pending_revokes_no_map(
 
     assert clear_revoke_response == {}
 
-    for cred in issue_alice_creds_and_revoke_unpublished:
+    for cred in revoke_alice_creds:
         rev_record = (
             await faber_client.get(
                 f"{CREDENTIALS_BASE_PATH}/revocation/record"
@@ -136,11 +134,9 @@ async def test_clear_pending_revokes_bad_payload(
 @pytest.mark.anyio
 async def test_publish_all_revocations_for_rev_reg_id(
     faber_client: RichAsyncClient,
-    issue_alice_creds_and_revoke_unpublished: List[CredentialExchange],
+    revoke_alice_creds: List[CredentialExchange],
 ):
-    faber_cred_ex_id = issue_alice_creds_and_revoke_unpublished[
-        0
-    ].credential_exchange_id
+    faber_cred_ex_id = revoke_alice_creds[0].credential_exchange_id
     response = (
         await faber_client.get(
             f"{CREDENTIALS_BASE_PATH}/revocation/record"
@@ -156,7 +152,7 @@ async def test_publish_all_revocations_for_rev_reg_id(
         json={"revocation_registry_credential_map": {rev_reg_id: []}},
     )
 
-    for cred in issue_alice_creds_and_revoke_unpublished:
+    for cred in revoke_alice_creds:
         rev_record = (
             await faber_client.get(
                 f"{CREDENTIALS_BASE_PATH}/revocation/record"
@@ -171,14 +167,14 @@ async def test_publish_all_revocations_for_rev_reg_id(
 @pytest.mark.anyio
 async def test_publish_all_revocations_no_payload(
     faber_client: RichAsyncClient,
-    issue_alice_creds_and_revoke_unpublished: List[CredentialExchange],
+    revoke_alice_creds: List[CredentialExchange],
 ):
     await faber_client.post(
         f"{CREDENTIALS_BASE_PATH}/publish-revocations",
         json={"revocation_registry_credential_map": {}},
     )
 
-    for cred in issue_alice_creds_and_revoke_unpublished:
+    for cred in revoke_alice_creds:
         rev_record = (
             await faber_client.get(
                 f"{CREDENTIALS_BASE_PATH}/revocation/record"
@@ -193,11 +189,9 @@ async def test_publish_all_revocations_no_payload(
 @pytest.mark.anyio
 async def test_publish_one_revocation(
     faber_client: RichAsyncClient,
-    issue_alice_creds_and_revoke_unpublished: List[CredentialExchange],
+    revoke_alice_creds: List[CredentialExchange],
 ):
-    faber_cred_ex_id = issue_alice_creds_and_revoke_unpublished[
-        0
-    ].credential_exchange_id
+    faber_cred_ex_id = revoke_alice_creds[0].credential_exchange_id
     response = (
         await faber_client.get(
             f"{CREDENTIALS_BASE_PATH}/revocation/record"
@@ -213,7 +207,7 @@ async def test_publish_one_revocation(
         json={"revocation_registry_credential_map": {rev_reg_id: [cred_rev_id]}},
     )
 
-    for cred in issue_alice_creds_and_revoke_unpublished:
+    for cred in revoke_alice_creds:
         rev_record = (
             await faber_client.get(
                 f"{CREDENTIALS_BASE_PATH}/revocation/record"

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -18,13 +18,16 @@ VERIFIER_BASE_PATH = verifier_router.prefix
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "revoke_alice_creds_and_publish", ["auto_publish_true", "default"], indirect=True
+)
 @pytest.mark.parametrize("protocol_version", ["v1", "v2"])
 @pytest.mark.skipif(
     TestMode.regression_run in TestMode.fixture_params,
     reason="Proving revoked credentials is currently non-deterministic",
 )
 async def test_proof_revoked_credential(
-    issue_alice_creds_and_revoke_published: List[  # pylint: disable=unused-argument
+    revoke_alice_creds_and_publish: List[  # pylint: disable=unused-argument
         CredentialExchange
     ],
     credential_definition_id_revocable: str,

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -122,7 +122,7 @@ async def meld_co_issue_credential_to_alice(
 
 
 @pytest.fixture(scope="function")
-async def issue_alice_creds_and_revoke_unpublished(
+async def issue_alice_creds(
     faber_client: RichAsyncClient,
     alice_member_client: RichAsyncClient,
     credential_definition_id_revocable: str,

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -219,7 +219,20 @@ async def issue_alice_creds_and_revoke_unpublished(
 
 
 @pytest.fixture(scope="function")
-async def issue_alice_creds_and_revoke_published(
+async def revoke_alice_creds(
+    faber_client: RichAsyncClient,
+    issue_alice_creds: List[CredentialExchange],
+) -> List[CredentialExchange]:
+
+    for cred in issue_alice_creds:
+        await faber_client.post(
+            f"{CREDENTIALS_BASE_PATH}/revoke",
+            json={
+                "credential_exchange_id": cred.credential_id[3:],
+            },
+        )
+
+    return issue_alice_creds
     faber_client: RichAsyncClient,
     issue_alice_creds_and_revoke_unpublished: List[  # pylint: disable=redefined-outer-name
         CredentialExchange

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -221,7 +221,7 @@ async def issue_alice_creds(
 @pytest.fixture(scope="function")
 async def revoke_alice_creds(
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange], # pylint: disable=unused-argument
+    issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
 ) -> List[CredentialExchange]:
 
     for cred in issue_alice_creds:
@@ -239,7 +239,7 @@ async def revoke_alice_creds(
 async def revoke_alice_creds_and_publish(
     request,
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange], # pylint: disable=unused-argument
+    issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
 ) -> List[CredentialExchange]:
 
     auto_publish = False

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -221,7 +221,7 @@ async def issue_alice_creds(
 @pytest.fixture(scope="function")
 async def revoke_alice_creds(
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange],
+    issue_alice_creds: List[CredentialExchange], # pylint: disable=unused-argument
 ) -> List[CredentialExchange]:
 
     for cred in issue_alice_creds:
@@ -239,7 +239,7 @@ async def revoke_alice_creds(
 async def revoke_alice_creds_and_publish(
     request,
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange],
+    issue_alice_creds: List[CredentialExchange], # pylint: disable=unused-argument
 ) -> List[CredentialExchange]:
 
     auto_publish = False

--- a/app/tests/fixtures/credentials.py
+++ b/app/tests/fixtures/credentials.py
@@ -147,12 +147,13 @@ async def issue_alice_creds(
             },
         }
 
-        faber_send_response = await faber_client.post(
-            CREDENTIALS_BASE_PATH,
-            json=credential,
-        )
-        cred_ex_id = faber_send_response.json()["credential_exchange_id"]
-        faber_cred_ex_ids += [cred_ex_id]
+        faber_cred_ex_id = (
+            await faber_client.post(
+                CREDENTIALS_BASE_PATH,
+                json=credential,
+            )
+        ).json()["credential_exchange_id"]
+        faber_cred_ex_ids += [faber_cred_ex_id]
 
     num_tries = 0
     num_credentials_returned = 0
@@ -203,32 +204,20 @@ async def issue_alice_creds(
 
     assert len(cred_ex_response) == 3
 
-    # revoke all credentials in list
-    for cred in cred_ex_response:
-        await faber_client.post(
-            f"{CREDENTIALS_BASE_PATH}/revoke",
-            json={
-                "credential_exchange_id": cred["credential_exchange_id"],
-            },
-        )
-
-    credential_exchange_records = [
-        CredentialExchange(**cred) for cred in cred_ex_response
-    ]
-    return credential_exchange_records
+    return [CredentialExchange(**cred) for cred in cred_ex_response]
 
 
 @pytest.fixture(scope="function")
 async def revoke_alice_creds(
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
+    issue_alice_creds: List[CredentialExchange],  # pylint: disable=redefined-outer-name
 ) -> List[CredentialExchange]:
 
     for cred in issue_alice_creds:
         await faber_client.post(
             f"{CREDENTIALS_BASE_PATH}/revoke",
             json={
-                "credential_exchange_id": cred.credential_id[3:],
+                "credential_exchange_id": cred.credential_id,
             },
         )
 
@@ -239,7 +228,7 @@ async def revoke_alice_creds(
 async def revoke_alice_creds_and_publish(
     request,
     faber_client: RichAsyncClient,
-    issue_alice_creds: List[CredentialExchange],  # pylint: disable=unused-argument
+    issue_alice_creds: List[CredentialExchange],  # pylint: disable=redefined-outer-name
 ) -> List[CredentialExchange]:
 
     auto_publish = False
@@ -250,7 +239,7 @@ async def revoke_alice_creds_and_publish(
         await faber_client.post(
             f"{CREDENTIALS_BASE_PATH}/revoke",
             json={
-                "credential_exchange_id": cred.credential_id[3:],
+                "credential_exchange_id": cred.credential_id,
                 "auto_publish_on_ledger": auto_publish,
             },
         )

--- a/app/tests/services/issuer/test_issuer.py
+++ b/app/tests/services/issuer/test_issuer.py
@@ -429,7 +429,6 @@ async def test_revoke_credential(
 
     revoke_credential = mock(RevokeCredential)
     revoke_credential.credential_exchange_id = "random_cred_ex_id"
-    revoke_credential.credential_definition_id = "some_random_cred_def_id"
     revoke_credential.auto_publish_on_ledger = True
     status_code = 204
 
@@ -438,7 +437,6 @@ async def test_revoke_credential(
 
     verify(revocation_registry).revoke_credential(
         controller=mock_agent_controller,
-        credential_definition_id=revoke_credential.credential_definition_id,
         credential_exchange_id=revoke_credential.credential_exchange_id,
         auto_publish_to_ledger=revoke_credential.auto_publish_on_ledger,
     )

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -82,7 +82,6 @@ async def test_revoke_credential(mock_agent_controller: AcaPyClient):
 
     revoke_credential_result = await rg.revoke_credential(
         controller=mock_agent_controller,
-        credential_definition_id=cred_def_id,
         credential_exchange_id=cred_id,
         auto_publish_to_ledger=False,
     )
@@ -99,7 +98,6 @@ async def test_revoke_credential(mock_agent_controller: AcaPyClient):
         ).thenRaise(ApiException(reason=error_msg, status=500))
         await rg.revoke_credential(
             controller=mock_agent_controller,
-            credential_definition_id=cred_def_id,
             credential_exchange_id=cred_id,
             auto_publish_to_ledger=False,
         )


### PR DESCRIPTION
The /revoke credential endpoint accepts an unused argument: `credential_definition_id`. This is now removed.

Additionally, e2e test coverage is added for the auto_publish_to_ledger option, which was previously uncovered.