### PR TITLE
:art: Cleanup and parametrize verifier tests

### DIFF
--- a/app/models/verifier.py
+++ b/app/models/verifier.py
@@ -125,5 +125,5 @@ class RejectProofRequest(ProofId):
     @classmethod
     def validate_problem_report(cls, value):
         if value == "":
-            raise ValueError("problem_report cannot be empty string")
+            raise CloudApiValueError("problem_report cannot be an empty string")
         return value

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -6,6 +6,7 @@ from assertpy import assert_that
 from app.routes.definitions import CredentialSchema
 from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
+from app.tests.util.credentials import sample_credential_attributes
 from app.tests.util.ecosystem_connections import FaberAliceConnect
 from app.tests.util.webhooks import check_webhook_state
 from app.util.credentials import cred_id_no_version
@@ -29,7 +30,7 @@ async def test_send_credential_oob(
         "protocol_version": protocol_version,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 
@@ -51,7 +52,7 @@ async def test_send_credential_oob(
     assert_that(data).contains("credential_id")
     assert_that(data).has_state("offer-sent")
     assert_that(data).has_protocol_version(protocol_version)
-    assert_that(data).has_attributes({"speed": "10"})
+    assert_that(data).has_attributes(sample_credential_attributes)
     assert_that(data).has_schema_id(schema_definition.id)
 
     invitation_response = await faber_client.post(
@@ -104,7 +105,7 @@ async def test_send_credential(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 
@@ -126,7 +127,7 @@ async def test_send_credential(
     assert_that(data).contains("credential_id")
     assert_that(data).has_state("offer-sent")
     assert_that(data).has_protocol_version(protocol_version)
-    assert_that(data).has_attributes({"speed": "10"})
+    assert_that(data).has_attributes(sample_credential_attributes)
     assert_that(data).has_schema_id(schema_definition.id)
 
     assert await check_webhook_state(
@@ -151,7 +152,7 @@ async def test_create_offer(
         "protocol_version": protocol_version,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 
@@ -164,7 +165,7 @@ async def test_create_offer(
     assert_that(data).contains("credential_id")
     assert_that(data).has_state("offer-sent")
     assert_that(data).has_protocol_version(protocol_version)
-    assert_that(data).has_attributes({"speed": "10"})
+    assert_that(data).has_attributes(sample_credential_attributes)
     assert_that(data).has_schema_id(schema_definition.id)
 
     assert await check_webhook_state(
@@ -191,7 +192,7 @@ async def test_send_credential_request(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 
@@ -262,7 +263,7 @@ async def test_revoke_credential(
         "connection_id": faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id_revocable,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -29,7 +29,7 @@ async def test_send_credential_oob(
         "protocol_version": protocol_version,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 
@@ -104,7 +104,7 @@ async def test_send_credential(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 
@@ -151,7 +151,7 @@ async def test_create_offer(
         "protocol_version": protocol_version,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 
@@ -191,7 +191,7 @@ async def test_send_credential_request(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 
@@ -262,7 +262,7 @@ async def test_revoke_credential(
         "connection_id": faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id_revocable,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.routes.issuer import router
+from app.tests.util.credentials import sample_credential_attributes
 from app.tests.util.ecosystem_connections import FaberAliceConnect
 from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
@@ -30,7 +31,7 @@ async def test_issue_credential_with_save_exchange_record(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
         "save_exchange_record": save_exchange_record,
     }
@@ -100,7 +101,7 @@ async def test_get_cred_exchange_records(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
         "save_exchange_record": True,
     }

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -30,7 +30,7 @@ async def test_issue_credential_with_save_exchange_record(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
         "save_exchange_record": save_exchange_record,
     }
@@ -100,7 +100,7 @@ async def test_get_cred_exchange_records(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
         "save_exchange_record": True,
     }
@@ -115,7 +115,7 @@ async def test_get_cred_exchange_records(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "20"},
+            "attributes": {"speed": "20", "name": "Alice", "age": "44"},
         },
         "save_exchange_record": True,
     }

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -11,12 +11,10 @@ from app.routes.issuer import router as issuer_router
 from app.routes.oob import router as oob_router
 from app.routes.verifier import AcceptProofRequest, RejectProofRequest
 from app.routes.verifier import router as verifier_router
-from app.services.trust_registry.actors import fetch_actor_by_id
 from app.tests.services.verifier.utils import indy_proof_request
 from app.tests.util.ecosystem_connections import AcmeAliceConnect, MeldCoAliceConnect
 from app.tests.util.verifier import send_proof_request
-from app.tests.util.webhooks import check_webhook_state, get_wallet_id_from_async_client
-from app.util.string import base64_to_json
+from app.tests.util.webhooks import check_webhook_state
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 from shared.models.presentation_exchange import PresentationExchange
@@ -700,111 +698,3 @@ async def test_saving_of_presentation_exchange_records(
         assert len(acme_pres_ex_records) == 1  # Save record is True, should be 1 record
     else:
         assert len(acme_pres_ex_records) == 0  # default is to remove records
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("protocol_version", ["v1", "v2"])
-async def test_accept_proof_request_verifier_no_public_did(
-    credential_definition_id: str,
-    issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
-    acme_client: RichAsyncClient,
-    alice_member_client: RichAsyncClient,
-    protocol_version: str,
-):
-    # Create connection between holder and verifier
-    # We need to use the multi-use didcomm invitation from the trust registry
-    acme_wallet_id = get_wallet_id_from_async_client(acme_client)
-    verifier_actor = await fetch_actor_by_id(acme_wallet_id)
-
-    assert verifier_actor
-    assert verifier_actor["didcomm_invitation"]
-
-    invitation_json = base64_to_json(
-        verifier_actor["didcomm_invitation"].split("?oob=")[1]
-    )
-    invitation_response = (
-        await alice_member_client.post(
-            OOB_BASE_PATH + "/accept-invitation",
-            json={"invitation": invitation_json},
-        )
-    ).json()
-
-    payload = await check_webhook_state(
-        client=acme_client,
-        topic="connections",
-        state="completed",
-    )
-    holder_verifier_connection_id = invitation_response["connection_id"]
-    verifier_holder_connection_id = payload["connection_id"]
-
-    # Present proof from holder to verifier
-    request_body = {
-        "protocol_version": protocol_version,
-        "connection_id": verifier_holder_connection_id,
-        "indy_proof_request": {
-            "name": "Age Check",
-            "version": "1.0",
-            "requested_attributes": {
-                "name": {
-                    "name": "name",
-                    "restrictions": [{"cred_def_id": credential_definition_id}],
-                }
-            },
-            "requested_predicates": {
-                "age_over_21": {
-                    "name": "age",
-                    "p_type": ">=",
-                    "p_value": 21,
-                    "restrictions": [{"cred_def_id": credential_definition_id}],
-                }
-            },
-        },
-    }
-    send_proof_response = await send_proof_request(acme_client, request_body)
-
-    payload = await check_webhook_state(
-        client=alice_member_client,
-        topic="proofs",
-        state="request-received",
-        filter_map={
-            "connection_id": holder_verifier_connection_id,
-        },
-    )
-
-    verifier_proof_exchange_id = send_proof_response["proof_id"]
-    holder_proof_exchange_id = payload["proof_id"]
-
-    available_credentials = (
-        await alice_member_client.get(
-            f"{VERIFIER_BASE_PATH}/proofs/{holder_proof_exchange_id}/credentials",
-        )
-    ).json()
-
-    cred_id = available_credentials[0]["cred_info"]["referent"]
-
-    await alice_member_client.post(
-        VERIFIER_BASE_PATH + "/accept-request",
-        json={
-            "proof_id": holder_proof_exchange_id,
-            "indy_presentation_spec": {
-                "requested_attributes": {
-                    "name": {
-                        "cred_id": cred_id,
-                        "revealed": True,
-                    }
-                },
-                "requested_predicates": {"age_over_21": {"cred_id": cred_id}},
-                "self_attested_attributes": {},
-            },
-        },
-    )
-
-    event = await check_webhook_state(
-        client=acme_client,
-        topic="proofs",
-        state="done",
-        filter_map={
-            "proof_id": verifier_proof_exchange_id,
-        },
-    )
-    assert event["verified"]

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -6,7 +6,6 @@ from aries_cloudcontroller import (
     IndyPresSpec,
     IndyRequestedCredsRequestedAttr,
 )
-from assertpy import assert_that
 from fastapi import HTTPException
 
 from app.routes.connections import router as conn_router
@@ -24,11 +23,10 @@ from app.services.trust_registry.actors import fetch_actor_by_id
 from app.tests.services.verifier.utils import indy_proof_request
 from app.tests.util.ecosystem_connections import AcmeAliceConnect, MeldCoAliceConnect
 from app.tests.util.webhooks import check_webhook_state, get_wallet_id_from_async_client
-from app.util.string import base64_to_json, random_string
+from app.util.string import base64_to_json
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 from shared.models.presentation_exchange import PresentationExchange
-from shared.models.protocol import PresentProofProtocolVersion
 
 CONNECTIONS_BASE_PATH = conn_router.prefix
 DEFINITIONS_BASE_PATH = def_router.prefix

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import pytest
@@ -386,6 +387,8 @@ async def test_get_proof_and_get_proofs(
     assert "presentation" in result
     assert "presentation_request" in result
     assert result["protocol_version"] == protocol_version
+
+    await asyncio.sleep(0.3)  # allow moment for alice records to update
 
     # Fetch proofs for alice
     alice_proofs_response = await alice_member_client.get(

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -2,23 +2,14 @@ import asyncio
 import json
 
 import pytest
-from aries_cloudcontroller import (
-    AttachmentDef,
-    IndyPresSpec,
-    IndyRequestedCredsRequestedAttr,
-)
+from aries_cloudcontroller import IndyPresSpec, IndyRequestedCredsRequestedAttr
 from fastapi import HTTPException
 
 from app.routes.connections import router as conn_router
 from app.routes.definitions import router as def_router
 from app.routes.issuer import router as issuer_router
-from app.routes.oob import AcceptOobInvitation, CreateOobInvitation
 from app.routes.oob import router as oob_router
-from app.routes.verifier import (
-    AcceptProofRequest,
-    CreateProofRequest,
-    RejectProofRequest,
-)
+from app.routes.verifier import AcceptProofRequest, RejectProofRequest
 from app.routes.verifier import router as verifier_router
 from app.services.trust_registry.actors import fetch_actor_by_id
 from app.tests.services.verifier.utils import indy_proof_request
@@ -131,104 +122,6 @@ async def test_accept_proof_request(
         look_back=5,
     )
     assert acme_proof_event["verified"] is True
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("protocol_version", ["v1", "v2"])
-async def test_accept_proof_request_oob(
-    issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
-    alice_member_client: RichAsyncClient,
-    bob_member_client: RichAsyncClient,
-    protocol_version: str,
-):
-    # Create the proof request against aca-py
-    create_proof_request = CreateProofRequest(
-        indy_proof_request=indy_proof_request,
-        comment="some comment",
-        protocol_version=protocol_version,
-    )
-    create_proof_response = await bob_member_client.post(
-        VERIFIER_BASE_PATH + "/create-request",
-        json=create_proof_request.model_dump(by_alias=True),
-    )
-    bob_exchange = create_proof_response.json()
-    assert bob_exchange["protocol_version"] == protocol_version
-    thread_id = bob_exchange["thread_id"]
-
-    create_oob_invitation_request = CreateOobInvitation(
-        create_connection=False,
-        use_public_did=False,
-        attachments=[AttachmentDef(id=bob_exchange["proof_id"], type="present-proof")],
-    )
-
-    invitation_response = await bob_member_client.post(
-        f"{OOB_BASE_PATH}/create-invitation",
-        json=create_oob_invitation_request.model_dump(),
-    )
-    assert invitation_response.status_code == 200
-    invitation = (invitation_response.json())["invitation"]
-
-    accept_oob_invitation_request = AcceptOobInvitation(invitation=invitation)
-    await alice_member_client.post(
-        f"{OOB_BASE_PATH}/accept-invitation",
-        json=accept_oob_invitation_request.model_dump(by_alias=True),
-    )
-
-    alice_request_received = await check_webhook_state(
-        client=alice_member_client,
-        topic="proofs",
-        state="request-received",
-        filter_map={
-            "thread_id": thread_id,
-        },
-    )
-
-    alice_proof_id = alice_request_received["proof_id"]
-    assert alice_proof_id
-
-    requested_credentials = await alice_member_client.get(
-        f"{VERIFIER_BASE_PATH}/proofs/{alice_proof_id}/credentials"
-    )
-
-    referent = requested_credentials.json()[0]["cred_info"]["referent"]
-    assert referent
-
-    indy_request_attrs = IndyRequestedCredsRequestedAttr(
-        cred_id=referent, revealed=True
-    )
-    proof_accept = AcceptProofRequest(
-        proof_id=alice_proof_id,
-        indy_presentation_spec=IndyPresSpec(
-            requested_attributes={"0_speed_uuid": indy_request_attrs},
-            requested_predicates={},
-            self_attested_attributes={},
-        ),
-    )
-
-    accept_response = await alice_member_client.post(
-        VERIFIER_BASE_PATH + "/accept-request",
-        json=proof_accept.model_dump(),
-    )
-    assert accept_response.status_code == 200
-
-    assert await check_webhook_state(
-        client=alice_member_client,
-        topic="proofs",
-        state="presentation-sent",
-        filter_map={
-            "proof_id": alice_proof_id,
-        },
-    )
-
-    bob_presentation_received = await check_webhook_state(
-        client=bob_member_client,
-        topic="proofs",
-        state="done",
-        filter_map={
-            "thread_id": thread_id,
-        },
-    )
-    assert bob_presentation_received["role"] == "verifier"
 
 
 @pytest.mark.anyio
@@ -889,7 +782,7 @@ async def test_accept_proof_request_verifier_no_public_did(
 
     cred_id = available_credentials[0]["cred_info"]["referent"]
 
-    response = await alice_member_client.post(
+    await alice_member_client.post(
         VERIFIER_BASE_PATH + "/accept-request",
         json={
             "proof_id": holder_proof_exchange_id,

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -550,45 +550,6 @@ async def test_accept_proof_request_verifier_has_issuer_role(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("protocol_version", ["v1", "v2"])
-@pytest.mark.parametrize(
-    "meld_co_and_alice_connection", ["trust_registry", "default"], indirect=True
-)
-async def test_send_proof_request_verifier_has_issuer_role(
-    meld_co_and_alice_connection: MeldCoAliceConnect,
-    meld_co_client: RichAsyncClient,
-    alice_member_client: RichAsyncClient,
-    protocol_version: str,
-):
-    request_body = {
-        "connection_id": meld_co_and_alice_connection.meld_co_connection_id,
-        "protocol_version": protocol_version,
-        "indy_proof_request": indy_proof_request.to_dict(),
-    }
-    send_proof_response = await send_proof_request(meld_co_client, request_body)
-
-    assert "presentation" in send_proof_response
-    assert "presentation_request" in send_proof_response
-    assert "created_at" in send_proof_response
-    assert "proof_id" in send_proof_response
-    assert send_proof_response["role"] == "verifier"
-    assert send_proof_response["state"]
-
-    thread_id = send_proof_response["thread_id"]
-    assert thread_id
-
-    alice_connection_event = await check_webhook_state(
-        client=alice_member_client,
-        topic="proofs",
-        state="request-received",
-        filter_map={
-            "thread_id": thread_id,
-        },
-    )
-    assert alice_connection_event["protocol_version"] == protocol_version
-
-
-@pytest.mark.anyio
-@pytest.mark.parametrize("protocol_version", ["v1", "v2"])
 @pytest.mark.parametrize("acme_save_exchange_record", [False, True])
 @pytest.mark.parametrize("alice_save_exchange_record", [False, True])
 async def test_saving_of_presentation_exchange_records(

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -9,8 +9,11 @@ from app.routes.oob import AcceptOobInvitation, CreateOobInvitation
 from app.routes.oob import router as oob_router
 from app.routes.verifier import AcceptProofRequest, CreateProofRequest
 from app.routes.verifier import router as verifier_router
+from app.services.trust_registry.actors import fetch_actor_by_id
 from app.tests.services.verifier.utils import indy_proof_request
-from app.tests.util.webhooks import check_webhook_state
+from app.tests.util.verifier import send_proof_request
+from app.tests.util.webhooks import check_webhook_state, get_wallet_id_from_async_client
+from app.util.string import base64_to_json
 from shared import RichAsyncClient
 from shared.models.credential_exchange import CredentialExchange
 
@@ -114,3 +117,111 @@ async def test_accept_proof_request_oob(
         },
     )
     assert bob_presentation_received["role"] == "verifier"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("protocol_version", ["v1", "v2"])
+async def test_accept_proof_request_verifier_oob_connection(
+    credential_definition_id: str,
+    issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
+    acme_client: RichAsyncClient,
+    alice_member_client: RichAsyncClient,
+    protocol_version: str,
+):
+    # Create connection between holder and verifier
+    # We need to use the multi-use didcomm invitation from the trust registry
+    acme_wallet_id = get_wallet_id_from_async_client(acme_client)
+    verifier_actor = await fetch_actor_by_id(acme_wallet_id)
+
+    assert verifier_actor
+    assert verifier_actor["didcomm_invitation"]
+
+    invitation_json = base64_to_json(
+        verifier_actor["didcomm_invitation"].split("?oob=")[1]
+    )
+    invitation_response = (
+        await alice_member_client.post(
+            OOB_BASE_PATH + "/accept-invitation",
+            json={"invitation": invitation_json},
+        )
+    ).json()
+
+    payload = await check_webhook_state(
+        client=acme_client,
+        topic="connections",
+        state="completed",
+    )
+    holder_verifier_connection_id = invitation_response["connection_id"]
+    verifier_holder_connection_id = payload["connection_id"]
+
+    # Present proof from holder to verifier
+    request_body = {
+        "protocol_version": protocol_version,
+        "connection_id": verifier_holder_connection_id,
+        "indy_proof_request": {
+            "name": "Age Check",
+            "version": "1.0",
+            "requested_attributes": {
+                "name": {
+                    "name": "name",
+                    "restrictions": [{"cred_def_id": credential_definition_id}],
+                }
+            },
+            "requested_predicates": {
+                "age_over_21": {
+                    "name": "age",
+                    "p_type": ">=",
+                    "p_value": 21,
+                    "restrictions": [{"cred_def_id": credential_definition_id}],
+                }
+            },
+        },
+    }
+    send_proof_response = await send_proof_request(acme_client, request_body)
+
+    payload = await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        state="request-received",
+        filter_map={
+            "connection_id": holder_verifier_connection_id,
+        },
+    )
+
+    verifier_proof_exchange_id = send_proof_response["proof_id"]
+    holder_proof_exchange_id = payload["proof_id"]
+
+    available_credentials = (
+        await alice_member_client.get(
+            f"{VERIFIER_BASE_PATH}/proofs/{holder_proof_exchange_id}/credentials",
+        )
+    ).json()
+
+    cred_id = available_credentials[0]["cred_info"]["referent"]
+
+    await alice_member_client.post(
+        VERIFIER_BASE_PATH + "/accept-request",
+        json={
+            "proof_id": holder_proof_exchange_id,
+            "indy_presentation_spec": {
+                "requested_attributes": {
+                    "name": {
+                        "cred_id": cred_id,
+                        "revealed": True,
+                    }
+                },
+                "requested_predicates": {"age_over_21": {"cred_id": cred_id}},
+                "self_attested_attributes": {},
+            },
+        },
+    )
+
+    event = await check_webhook_state(
+        client=acme_client,
+        topic="proofs",
+        state="done",
+        filter_map={
+            "proof_id": verifier_proof_exchange_id,
+        },
+    )
+    assert event["verified"]

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -1,0 +1,116 @@
+import pytest
+from aries_cloudcontroller import (
+    AttachmentDef,
+    IndyPresSpec,
+    IndyRequestedCredsRequestedAttr,
+)
+
+from app.routes.oob import AcceptOobInvitation, CreateOobInvitation
+from app.routes.oob import router as oob_router
+from app.routes.verifier import AcceptProofRequest, CreateProofRequest
+from app.routes.verifier import router as verifier_router
+from app.tests.services.verifier.utils import indy_proof_request
+from app.tests.util.webhooks import check_webhook_state
+from shared import RichAsyncClient
+from shared.models.credential_exchange import CredentialExchange
+
+OOB_BASE_PATH = oob_router.prefix
+VERIFIER_BASE_PATH = verifier_router.prefix
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("protocol_version", ["v1", "v2"])
+async def test_accept_proof_request_oob(
+    issue_credential_to_alice: CredentialExchange,  # pylint: disable=unused-argument
+    alice_member_client: RichAsyncClient,
+    bob_member_client: RichAsyncClient,
+    protocol_version: str,
+):
+    # Create the proof request against aca-py
+    create_proof_request = CreateProofRequest(
+        indy_proof_request=indy_proof_request,
+        comment="some comment",
+        protocol_version=protocol_version,
+    )
+    create_proof_response = await bob_member_client.post(
+        VERIFIER_BASE_PATH + "/create-request",
+        json=create_proof_request.model_dump(by_alias=True),
+    )
+    bob_exchange = create_proof_response.json()
+    assert bob_exchange["protocol_version"] == protocol_version
+    thread_id = bob_exchange["thread_id"]
+
+    create_oob_invitation_request = CreateOobInvitation(
+        create_connection=False,
+        use_public_did=False,
+        attachments=[AttachmentDef(id=bob_exchange["proof_id"], type="present-proof")],
+    )
+
+    invitation_response = await bob_member_client.post(
+        f"{OOB_BASE_PATH}/create-invitation",
+        json=create_oob_invitation_request.model_dump(),
+    )
+    assert invitation_response.status_code == 200
+    invitation = (invitation_response.json())["invitation"]
+
+    accept_oob_invitation_request = AcceptOobInvitation(invitation=invitation)
+    await alice_member_client.post(
+        f"{OOB_BASE_PATH}/accept-invitation",
+        json=accept_oob_invitation_request.model_dump(by_alias=True),
+    )
+
+    alice_request_received = await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        state="request-received",
+        filter_map={
+            "thread_id": thread_id,
+        },
+    )
+
+    alice_proof_id = alice_request_received["proof_id"]
+    assert alice_proof_id
+
+    requested_credentials = await alice_member_client.get(
+        f"{VERIFIER_BASE_PATH}/proofs/{alice_proof_id}/credentials"
+    )
+
+    referent = requested_credentials.json()[0]["cred_info"]["referent"]
+    assert referent
+
+    indy_request_attrs = IndyRequestedCredsRequestedAttr(
+        cred_id=referent, revealed=True
+    )
+    proof_accept = AcceptProofRequest(
+        proof_id=alice_proof_id,
+        indy_presentation_spec=IndyPresSpec(
+            requested_attributes={"0_speed_uuid": indy_request_attrs},
+            requested_predicates={},
+            self_attested_attributes={},
+        ),
+    )
+
+    accept_response = await alice_member_client.post(
+        VERIFIER_BASE_PATH + "/accept-request",
+        json=proof_accept.model_dump(),
+    )
+    assert accept_response.status_code == 200
+
+    assert await check_webhook_state(
+        client=alice_member_client,
+        topic="proofs",
+        state="presentation-sent",
+        filter_map={
+            "proof_id": alice_proof_id,
+        },
+    )
+
+    bob_presentation_received = await check_webhook_state(
+        client=bob_member_client,
+        topic="proofs",
+        state="done",
+        filter_map={
+            "thread_id": thread_id,
+        },
+    )
+    assert bob_presentation_received["role"] == "verifier"

--- a/app/tests/models/test_verifier.py
+++ b/app/tests/models/test_verifier.py
@@ -8,6 +8,7 @@ from app.models.verifier import (
     IndyProofRequest,
     ProofRequestBase,
     ProofRequestType,
+    RejectProofRequest,
 )
 from shared.exceptions.cloudapi_value_error import CloudApiValueError
 
@@ -88,3 +89,12 @@ def test_accept_proof_request_model():
     assert exc.value.detail == (
         "dif_presentation_spec must be populated if `ld_proof` type is selected"
     )
+
+
+def test_reject_proof_request_model():
+    RejectProofRequest(proof_id="abc", problem_report="valid message")
+
+    with pytest.raises(CloudApiValueError) as exc:
+        RejectProofRequest(proof_id="abc", problem_report="")
+
+    assert exc.value.detail == "problem_report cannot be an empty string"

--- a/app/tests/util/credentials.py
+++ b/app/tests/util/credentials.py
@@ -24,7 +24,7 @@ async def issue_credential_to_alice(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 

--- a/app/tests/util/credentials.py
+++ b/app/tests/util/credentials.py
@@ -12,6 +12,9 @@ from shared.models.credential_exchange import CredentialExchange
 CREDENTIALS_BASE_PATH = router.prefix
 
 
+sample_credential_attributes = {"speed": "10", "name": "Alice", "age": "44"}
+
+
 @pytest.fixture(scope="function")
 async def issue_credential_to_alice(
     faber_client: RichAsyncClient,
@@ -24,7 +27,7 @@ async def issue_credential_to_alice(
         "connection_id": faber_and_alice_connection.faber_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 
@@ -74,7 +77,7 @@ async def meld_co_issue_credential_to_alice(
         "connection_id": meld_co_and_alice_connection.meld_co_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": meld_co_credential_definition_id,
-            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
+            "attributes": sample_credential_attributes,
         },
     }
 

--- a/app/tests/util/credentials.py
+++ b/app/tests/util/credentials.py
@@ -74,7 +74,7 @@ async def meld_co_issue_credential_to_alice(
         "connection_id": meld_co_and_alice_connection.meld_co_connection_id,
         "indy_credential_detail": {
             "credential_definition_id": meld_co_credential_definition_id,
-            "attributes": {"speed": "10"},
+            "attributes": {"speed": "10", "name": "Alice", "age": "44"},
         },
     }
 
@@ -128,7 +128,7 @@ async def issue_alice_creds_and_revoke_unpublished(
             "save_exchange_record": True,
             "indy_credential_detail": {
                 "credential_definition_id": credential_definition_id_revocable,
-                "attributes": {"speed": str(i)},
+                "attributes": {"speed": str(i), "name": "Alice", "age": "44"},
             },
         }
 

--- a/app/tests/util/definitions.py
+++ b/app/tests/util/definitions.py
@@ -22,7 +22,9 @@ async def schema_definition(
     mock_governance_auth: AcaPyAuthVerified,
 ) -> CredentialSchema:
     definition = CreateSchema(
-        name="test_schema", version=random_version(), attribute_names=["speed"]
+        name="test_schema",
+        version=random_version(),
+        attribute_names=["speed", "name", "age"],
     )
 
     schema_definition_result = await create_schema(definition, mock_governance_auth)

--- a/app/tests/util/definitions.py
+++ b/app/tests/util/definitions.py
@@ -37,7 +37,9 @@ async def schema_definition_alt(
     mock_governance_auth: AcaPyAuthVerified,
 ) -> CredentialSchema:
     definition = CreateSchema(
-        name="test_schema_alt", version=random_version(), attribute_names=["speed"]
+        name="test_schema_alt",
+        version=random_version(),
+        attribute_names=["speed", "name", "age"],
     )
 
     schema_definition_result = await create_schema(definition, mock_governance_auth)

--- a/app/tests/util/verifier.py
+++ b/app/tests/util/verifier.py
@@ -1,0 +1,14 @@
+from typing import Any, Dict
+
+from app.routes.verifier import router as verifier_router
+from shared.util.rich_async_client import RichAsyncClient
+
+VERIFIER_BASE_PATH = verifier_router.prefix
+
+
+async def send_proof_request(client: RichAsyncClient, json_body: Dict[str, Any]):
+    response = await client.post(
+        VERIFIER_BASE_PATH + "/send-request",
+        json=json_body,
+    )
+    return response.json()


### PR DESCRIPTION
Our e2e tests in `app/tests/e2e/verifier/test_verifier.py` could benefit from deduplication -- namely parametrizing by protocol version, so we don't have separate tests for v1 and v2.