### PR TITLE
Definitions swagger update

### DIFF
--- a/app/models/definitions.py
+++ b/app/models/definitions.py
@@ -25,11 +25,11 @@ class CredentialDefinition(BaseModel):
 class CreateSchema(BaseModel):
     name: str = Field(..., examples=["test_schema"])
     version: str = Field(..., examples=["0.3.0"])
-    attribute_names: List[str] = Field(..., examples=[["speed"]])
+    attribute_names: List[str] = Field(..., examples=[["name", "age"]])
 
 
 class CredentialSchema(BaseModel):
     id: str = Field(..., examples=["CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3"])
     name: str = Field(..., examples=["test_schema"])
     version: str = Field(..., examples=["0.3.0"])
-    attribute_names: List[str] = Field(..., examples=[["speed"]])
+    attribute_names: List[str] = Field(..., examples=[["name", "age"]])

--- a/app/models/definitions.py
+++ b/app/models/definitions.py
@@ -4,16 +4,9 @@ from pydantic import BaseModel, Field
 
 
 class CreateCredentialDefinition(BaseModel):
-    tag: str = Field(..., examples=["default"])
     schema_id: str = Field(..., examples=["CXQseFxV34pcb8vf32XhEa:2:test_schema:0.3"])
+    tag: str = Field(..., examples=["default"])
     support_revocation: bool = Field(default=False)
-    revocation_registry_size: int = Field(
-        default=32767,
-        description=(
-            "If revocation support is requested, this specifies the maximum number of "
-            "revocations to be stored by the registry. Default value is equal to the maximum: 32767."
-        ),
-    )
 
 
 class CredentialDefinition(BaseModel):

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -62,9 +62,11 @@ async def create_credential_definition(
     ---
     Only issuers can create credential definitions.
 
-    If revocation is requested ("support_revocation": true), revocation registries will be created.
+    A credential definition essentially builds off a schema, which defines the attributes that can belong to a
+    credential, and it just specifies whether credentials using this definition are revocable or not.
 
-    **NB**: The creation of these revocation registries can take up to one minute.
+    **NB**: If revocation is requested (`"support_revocation": true`), then revocation registries will be created.
+    The creation of these revocation registries can take up to one minute.
 
     Request Body:
     ---
@@ -245,8 +247,8 @@ async def get_credential_definitions(
     """
     Get credential definitions created by the tenant
     ---
-    This endpoint returns all credential definitions created by the tenant.
-    Remember only issuers can create credential definitions.
+    This endpoint returns all credential definitions created by the tenant. Only issuers can create
+    credential definitions, and so only issuers will get results from this endpoint.
 
     The results can be filtered by the parameters listed below.
 
@@ -339,7 +341,10 @@ async def get_credential_definition_by_id(
     """
     Get credential definition by id
     ---
-    This endpoint returns a credential definition by id.
+    This endpoint returns information for a credential definition.
+
+    Anyone can call this, whether they created the requested credential definition or not.
+    Practically it will just reveal the schema that was used for the credential definition.
 
     Parameters:
     ---
@@ -398,7 +403,7 @@ async def create_schema(
     """
     Create a new schema
     ---
-    This endpoint creates a new schema.
+    This endpoint creates and publishes a new schema to the ledger.
     Only tenants with the governance role can create schemas.
 
     Request Body:

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -59,7 +59,7 @@ async def get_credential_definitions(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[CredentialDefinition]:
     """
-    Get credential definitions created by the tenant.
+    Get credential definitions created by the tenant
     ---
     This endpoint returns all credential definitions created by the tenant.
     Remember only issuers can create credential definitions.
@@ -151,7 +151,7 @@ async def get_credential_definition_by_id(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> CredentialDefinition:
     """
-    Get credential definition by id.
+    Get credential definition by id
     ---
     This endpoint returns a credential definition by id.
 
@@ -209,7 +209,7 @@ async def create_credential_definition(
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
 ) -> CredentialDefinition:
     """
-    Create a credential definition.
+    Create a credential definition
     ---
     Only issuers can create credential definitions.
 
@@ -399,7 +399,7 @@ async def get_schemas(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[CredentialSchema]:
     """
-    Get schemas created by the tenant.
+    Get schemas created by the tenant
     ---
     Remember only tenants with the governance role can create schemas,
     i.e. only tenants with the governance role will get a non-empty response.
@@ -483,7 +483,7 @@ async def get_schema(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> CredentialSchema:
     """
-    Retrieve schema by id.
+    Retrieve schema by id
     ---
     This endpoint returns a schema by id.
 
@@ -526,7 +526,7 @@ async def create_schema(
     governance_auth: AcaPyAuthVerified = Depends(acapy_auth_governance),
 ) -> CredentialSchema:
     """
-    Create a new schema.
+    Create a new schema
     ---
     This endpoint creates a new schema.
     Only tenants with the governance role can create schemas.

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -66,17 +66,18 @@ async def get_credential_definitions(
 
     The results can be filtered by the parameters listed below.
 
-    Parameters:
+    Parameters (Optional):
     ---
-        issuer_did: Optional[str]
-        credential_definition_id: Optional[str]
-        schema_id: Optional[str]
-        schema_issuer_id: Optional[str]
-        schema_version: Optional[str]
+        issuer_did: str
+        credential_definition_id: str
+        schema_id: str
+        schema_issuer_id: str
+        schema_version: str
 
     Returns:
     ---
-        Created credential definitions
+        List[CredentialDefinition]
+            A list of created credential definitions
     """
     bound_logger = logger.bind(
         body={
@@ -159,6 +160,10 @@ async def get_credential_definition_by_id(
         credential_definition_id: str
             credential definition id
 
+    Returns:
+    ---
+        CredentialDefinition
+            The credential definition
     """
     bound_logger = logger.bind(
         body={"credential_definition_id": credential_definition_id}
@@ -231,7 +236,8 @@ async def create_credential_definition(
         }
     Returns:
     ---
-        Credential Definition
+        CredentialDefinition
+            The created credential definition
     """
     bound_logger = logger.bind(
         body={
@@ -400,16 +406,17 @@ async def get_schemas(
 
     Results can be filtered by the parameters listed below.
 
-    Parameters:
+    Parameters (Optional):
     ---
-        schema_id: str (Optional)
-        schema_issuer_did: str (Optional)
-        schema_name: str (Optional)
-        schema_version: str (Optional)
+        schema_id: str
+        schema_issuer_did: str
+        schema_name: str
+        schema_version: str
 
     Returns:
     ---
-        Credential Schemas: list
+        List[CredentialSchema]
+            A list of created schemas
     """
     bound_logger = logger.bind(
         body={
@@ -490,8 +497,8 @@ async def get_schema(
 
     Returns:
     ---
-        Credential Schema
-
+        CredentialSchema
+            The schema object
     """
     bound_logger = logger.bind(body={"schema_id": schema_id})
     bound_logger.info("GET request received: Get schema by id")
@@ -537,6 +544,7 @@ async def create_schema(
     Returns:
     ---
         CredentialSchema
+            The created schema object
     """
     bound_logger = logger.bind(body=schema)
     bound_logger.info("POST request received: Create schema (publish and register)")

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -60,7 +60,7 @@ async def get_credential_definitions(
 ) -> List[CredentialDefinition]:
     """
     Get credential definitions created by the tenant.
-    ------------------------------------------------
+    ---
     This endpoint returns all credential definitions created by the tenant.
     Remember only issuers can create credential definitions.
 
@@ -151,11 +151,11 @@ async def get_credential_definition_by_id(
 ) -> CredentialDefinition:
     """
     Get credential definition by id.
-    ---------------------------------
+    ---
     This endpoint returns a credential definition by id.
 
     Parameters:
-    -----------
+    ---
         credential_definition_id: str
             credential definition id
 
@@ -205,7 +205,7 @@ async def create_credential_definition(
 ) -> CredentialDefinition:
     """
     Create a credential definition.
-    -------------------------------
+    ---
     Only issuers can create credential definitions.
 
     If revocation is supported ("support_revocation": true), revocation registries will be created.
@@ -216,7 +216,7 @@ async def create_credential_definition(
     as this will allow for minimal ledger writes (lower cost).
 
     Request Body:
-    -----------
+    ---
         body: CreateCredentialDefinition
             Payload for creating a credential definition.
         {
@@ -230,7 +230,7 @@ async def create_credential_definition(
                 The maximum number of revocations to be stored by the registry.
         }
     Returns:
-    --------
+    ---
         Credential Definition
     """
     bound_logger = logger.bind(
@@ -394,21 +394,21 @@ async def get_schemas(
 ) -> List[CredentialSchema]:
     """
     Get schemas created by the tenant.
-    -----------------------------------
+    ---
     Remember only tenants with the governance role can create schemas,
     i.e. only tenants with the governance role will get a non-empty response.
 
     Results can be filtered by the parameters listed below.
 
     Parameters:
-    -----------
+    ---
         schema_id: str (Optional)
         schema_issuer_did: str (Optional)
         schema_name: str (Optional)
         schema_version: str (Optional)
 
     Returns:
-    --------
+    ---
         Credential Schemas: list
     """
     bound_logger = logger.bind(
@@ -477,19 +477,19 @@ async def get_schema(
 ) -> CredentialSchema:
     """
     Retrieve schema by id.
-    ----------------------
+    ---
     This endpoint returns a schema by id.
 
     Any tenant can call this endpoint to retrieve a schema.
     This endpoint will list all the attributes of the schema.
 
     Parameters:
-    -----------
+    ---
         schema_id: str
             schema id
 
     Returns:
-    --------
+    ---
         Credential Schema
 
     """
@@ -520,12 +520,12 @@ async def create_schema(
 ) -> CredentialSchema:
     """
     Create a new schema.
-    --------------------
+    ---
     This endpoint creates a new schema.
     Only tenants with the governance role can create schemas.
 
     Request Body:
-    ------------
+    ---
         body: CreateSchema
             name: str
                 The name of the schema.
@@ -535,8 +535,8 @@ async def create_schema(
                 The attribute names of the schema.
 
     Returns:
-    --------
-        Credential Schema
+    ---
+        CredentialSchema
     """
     bound_logger = logger.bind(body=schema)
     bound_logger.info("POST request received: Create schema (publish and register)")

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -207,7 +207,7 @@ async def create_credential_definition(
     Create a credential definition.
     -------------------------------
     Only issuers can create credential definitions.
-    
+
     If revocation is supported ("support_revocation": true), revocation registries will be created.
 
     **NB**: The creation of these revocation registries can take up to one minute.

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -63,7 +63,7 @@ async def create_credential_definition(
     Only issuers can create credential definitions.
 
     A credential definition essentially builds off a schema, which defines the attributes that can belong to a
-    credential, and it just specifies whether credentials using this definition are revocable or not.
+    credential, and it specifies whether credentials using this definition are revocable or not.
 
     **NB**: If revocation is requested (`"support_revocation": true`), then revocation registries will be created.
     The creation of these revocation registries can take up to one minute.
@@ -401,10 +401,15 @@ async def create_schema(
     governance_auth: AcaPyAuthVerified = Depends(acapy_auth_governance),
 ) -> CredentialSchema:
     """
-    Create a new schema
+    Create and publish a new schema to the ledger
     ---
-    This endpoint creates and publishes a new schema to the ledger.
-    Only tenants with the governance role can create schemas.
+    **NB**: Only governance can create schemas.
+
+    A schema is used to create credential definitions, which is used for issuing credentials.
+    The schema defines the attributes that can exist in that credential.
+
+    When a schema is created, it is published to the ledger and written to our public trust registry,
+    so that everyone in the ecosystem can view schemas that are valid and available.
 
     Request Body:
     ---
@@ -569,10 +574,16 @@ async def get_schemas(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[CredentialSchema]:
     """
-    Get schemas created by the tenant
+    Get created schemas
     ---
-    Remember only tenants with the governance role can create schemas,
-    i.e. only tenants with the governance role will get a non-empty response.
+    All tenants can call this endpoint to view available schemas.
+
+    If governance calls this endpoint, it will return all the schemas created by governance
+    (whether the schemas are on the trust registry or not).
+
+    If tenants call this endpoint, it will return all schemas on the trust registry.
+    The difference between this endpoint and the public trust registry endpoint, is that this response includes
+    the attribute information of the schemas.
 
     Results can be filtered by the parameters listed below.
 
@@ -657,7 +668,7 @@ async def get_schema(
     """
     Retrieve schema by id
     ---
-    This endpoint returns a schema by id.
+    This endpoint fetches a schema from the ledger, using the schema_id.
 
     Any tenant can call this endpoint to retrieve a schema.
     This endpoint will list all the attributes of the schema.

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -215,11 +215,11 @@ async def create_credential_definition(
     It is recommended to use the max (default) revocation registry size of 32767,
     as this will allow for minimal ledger writes (lower cost).
 
-    Parameters:
+    Request Body:
     -----------
         body: CreateCredentialDefinition
             Payload for creating a credential definition.
-
+        {
             tag: str
                 The tag of the credential definition.
             schema_id: str
@@ -228,7 +228,7 @@ async def create_credential_definition(
                 Whether the credential definition should support revocation.
             revocation_registry_size: int
                 The maximum number of revocations to be stored by the registry.
-
+        }
     Returns:
     --------
         Credential Definition
@@ -395,7 +395,8 @@ async def get_schemas(
     """
     Get schemas created by the tenant.
     -----------------------------------
-    Remember only tenants with the governance role can create schemas.
+    Remember only tenants with the governance role can create schemas,
+    i.e. only tenants with the governance role will get a non-empty response.
 
     Results can be filtered by the parameters listed below.
 
@@ -467,7 +468,9 @@ async def get_schemas(
     return schemas
 
 
-@router.get("/schemas/{schema_id}", response_model=CredentialSchema)
+@router.get(
+    "/schemas/{schema_id}", response_model=CredentialSchema, summary="Get Schema By Id"
+)
 async def get_schema(
     schema_id: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
@@ -478,6 +481,7 @@ async def get_schema(
     This endpoint returns a schema by id.
 
     Any tenant can call this endpoint to retrieve a schema.
+    This endpoint will list all the attributes of the schema.
 
     Parameters:
     -----------
@@ -520,7 +524,7 @@ async def create_schema(
     This endpoint creates a new schema.
     Only tenants with the governance role can create schemas.
 
-    Parameters:
+    Request Body:
     ------------
         body: CreateSchema
             name: str

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -59,7 +59,12 @@ async def get_credential_definitions(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[CredentialDefinition]:
     """
-        Get agent-created credential definitions
+    Get credential definitions created by the tenant.
+    ------------------------------------------------
+    This endpoint returns all credential definitions created by the tenant.
+    Remember only issuers can create credential definitions.
+
+    The results can be filtered by the parameters listed below.
 
     Parameters:
     ---
@@ -145,7 +150,9 @@ async def get_credential_definition_by_id(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> CredentialDefinition:
     """
-        Get credential definition by id.
+    Get credential definition by id.
+    ---------------------------------
+    This endpoint returns a credential definition by id.
 
     Parameters:
     -----------
@@ -198,7 +205,9 @@ async def create_credential_definition(
 ) -> CredentialDefinition:
     """
     Create a credential definition.
-
+    -------------------------------
+    Only issuers can create credential definitions.
+    
     If revocation is supported ("support_revocation": true), revocation registries will be created.
 
     **NB**: The creation of these revocation registries can take up to one minute.
@@ -208,8 +217,17 @@ async def create_credential_definition(
 
     Parameters:
     -----------
-        credential_definition: CreateCredentialDefinition
+        body: CreateCredentialDefinition
             Payload for creating a credential definition.
+
+            tag: str
+                The tag of the credential definition.
+            schema_id: str
+                The schema id of schema used to create credential definition against.
+            support_revocation: bool
+                Whether the credential definition should support revocation.
+            revocation_registry_size: int
+                The maximum number of revocations to be stored by the registry.
 
     Returns:
     --------
@@ -375,7 +393,11 @@ async def get_schemas(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[CredentialSchema]:
     """
-        Retrieve schemas that the current agent created.
+    Get schemas created by the tenant.
+    -----------------------------------
+    Remember only tenants with the governance role can create schemas.
+
+    Results can be filtered by the parameters listed below.
 
     Parameters:
     -----------
@@ -386,7 +408,7 @@ async def get_schemas(
 
     Returns:
     --------
-        son response with created schemas from ledger.
+        Credential Schemas: list
     """
     bound_logger = logger.bind(
         body={
@@ -451,12 +473,21 @@ async def get_schema(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> CredentialSchema:
     """
-        Retrieve schema by id.
+    Retrieve schema by id.
+    ----------------------
+    This endpoint returns a schema by id.
+
+    Any tenant can call this endpoint to retrieve a schema.
 
     Parameters:
     -----------
         schema_id: str
             schema id
+
+    Returns:
+    --------
+        Credential Schema
+
     """
     bound_logger = logger.bind(body={"schema_id": schema_id})
     bound_logger.info("GET request received: Get schema by id")
@@ -484,16 +515,24 @@ async def create_schema(
     governance_auth: AcaPyAuthVerified = Depends(acapy_auth_governance),
 ) -> CredentialSchema:
     """
-        Create a new schema.
+    Create a new schema.
+    --------------------
+    This endpoint creates a new schema.
+    Only tenants with the governance role can create schemas.
 
     Parameters:
     ------------
-        schema: CreateSchema
-            Payload for creating a schema.
+        body: CreateSchema
+            name: str
+                The name of the schema.
+            version: str
+                The version of the schema.
+            attribute_names: List[str]
+                The attribute names of the schema.
 
     Returns:
     --------
-        The response object from creating a schema.
+        Credential Schema
     """
     bound_logger = logger.bind(body=schema)
     bound_logger.info("POST request received: Create schema (publish and register)")

--- a/app/routes/definitions.py
+++ b/app/routes/definitions.py
@@ -48,7 +48,11 @@ router = APIRouter(
 )
 
 
-@router.get("/credentials", response_model=List[CredentialDefinition])
+@router.get(
+    "/credentials",
+    summary="Get Created Credential Definitions",
+    response_model=List[CredentialDefinition],
+)
 async def get_credential_definitions(
     issuer_did: Optional[str] = None,
     credential_definition_id: Optional[str] = None,
@@ -144,7 +148,9 @@ async def get_credential_definitions(
 
 
 @router.get(
-    "/credentials/{credential_definition_id}", response_model=CredentialDefinition
+    "/credentials/{credential_definition_id}",
+    summary="Get a Credential Definition",
+    response_model=CredentialDefinition,
 )
 async def get_credential_definition_by_id(
     credential_definition_id: str,
@@ -203,7 +209,11 @@ async def get_credential_definition_by_id(
     return cloudapi_credential_definition
 
 
-@router.post("/credentials", response_model=CredentialDefinition)
+@router.post(
+    "/credentials",
+    summary="Create a new Credential Definition",
+    response_model=CredentialDefinition,
+)
 async def create_credential_definition(
     credential_definition: CreateCredentialDefinition,
     auth: AcaPyAuthVerified = Depends(acapy_auth_verified),
@@ -390,7 +400,11 @@ async def create_credential_definition(
     return result
 
 
-@router.get("/schemas", response_model=List[CredentialSchema])
+@router.get(
+    "/schemas",
+    summary="Get Created Schemas",
+    response_model=List[CredentialSchema],
+)
 async def get_schemas(
     schema_id: Optional[str] = None,
     schema_issuer_did: Optional[str] = None,
@@ -476,7 +490,9 @@ async def get_schemas(
 
 
 @router.get(
-    "/schemas/{schema_id}", response_model=CredentialSchema, summary="Get Schema By Id"
+    "/schemas/{schema_id}",
+    summary="Get Schema By Id",
+    response_model=CredentialSchema,
 )
 async def get_schema(
     schema_id: str,

--- a/app/services/revocation_registry.py
+++ b/app/services/revocation_registry.py
@@ -437,7 +437,7 @@ async def wait_for_active_registry(
     active_registries = []
     sleep_duration = 0  # First sleep should be 0
 
-    while len(active_registries) < 2:
+    while len(active_registries) < 1:  # We need one of the two registries to be ready
         await asyncio.sleep(sleep_duration)
         active_registries = await get_created_active_registries(controller, cred_def_id)
         sleep_duration = 0.5  # Following sleeps should wait 0.5s before retry

--- a/app/tests/e2e/test_definitions.py
+++ b/app/tests/e2e/test_definitions.py
@@ -204,6 +204,6 @@ async def test_create_credential_definition_issuer_tenant(
             )
         ).rev_reg_ids
 
-        # There should be two revocation registries,
+        # There should be two revocation registries, assert at least one exists
         # one being used to issue credentials against and once full with to the next one
-        assert len(revocation_registries) == 2
+        assert len(revocation_registries) >= 1


### PR DESCRIPTION
Update docstrings

:sparkles: modifies the get schemas route to return schemas from trust registry when regular tenants call the endpoint (previously only governance would ever get a result from get_schemas)

:sparkles: now only waits for one active registry to be created, for a revocable cred def to be complete, instead of waiting for both of them

:boom: no longer allows clients to customise the revocation registry size (will always default to max value)