### PR TITLE
Fix reject proof request

### DIFF
--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -115,6 +115,6 @@ class RejectProofRequest(ProofId):
     @field_validator("problem_report", mode="before")
     @classmethod
     def validate_problem_report(cls, value):
-        if value is None:
+        if value == "":
             raise ValueError("problem_report cannot be None")
         return value

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -117,5 +117,5 @@ class RejectProofRequest(ProofId):
     @classmethod
     def validate_problem_report(cls, value):
         if value == "":
-            raise ValueError("problem_report cannot be None")
+            raise ValueError("problem_report cannot be empty string")
         return value

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -113,6 +113,7 @@ class RejectProofRequest(ProofId):
         description="Problem report to send with the rejection",
     )
     @field_validator("problem_report", mode="before")
+    @classmethod
     def validate_problem_report(cls, value):
         if value is None:
             raise ValueError("problem_report cannot be None")

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -110,6 +110,7 @@ class AcceptProofRequest(ProofId):
 
 class RejectProofRequest(ProofId):
     problem_report: str = Field(
+        default="Rejected",
         description="Problem report to send with the rejection",
     )
 

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -109,4 +109,4 @@ class AcceptProofRequest(ProofId):
 
 
 class RejectProofRequest(ProofId):
-    problem_report: Optional[str] = None
+    problem_report: str

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -111,7 +111,7 @@ class AcceptProofRequest(ProofId):
 class RejectProofRequest(ProofId):
     problem_report: str = Field(
         default="Rejected",
-        description="Problem report to send with the rejection",
+        description="Message to send with the rejection",
     )
 
     @field_validator("problem_report", mode="before")

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -109,4 +109,7 @@ class AcceptProofRequest(ProofId):
 
 
 class RejectProofRequest(ProofId):
-    problem_report: str
+    problem_report: str = Field(
+        ...,
+        description="Problem report to send with the rejection",
+    )

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -112,6 +112,7 @@ class RejectProofRequest(ProofId):
     problem_report: str = Field(
         description="Problem report to send with the rejection",
     )
+
     @field_validator("problem_report", mode="before")
     @classmethod
     def validate_problem_report(cls, value):

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -110,6 +110,10 @@ class AcceptProofRequest(ProofId):
 
 class RejectProofRequest(ProofId):
     problem_report: str = Field(
-        ...,
         description="Problem report to send with the rejection",
     )
+    @field_validator("problem_report", mode="before")
+    def validate_my_field(cls, value):
+        if value is None:
+            raise ValueError("problem_report cannot be None")
+        return value

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -113,6 +113,13 @@ class RejectProofRequest(ProofId):
         default="Rejected",
         description="Message to send with the rejection",
     )
+    delete_proof_record: bool = Field(
+        default=False,
+        description=(
+            "(True) delete the proof exchange record after rejecting, or "
+            "(default, False) preserve the record after rejecting"
+        ),
+    )
 
     @field_validator("problem_report", mode="before")
     @classmethod

--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -113,7 +113,7 @@ class RejectProofRequest(ProofId):
         description="Problem report to send with the rejection",
     )
     @field_validator("problem_report", mode="before")
-    def validate_my_field(cls, value):
+    def validate_problem_report(cls, value):
         if value is None:
             raise ValueError("problem_report cannot be None")
         return value

--- a/app/routes/verifier.py
+++ b/app/routes/verifier.py
@@ -204,14 +204,12 @@ async def reject_proof_request(
             )
 
             if proof_record.state != "request-received":
-                bound_logger.info(
-                    "Proof record must be in state `request-received` to reject; had state: `{}`.",
-                    proof_record.state,
+                message = (
+                    "Proof record must be in state `request-received` to reject; "
+                    f"record has state: `{proof_record.state}`."
                 )
-                raise CloudApiException(
-                    "Record must be in state request-received to decline proof request.",
-                    400,
-                )
+                bound_logger.info(message)
+                raise CloudApiException(message, 400)
 
             bound_logger.debug("Rejecting proof request")
             await verifier.reject_proof_request(

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -152,24 +152,22 @@ class VerifierV1(Verifier):
         bound_logger.info("Request to reject v1 presentation exchange record")
         proof_id = pres_id_no_version(proof_id=reject_proof_request.proof_id)
 
-        # Report problem if desired
-        if reject_proof_request.problem_report:
-            request_body = V10PresentationProblemReportRequest(
-                description=reject_proof_request.problem_report
-            )
+        request_body = V10PresentationProblemReportRequest(
+            description=reject_proof_request.problem_report
+        )
 
-            try:
-                bound_logger.debug("Submitting v1 problem report")
-                await handle_acapy_call(
-                    logger=bound_logger,
-                    acapy_call=controller.present_proof_v1_0.report_problem,
-                    pres_ex_id=proof_id,
-                    body=request_body,
-                )
-            except CloudApiException as e:
-                raise CloudApiException(
-                    f"Failed to send problem report: {e.detail}.", e.status_code
-                ) from e
+        try:
+            bound_logger.debug("Submitting v1 problem report")
+            await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=controller.present_proof_v1_0.report_problem,
+                pres_ex_id=proof_id,
+                body=request_body,
+            )
+        except CloudApiException as e:
+            raise CloudApiException(
+                f"Failed to send problem report: {e.detail}.", e.status_code
+            ) from e
 
         try:
             bound_logger.debug("Deleting v1 presentation exchange record")

--- a/app/services/verifier/acapy_verifier_v1.py
+++ b/app/services/verifier/acapy_verifier_v1.py
@@ -169,17 +169,18 @@ class VerifierV1(Verifier):
                 f"Failed to send problem report: {e.detail}.", e.status_code
             ) from e
 
-        try:
-            bound_logger.debug("Deleting v1 presentation exchange record")
-            await handle_acapy_call(
-                logger=bound_logger,
-                acapy_call=controller.present_proof_v1_0.delete_record,
-                pres_ex_id=proof_id,
-            )
-        except CloudApiException as e:
-            raise CloudApiException(
-                f"Failed to delete record: {e.detail}.", e.status_code
-            ) from e
+        if reject_proof_request.delete_proof_record:
+            try:
+                bound_logger.debug("Deleting v1 presentation exchange record")
+                await handle_acapy_call(
+                    logger=bound_logger,
+                    acapy_call=controller.present_proof_v1_0.delete_record,
+                    pres_ex_id=proof_id,
+                )
+            except CloudApiException as e:
+                raise CloudApiException(
+                    f"Failed to delete record: {e.detail}.", e.status_code
+                ) from e
 
         bound_logger.info("Successfully rejected v1 presentation exchange record.")
 

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -168,23 +168,21 @@ class VerifierV2(Verifier):
         bound_logger.info("Request to reject v2 presentation exchange record")
         pres_ex_id = pres_id_no_version(proof_id=reject_proof_request.proof_id)
 
-        # Report problem if desired
-        if reject_proof_request.problem_report:
-            request_body = V20PresProblemReportRequest(
-                description=reject_proof_request.problem_report
+        request_body = V20PresProblemReportRequest(
+            description=reject_proof_request.problem_report
+        )
+        try:
+            bound_logger.debug("Submitting v2 problem report")
+            await handle_acapy_call(
+                logger=bound_logger,
+                acapy_call=controller.present_proof_v2_0.report_problem,
+                pres_ex_id=pres_ex_id,
+                body=request_body,
             )
-            try:
-                bound_logger.debug("Submitting v2 problem report")
-                await handle_acapy_call(
-                    logger=bound_logger,
-                    acapy_call=controller.present_proof_v2_0.report_problem,
-                    pres_ex_id=pres_ex_id,
-                    body=request_body,
-                )
-            except CloudApiException as e:
-                raise CloudApiException(
-                    f"Failed to send problem report: {e.detail}.", e.status_code
-                ) from e
+        except CloudApiException as e:
+            raise CloudApiException(
+                f"Failed to send problem report: {e.detail}.", e.status_code
+            ) from e
 
         try:
             bound_logger.debug("Deleting v2 presentation exchange record")

--- a/app/services/verifier/acapy_verifier_v2.py
+++ b/app/services/verifier/acapy_verifier_v2.py
@@ -184,17 +184,18 @@ class VerifierV2(Verifier):
                 f"Failed to send problem report: {e.detail}.", e.status_code
             ) from e
 
-        try:
-            bound_logger.debug("Deleting v2 presentation exchange record")
-            await handle_acapy_call(
-                logger=bound_logger,
-                acapy_call=controller.present_proof_v2_0.delete_record,
-                pres_ex_id=pres_ex_id,
-            )
-        except CloudApiException as e:
-            raise CloudApiException(
-                f"Failed to delete record: {e.detail}.", e.status_code
-            ) from e
+        if reject_proof_request.delete_proof_record:
+            try:
+                bound_logger.debug("Deleting v2 presentation exchange record")
+                await handle_acapy_call(
+                    logger=bound_logger,
+                    acapy_call=controller.present_proof_v2_0.delete_record,
+                    pres_ex_id=pres_ex_id,
+                )
+            except CloudApiException as e:
+                raise CloudApiException(
+                    f"Failed to delete record: {e.detail}.", e.status_code
+                ) from e
 
         bound_logger.info("Successfully rejected v2 presentation exchange record.")
 

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -500,7 +500,7 @@ async def test_reject_proof_request(
     assert alice_exchange["protocol_version"] == "v1"
 
     reject_proof_request_v1 = RejectProofRequest(
-        proof_id=alice_exchange["proof_id"], problem_report=None
+        proof_id=alice_exchange["proof_id"], problem_report="rejected"
     )
 
     response = await alice_member_client.post(

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -471,17 +471,18 @@ async def test_send_proof_request(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("protocol_version", ["v1"])
 async def test_reject_proof_request(
     acme_and_alice_connection: AcmeAliceConnect,
     alice_member_client: RichAsyncClient,
     acme_client: RichAsyncClient,
+    protocol_version: str,
 ):
-    # V1
     response = await acme_client.post(
         VERIFIER_BASE_PATH + "/send-request",
         json={
             "connection_id": acme_and_alice_connection.acme_connection_id,
-            "protocol_version": "v1",
+            "protocol_version": protocol_version,
             "indy_proof_request": indy_proof_request.to_dict(),
         },
     )
@@ -497,7 +498,7 @@ async def test_reject_proof_request(
             "thread_id": thread_id,
         },
     )
-    assert alice_exchange["protocol_version"] == "v1"
+    assert alice_exchange["protocol_version"] == protocol_version
 
     reject_proof_request_v1 = RejectProofRequest(
         proof_id=alice_exchange["proof_id"], problem_report="rejected"

--- a/app/tests/services/verifier/test_acapy_verifier_v1.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v1.py
@@ -194,7 +194,7 @@ async def test_reject_proof_reject(mock_agent_controller: AcaPyClient):
     deleted_proof_request = await VerifierV1.reject_proof_request(
         controller=mock_agent_controller,
         reject_proof_request=RejectProofRequest(
-            proof_id="v1-abc", problem_report="some message"
+            proof_id="v1-abc", problem_report="some message", delete_proof_record=True
         ),
     )
 
@@ -245,7 +245,7 @@ async def test_reject_proof_reject_exception_delete(
         await VerifierV1.reject_proof_request(
             controller=mock_agent_controller,
             reject_proof_request=RejectProofRequest(
-                proof_id="v1-abc", problem_report="bad"
+                proof_id="v1-abc", problem_report="bad", delete_proof_record=True
             ),
         )
 

--- a/app/tests/services/verifier/test_acapy_verifier_v2.py
+++ b/app/tests/services/verifier/test_acapy_verifier_v2.py
@@ -273,7 +273,7 @@ async def test_reject_proof_reject(mock_agent_controller: AcaPyClient):
     deleted_proof_request = await VerifierV2.reject_proof_request(
         controller=mock_agent_controller,
         reject_proof_request=RejectProofRequest(
-            proof_id="v2-abc", problem_report="some message"
+            proof_id="v2-abc", problem_report="some message", delete_proof_record=True
         ),
     )
 
@@ -324,7 +324,7 @@ async def test_reject_proof_reject_exception_delete(
         await VerifierV2.reject_proof_request(
             controller=mock_agent_controller,
             reject_proof_request=RejectProofRequest(
-                proof_id="v2-abc", problem_report="bad"
+                proof_id="v2-abc", problem_report="bad", delete_proof_record=True
             ),
         )
 

--- a/app/tests/services/verifier/test_verifier.py
+++ b/app/tests/services/verifier/test_verifier.py
@@ -254,7 +254,9 @@ async def test_reject_proof_request(
     mock_tenant_auth: AcaPyAuth,
     mocker: MockerFixture,
 ):
-    proof_request_v1 = test_module.RejectProofRequest(proof_id="v1-1234")
+    proof_request_v1 = test_module.RejectProofRequest(
+        proof_id="v1-1234", problem_report="rejected"
+    )
     # V1
 
     mocker.patch.object(
@@ -272,7 +274,9 @@ async def test_reject_proof_request(
     ).thenReturn(to_async(presentation_exchange_record_1))
 
     result = await test_module.reject_proof_request(
-        body=test_module.RejectProofRequest(proof_id="v1-1234"),
+        body=test_module.RejectProofRequest(
+            proof_id="v1-1234", problem_report="rejected"
+        ),
         auth=mock_tenant_auth,
     )
 
@@ -284,7 +288,9 @@ async def test_reject_proof_request(
         controller=mock_agent_controller, proof_id=proof_request_v1.proof_id
     )
 
-    proof_request_v2 = test_module.RejectProofRequest(proof_id="v2-1234")
+    proof_request_v2 = test_module.RejectProofRequest(
+        proof_id="v2-1234", problem_report="rejected"
+    )
 
     # V2
     when(VerifierV2).reject_proof_request(
@@ -296,7 +302,9 @@ async def test_reject_proof_request(
     ).thenReturn(to_async(presentation_exchange_record_2))
 
     result = await test_module.reject_proof_request(
-        body=test_module.RejectProofRequest(proof_id="v2-1234"),
+        body=test_module.RejectProofRequest(
+            proof_id="v2-1234", problem_report="rejected"
+        ),
         auth=mock_tenant_auth,
     )
 

--- a/shared/models/presentation_exchange.py
+++ b/shared/models/presentation_exchange.py
@@ -8,7 +8,10 @@ from aries_cloudcontroller import (
 )
 from pydantic import BaseModel
 
+from shared.log_config import get_logger
 from shared.models.protocol import PresentProofProtocolVersion
+
+logger = get_logger(__name__)
 
 State = Literal[
     "abandoned",
@@ -58,6 +61,7 @@ def presentation_record_to_model(
                 else None
             )
         except AttributeError:
+            logger.info("Presentation record has no indy presentation")
             presentation = None
 
         try:
@@ -65,6 +69,7 @@ def presentation_record_to_model(
                 **record.by_format.pres_request["indy"]
             )
         except AttributeError:
+            logger.info("Presentation record has no indy presentation request")
             presentation_request = None
 
         return PresentationExchange(
@@ -122,6 +127,7 @@ def v1_presentation_state_to_rfc_state(state: Optional[str]) -> Optional[str]:
     }
 
     if not state or state not in translation_dict:
+        logger.warning("Presentation record has unknown state: {}", state)
         return None
 
     return translation_dict[state]

--- a/shared/models/presentation_exchange.py
+++ b/shared/models/presentation_exchange.py
@@ -115,6 +115,7 @@ def presentation_record_to_model(
 def v1_presentation_state_to_rfc_state(state: Optional[str]) -> Optional[str]:
     translation_dict = {
         "abandoned": "abandoned",
+        "deleted": "deleted",
         "done": "done",
         "presentation_acked": "done",
         "presentation_received": "presentation-received",
@@ -136,6 +137,7 @@ def v1_presentation_state_to_rfc_state(state: Optional[str]) -> Optional[str]:
 def back_to_v1_presentation_state(state: Optional[str]) -> Optional[str]:
     translation_dict = {
         "abandoned": "abandoned",
+        "deleted": "deleted",
         "done": "verified",
         "presentation-received": "presentation_received",
         "presentation-sent": "presentation_sent",


### PR DESCRIPTION
If prover does not pass a `problem_report` verifier state does not go to abandoned 

Updated `RejectProofRequest` model to require `problem_report`

closes #782 