### PR TITLE
 ✨ publishing pending revocations should wait and assert transaction has been acked

### DIFF
--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import List, Optional
 from uuid import UUID
 
@@ -26,6 +27,7 @@ from app.util.acapy_issuer_utils import (
     issuer_from_protocol_version,
 )
 from app.util.did import did_from_credential_definition_id, qualified_did_sov
+from app.util.retry_method import coroutine_with_retry_until_value
 from shared.log_config import get_logger
 from shared.models.credential_exchange import (
     CredentialExchange,
@@ -661,10 +663,32 @@ async def publish_revocations(
 
     async with client_from_auth(auth) as aries_controller:
         bound_logger.debug("Publishing revocations")
-        await revocation_registry.publish_pending_revocations(
+        endorser_transaction_id = await revocation_registry.publish_pending_revocations(
             controller=aries_controller,
             revocation_registry_credential_map=publish_request.revocation_registry_credential_map,
         )
+
+        # Wait for publish complete
+
+        bound_logger.info(
+            "Wait for publish complete on transaction id: {}", endorser_transaction_id
+        )
+        try:
+            # Wait for transaction to be acknowledged and written to the ledger
+            await coroutine_with_retry_until_value(
+                coroutine_func=aries_controller.endorse_transaction.get_transaction,
+                args=(endorser_transaction_id,),
+                field_name="state",
+                expected_value="transaction_acked",
+                logger=bound_logger,
+                max_attempts=15,
+                retry_delay=2,
+            )
+        except asyncio.TimeoutError as e:
+            raise CloudApiException(
+                "Timeout waiting for endorser to accept the revocations request.",
+                504,
+            ) from e
 
     bound_logger.info("Successfully published revocations.")
 

--- a/app/tests/services/test_revocation_registry.py
+++ b/app/tests/services/test_revocation_registry.py
@@ -11,6 +11,8 @@ from aries_cloudcontroller import (
     PublishRevocations,
     RevokeRequest,
     RevRegResult,
+    TransactionRecord,
+    TxnOrPublishRevocationsResult,
     V10CredentialExchange,
     V20CredExRecordDetail,
     V20CredExRecordIndy,
@@ -115,7 +117,15 @@ async def test_publish_pending_revocations_success(mock_agent_controller: AcaPyC
     # Simulate successful publish revocations call
     when(mock_agent_controller.revocation).publish_revocations(
         body=PublishRevocations(rrid2crid=revocation_registry_credential_map)
-    ).thenReturn(to_async())
+    ).thenReturn(
+        to_async(
+            TxnOrPublishRevocationsResult(
+                txn=TransactionRecord(
+                    transaction_id="97a46fab-5499-42b3-a2a1-7eb9faad31c0"
+                )
+            )
+        )
+    )
 
     await rg.publish_pending_revocations(
         controller=mock_agent_controller,


### PR DESCRIPTION
Required in the 0.12 upgrade -- I figured it's best to implement this in its own PR

Seems to be a timing factor in 0.12, which causes revoked credentials to still appear to be valid in our tests

A fix for that is that the publish revocations endpoint should wait for the ledger transaction to be acked by the endorser before returning a success

To-do later:
- it may be worth including some enriched response instead of a 204.
- We could respond with the number of credentials revoked for this request.