### PR TITLE
:sparkles: Don't delete the credential when deleting credential exchange record

### DIFF
--- a/app/services/issuer/acapy_issuer_v1.py
+++ b/app/services/issuer/acapy_issuer_v1.py
@@ -165,29 +165,13 @@ class IssuerV1(Issuer):
         bound_logger.debug("Get credential id without version")
         credential_exchange_id = cred_id_no_version(credential_exchange_id)
 
-        bound_logger.debug("Getting v1 credential record")
-        record = await handle_acapy_call(
-            logger=bound_logger,
-            acapy_call=controller.issue_credential_v1_0.get_record,
-            cred_ex_id=credential_exchange_id,
-        )
-
         bound_logger.debug("Deleting v1 credential record")
         await handle_acapy_call(
             logger=bound_logger,
             acapy_call=controller.issue_credential_v1_0.delete_record,
             cred_ex_id=credential_exchange_id,
         )
-
-        # also delete indy credential
-        if record.credential_id:
-            bound_logger.debug("Deleting indy credential")
-            await handle_acapy_call(
-                logger=bound_logger,
-                acapy_call=controller.credentials.delete_record,
-                credential_id=record.credential_id,
-            )
-        bound_logger.debug("Successfully deleted credential.")
+        bound_logger.debug("Successfully deleted credential record.")
 
     @classmethod
     async def get_records(

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -187,29 +187,13 @@ class IssuerV2(Issuer):
         bound_logger.debug("Get credential id without version")
         credential_exchange_id = cred_id_no_version(credential_exchange_id)
 
-        bound_logger.debug("Getting v2 credential record")
-        record = await handle_acapy_call(
-            logger=bound_logger,
-            acapy_call=controller.issue_credential_v2_0.get_record,
-            cred_ex_id=credential_exchange_id,
-        )
-
         bound_logger.debug("Deleting v2 credential record")
         await handle_acapy_call(
             logger=bound_logger,
             acapy_call=controller.issue_credential_v2_0.delete_record,
             cred_ex_id=credential_exchange_id,
         )
-
-        # also delete indy credential
-        if record.indy and record.indy.cred_id_stored:
-            bound_logger.debug("Deleting indy credential")
-            await handle_acapy_call(
-                logger=bound_logger,
-                acapy_call=controller.credentials.delete_record,
-                credential_id=record.indy.cred_id_stored,
-            )
-        bound_logger.debug("Successfully deleted credential.")
+        bound_logger.debug("Successfully deleted credential record.")
 
     @classmethod
     async def get_records(

--- a/app/tests/services/issuer/test_acapy_issuer_v1.py
+++ b/app/tests/services/issuer/test_acapy_issuer_v1.py
@@ -118,40 +118,16 @@ async def test_get_record(mock_agent_controller: AcaPyClient):
 
 
 @pytest.mark.anyio
-async def test_delete_credential_exchange_with_credential(
+async def test_delete_credential_exchange(
     mock_agent_controller: AcaPyClient,
 ):
     with_credential_id = v1_credential_exchange_records[1]
-
-    when(mock_agent_controller.issue_credential_v1_0).get_record(
-        cred_ex_id=with_credential_id.credential_exchange_id
-    ).thenReturn(to_async(with_credential_id))
     when(mock_agent_controller.issue_credential_v1_0).delete_record(
         cred_ex_id=with_credential_id.credential_exchange_id
-    ).thenReturn(to_async())
-    when(mock_agent_controller.credentials).delete_record(
-        credential_id=with_credential_id.credential_id
     ).thenReturn(to_async())
     await IssuerV1.delete_credential_exchange_record(
         mock_agent_controller,
         credential_exchange_id=with_credential_id.credential_exchange_id,
-    )
-
-
-@pytest.mark.anyio
-async def test_delete_credential_exchange_without_credential(
-    mock_agent_controller: AcaPyClient,
-):
-    without_credential_id = v1_credential_exchange_records[0]
-    when(mock_agent_controller.issue_credential_v1_0).get_record(
-        cred_ex_id=without_credential_id.credential_exchange_id
-    ).thenReturn(to_async(without_credential_id))
-    when(mock_agent_controller.issue_credential_v1_0).delete_record(
-        cred_ex_id=without_credential_id.credential_exchange_id
-    ).thenReturn(to_async())
-    await IssuerV1.delete_credential_exchange_record(
-        mock_agent_controller,
-        credential_exchange_id=without_credential_id.credential_exchange_id,
     )
 
 

--- a/app/tests/services/issuer/test_acapy_issuer_v2.py
+++ b/app/tests/services/issuer/test_acapy_issuer_v2.py
@@ -149,40 +149,17 @@ async def test_get_record(mock_agent_controller: AcaPyClient):
 
 
 @pytest.mark.anyio
-async def test_delete_credential_exchange_with_credential(
+async def test_delete_credential_exchange(
     mock_agent_controller: AcaPyClient,
 ):
     with_credential_id = v2_credential_exchange_records[1]
 
-    when(mock_agent_controller.issue_credential_v2_0).get_record(
-        cred_ex_id=with_credential_id.cred_ex_record.cred_ex_id
-    ).thenReturn(to_async(with_credential_id))
     when(mock_agent_controller.issue_credential_v2_0).delete_record(
         cred_ex_id=with_credential_id.cred_ex_record.cred_ex_id
-    ).thenReturn(to_async())
-    when(mock_agent_controller.credentials).delete_record(
-        credential_id=with_credential_id.indy.cred_id_stored
     ).thenReturn(to_async())
     await IssuerV2.delete_credential_exchange_record(
         mock_agent_controller,
         credential_exchange_id=with_credential_id.cred_ex_record.cred_ex_id,
-    )
-
-
-@pytest.mark.anyio
-async def test_delete_credential_exchange_without_credential(
-    mock_agent_controller: AcaPyClient,
-):
-    without_credential_id = v2_credential_exchange_records[0]
-    when(mock_agent_controller.issue_credential_v2_0).get_record(
-        cred_ex_id=without_credential_id.cred_ex_record.cred_ex_id
-    ).thenReturn(to_async(without_credential_id))
-    when(mock_agent_controller.issue_credential_v2_0).delete_record(
-        cred_ex_id=without_credential_id.cred_ex_record.cred_ex_id
-    ).thenReturn(to_async())
-    await IssuerV2.delete_credential_exchange_record(
-        mock_agent_controller,
-        credential_exchange_id=without_credential_id.cred_ex_record.cred_ex_id,
     )
 
 


### PR DESCRIPTION
It appears that the initial implementation of deleting a credential exchange record, would go the extra mile and also delete the credential from the wallet. This is a bit an over-eager thing to do if you ask me. Exchange records do not represent the credential itself. So deleting the exchange record should not do anything to the credential in your wallet.