### PR TITLE
📝 Update docstrings wallet/dids

### DIFF
--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -1,14 +1,11 @@
+import warnings
 from typing import List, Optional
 
+from aries_cloudcontroller import DIDCreateOptions
 from aries_cloudcontroller.models.indy_cred_info import (
     IndyCredInfo as IndyCredInfoAcaPy,
 )
 from aries_cloudcontroller.models.vc_record import VCRecord as VCRecordAcaPy
-from pydantic import BaseModel, Field
-import warnings
-from typing import Optional
-
-from aries_cloudcontroller import DIDCreateOptions
 from pydantic import BaseModel, Field, StrictStr, model_validator
 from typing_extensions import deprecated
 

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -51,7 +51,7 @@ class CredInfoList(BaseModel):
 
 class DIDCreate(BaseModel):
     method: Optional[StrictStr] = Field(
-        default=None,
+        default="sov",
         description="Method for the requested DID. Supported methods are 'key', 'sov', and any other registered method.",
         examples=["sov", "key", "did:peer:2", "did:peer:4"],
     )

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -54,7 +54,9 @@ class DIDCreate(DIDCreateAcaPy):
 
     method: Optional[StrictStr] = Field(
         default="sov",
-        description="Method for the requested DID. Supported methods are 'sov', `web`, `did:peer:2` or `did:peer:4`.",
+        description=(
+            "Method for the requested DID. Supported methods are 'sov', 'key', 'web', 'did:peer:2', or 'did:peer:4'."
+        ),
         examples=["sov", "key", "web", "did:peer:2", "did:peer:4"],
     )
     options: Optional[DIDCreateOptions] = Field(
@@ -72,10 +74,9 @@ class DIDCreate(DIDCreateAcaPy):
         description="Key type to use for the DID key_pair. Validated with the chosen DID method's supported key types.",
         examples=["ed25519", "bls12381g2"],
     )
-    did: Optional[str] = Field(
+    did: Optional[StrictStr] = Field(
         default=None,
         description="Specify the final value of DID (including `did:<method>:` prefix) if the method supports it.",
-        strict=True,
     )
 
     @model_validator(mode="before")

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -85,15 +85,15 @@ class DIDCreate(DIDCreateAcaPy):
         Priority: If both are provided, new fields take precedence.
         """
 
-        if not values.get("options"):
+        options: dict = values.get("options")
+        if not options:
             values["options"] = {}
             values["options"]["key_type"] = values.get("key_type") or "ed25519"
             values["options"]["did"] = values.get("did")
         else:
-            options: dict = values.get("options")
             if not options.get("key_type"):
                 values["options"]["key_type"] = values.get("key_type") or "ed25519"
             if not options.get("did") and values.get("did"):
-                values["options"]["did"] = values.get("did")
+                values["options"]["did"] = values["did"]
 
         return values

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -55,7 +55,7 @@ class DIDCreate(DIDCreateAcaPy):
     method: Optional[StrictStr] = Field(
         default="sov",
         description="Method for the requested DID. Supported methods are 'sov', `web`, `did:peer:2` or `did:peer:4`.",
-        examples=["sov", "key", "did:peer:2", "did:peer:4"],
+        examples=["sov", "key", "web", "did:peer:2", "did:peer:4"],
     )
     options: Optional[DIDCreateOptions] = Field(
         default=None,

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -85,7 +85,7 @@ class DIDCreate(DIDCreateAcaPy):
         Priority: If both are provided, new fields take precedence.
         """
 
-        if values.get("options") is None:
+        if not values.get("options"):
             values["options"] = {}
             values["options"]["key_type"] = values.get("key_type") or "ed25519"
             values["options"]["did"] = values.get("did")

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -87,7 +87,12 @@ class DIDCreate(DIDCreateAcaPy):
 
         if values.get("options") is None:
             values["options"] = {}
-        values["options"]["key_type"] = values.get("key_type") or "ed25519"
-        values["options"]["did"] = values.get("did")
+            values["options"]["key_type"] = values.get("key_type") or "ed25519"
+            values["options"]["did"] = values.get("did")
+        else:
+            if not values["options"]["key_type"]:
+                values["options"]["key_type"] = values.get("key_type") or "ed25519"
+            if not values["options"].get("did") and values.get("did"):
+                values["options"]["did"] = values.get("did")
 
         return values

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -5,6 +5,12 @@ from aries_cloudcontroller.models.indy_cred_info import (
 )
 from aries_cloudcontroller.models.vc_record import VCRecord as VCRecordAcaPy
 from pydantic import BaseModel, Field
+import warnings
+from typing import Optional
+
+from aries_cloudcontroller import DIDCreateOptions
+from pydantic import BaseModel, Field, StrictStr, model_validator
+from typing_extensions import deprecated
 
 
 class SetDidEndpointRequest(BaseModel):
@@ -41,3 +47,58 @@ class IndyCredInfo(IndyCredInfoAcaPy):
 
 class CredInfoList(BaseModel):
     results: Optional[List[IndyCredInfo]] = None
+
+
+class DIDCreate(BaseModel):
+    method: Optional[StrictStr] = Field(
+        default=None,
+        description="Method for the requested DID. Supported methods are 'key', 'sov', and any other registered method.",
+        examples=["sov", "key", "did:peer:2","did:peer:4"],
+    )
+    options: Optional[DIDCreateOptions] = Field(
+        default=None,
+        deprecated=deprecated("Please use key_type and did fields directly instead."),
+        description="To define a key type and/or a did depending on chosen DID method.",
+        examples=[{"key_type": "ed25519", "did": "did:peer:2"}],
+    )
+    seed: Optional[StrictStr] = Field(
+        default=None,
+        description="Optional seed to use for DID. Must be enabled in configuration before use.",
+    )
+    key_type: Optional[StrictStr] = Field(
+        default="ed25519",
+        description="Key type to use for the DID key_pair. Validated with the chosen DID method's supported key types.",
+        examples=["ed25519", "x25519", "bls12381g1", "bls12381g2", "bls12381g1g2"],
+    )
+    did: Optional[str] = Field(
+        default=None,
+        description="Specify final value of the did (including did:<method>: prefix) if the method supports or requires so.",
+        strict=True,
+    )
+
+    @model_validator(mode="before")
+    def handle_deprecated_options(cls, values: dict) -> dict:
+        """
+        Handle both deprecated options field and new flattened fields.
+        Priority: If both are provided, new fields take precedence.
+        """
+        options = values.get("options")
+
+        if options:
+            warnings.warn(
+                "The 'options' field is deprecated. Please use 'key_type' and 'did' fields directly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+            # Only use options values if new fields are not set
+            if not values.get("key_type") and options.get("key_type"):
+                values["key_type"] = options["key_type"]
+            if not values.get("did") and options.get("did"):
+                values["did"] = options["did"]
+
+        # Default key_type to ed25519 if not provided
+        if not values.get("key_type"):
+            values["key_type"] = "ed25519"
+
+        return values

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -52,7 +52,7 @@ class CredInfoList(BaseModel):
 class DIDCreate(BaseModel):
     method: Optional[StrictStr] = Field(
         default="sov",
-        description="Method for the requested DID. Supported methods are 'key', 'sov', and any other registered method.",
+        description="Method for the requested DID. Supported methods are 'sov', `web`, `did:peer:2` or `did:peer:4`.",
         examples=["sov", "key", "did:peer:2", "did:peer:4"],
     )
     options: Optional[DIDCreateOptions] = Field(
@@ -72,11 +72,12 @@ class DIDCreate(BaseModel):
     )
     did: Optional[str] = Field(
         default=None,
-        description="Specify final value of the did (including did:<method>: prefix) if the method supports or requires so.",
+        description="Specify final value of did (including did:<method>: prefix) if the method supports/requires it.",
         strict=True,
     )
 
     @model_validator(mode="before")
+    @classmethod
     def handle_deprecated_options(cls, values: dict) -> dict:
         """
         Handle both deprecated options field and new flattened fields.

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -53,7 +53,7 @@ class DIDCreate(BaseModel):
     method: Optional[StrictStr] = Field(
         default=None,
         description="Method for the requested DID. Supported methods are 'key', 'sov', and any other registered method.",
-        examples=["sov", "key", "did:peer:2","did:peer:4"],
+        examples=["sov", "key", "did:peer:2", "did:peer:4"],
     )
     options: Optional[DIDCreateOptions] = Field(
         default=None,

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -90,9 +90,10 @@ class DIDCreate(DIDCreateAcaPy):
             values["options"]["key_type"] = values.get("key_type") or "ed25519"
             values["options"]["did"] = values.get("did")
         else:
-            if not values["options"]["key_type"]:
+            options: dict = values.get("options")
+            if not options.get("key_type"):
                 values["options"]["key_type"] = values.get("key_type") or "ed25519"
-            if not values["options"].get("did") and values.get("did"):
+            if not options.get("did") and values.get("did"):
                 values["options"]["did"] = values.get("did")
 
         return values

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -57,7 +57,7 @@ async def create_did(
     acapy_did_create = None
     if did_create:
         acapy_did_create = DIDCreateAcaPy(**did_create.model_dump())
-        
+
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Creating DID")
         result = await acapy_wallet.create_did(

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -1,8 +1,6 @@
 from typing import List, Optional
 
-from aries_cloudcontroller import DID
-from aries_cloudcontroller import DIDCreate as AcapyDIDCreate
-from aries_cloudcontroller import DIDEndpoint, DIDEndpointWithType
+from aries_cloudcontroller import DID, DIDEndpoint, DIDEndpointWithType
 from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -40,28 +38,20 @@ async def create_did(
             method: Optional[str]
             options: Optional[DIDCreateOptions]
             seed: Optional[str]
+            key_type: Optional[str]
+            did: Optional[str]
 
     Response:
     ---
         Returns the created DID object.
 
     """
-    logger.debug("POST request received: Create DID")
-    payload = None
-    if did_create:
-        payload = AcapyDIDCreate(
-            method=did_create.method,
-            options={
-                "key_type": did_create.key_type,
-                "did": did_create.did,
-            },
-            seed=did_create.seed,
-        )
+    logger.debug("POST request received: Create DID {}", did_create)
 
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Creating DID")
         result = await acapy_wallet.create_did(
-            did_create=payload, controller=aries_controller
+            did_create=did_create, controller=aries_controller
         )
 
     logger.debug("Successfully created DID.")
@@ -139,8 +129,8 @@ async def set_public_did(
     ---
 
     This endpoint allows you to set the current public DID.
-    The tenant needs a connection with an endorser to make a did public and by default
-    only issuers will have public DIDs and so only issuers can update their public did.
+    The tenant needs an endorser connection to make a DID public.
+    By default, only issuers have public DIDs and can update them.
 
     Request body:
     ---

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -31,12 +31,12 @@ async def create_did(
     ---
 
     This endpoint allows you to create a new DID in the wallet.
-    The `method` parameter is optional and can be set to 'key',
-    'sov', `web`, `did:peer:2` or `did:peer:4`.
+    The `method` parameter is optional and can be set to
+    'sov', 'key', 'web', 'did:peer:2', or 'did:peer:4'.
 
-    The `options` field is deprecated and has been flattened,
-    such that `did` and `key_type` are now top-level fields.
-    The `options` field will still take precedence over the top-level fields if it is present.
+    The `options` field is deprecated and has been flattened, such that `did` and
+    `key_type` are now top-level fields. The `options` field will still
+    take precedence over the top-level fields if it is present.
 
     Request Body:
     ---
@@ -79,7 +79,7 @@ async def list_dids(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[DID]:
     """
-    Retrieve list of DIDs
+    Retrieve List of DIDs
     ---
 
     This endpoint allows you to retrieve a list of DIDs in the wallet.
@@ -109,7 +109,7 @@ async def get_public_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
     """
-    Fetch the current public DID
+    Fetch the Current Public DID
     ---
 
     This endpoint allows you to fetch the current public DID.
@@ -140,12 +140,14 @@ async def set_public_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
     """
-    Set the current public DID
+    Set the Current Public DID
     ---
 
     This endpoint allows you to set the current public DID.
-    The tenant needs an endorser connection to make a DID public.
-    By default, only issuers have public DIDs and can update them.
+
+    **Notes:**
+        - Requires an active endorser connection to make a DID public.
+        - By default, only issuers can have and update public DIDs.
 
     Parameters:
     ---
@@ -171,7 +173,7 @@ async def rotate_keypair(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
     """
-    Rotate key pair for DID
+    Rotate Key Pair for DID
     ---
 
     This endpoint allows you to rotate the key pair for a DID.
@@ -201,7 +203,7 @@ async def get_did_endpoint(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DIDEndpoint:
     """
-    Get DID endpoint
+    Get DID Endpoint
     ---
 
     This endpoint allows you to fetch the endpoint for a DID.
@@ -233,7 +235,7 @@ async def set_did_endpoint(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
     """
-    Update endpoint of DID in wallet (and on ledger, if it is a public DID)
+    Update Endpoint of DID in Wallet (and on Ledger, if it is a Public DID)
     ---
 
     This endpoint allows you to update the endpoint for a DID.
@@ -242,7 +244,7 @@ async def set_did_endpoint(
     ---
         did: str
 
-    Request body:
+    Request Body:
     ---
         SetDidEndpointRequest:
             endpoint: str

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -25,7 +25,7 @@ async def create_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ):
     """
-    Create Local DID.
+    Create Local DID
     ---
 
     This endpoint allows you to create a new DID in the wallet.
@@ -60,7 +60,7 @@ async def list_dids(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[DID]:
     """
-    Retrieve list of DIDs.
+    Retrieve list of DIDs
     ---
 
     This endpoint allows you to retrieve a list of DIDs in the wallet.
@@ -90,7 +90,7 @@ async def get_public_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
     """
-    Fetch the current public DID.
+    Fetch the current public DID
     ---
 
     This endpoint allows you to fetch the current public DID.
@@ -121,7 +121,7 @@ async def set_public_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
     """
-    Set the current public DID.
+    Set the current public DID
     ---
 
     This endpoint allows you to set the current public DID.
@@ -152,7 +152,7 @@ async def rotate_keypair(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
     """
-    Rotate key pair for DID.
+    Rotate key pair for DID
     ---
 
     This endpoint allows you to rotate the key pair for a DID.
@@ -183,7 +183,7 @@ async def get_did_endpoint(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DIDEndpoint:
     """
-    Get DID endpoint.
+    Get DID endpoint
     ---
 
     This endpoint allows you to fetch the endpoint for a DID.
@@ -216,7 +216,7 @@ async def set_did_endpoint(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
     """
-    Update Endpoint in wallet and on ledger if posted to it.
+    Update Endpoint in wallet and on ledger if posted to it
     ---
 
     This endpoint allows you to update the endpoint for a DID.

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
-from aries_cloudcontroller import DID, DIDEndpoint, DIDEndpointWithType
+from aries_cloudcontroller import DID
+from aries_cloudcontroller import DIDCreate as AcapyDIDCreate
+from aries_cloudcontroller import DIDEndpoint, DIDEndpointWithType
 from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -45,14 +47,17 @@ async def create_did(
 
     """
     logger.debug("POST request received: Create DID")
-    payload = {
-        "method": did_create.method,
-        "options": {
-            "key_type": did_create.key_type,
-            "did": did_create.did,
-        },
-        "seed": did_create.seed,
-    }
+    payload = None
+    if did_create:
+        payload = AcapyDIDCreate(
+            method=did_create.method,
+            options={
+                "key_type": did_create.key_type,
+                "did": did_create.did,
+            },
+            seed=did_create.seed,
+        )
+
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Creating DID")
         result = await acapy_wallet.create_did(

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -19,12 +19,30 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/v1/wallet/dids", tags=["wallet"])
 
 
-@router.post("", response_model=DID)
+@router.post("", response_model=DID, summary="Create Local DID")
 async def create_did(
     did_create: Optional[DIDCreate] = None,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ):
-    """Create Local DID."""
+    """
+    Create Local DID.
+    ---
+
+    This endpoint allows you to create a new DID in the wallet.
+    The `method` parameter is optional and can be set to 'key' or 'sov'.
+
+    Request body:
+    ---
+        DIDCreate:
+            method: Optional[str]
+            options: Optional[DIDCreateOptions]
+            seed: Optional[str]
+
+    Response:
+    ---
+        Returns the created DID.
+
+    """
     logger.debug("POST request received: Create DID")
 
     async with client_from_auth(auth) as aries_controller:
@@ -37,12 +55,19 @@ async def create_did(
     return result
 
 
-@router.get("", response_model=List[DID])
+@router.get("", response_model=List[DID], summary="List DIDs")
 async def list_dids(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> List[DID]:
     """
     Retrieve list of DIDs.
+    ---
+
+    This endpoint allows you to retrieve a list of DIDs in the wallet.
+
+    Response:
+    ---
+        Returns a list of DIDs.
     """
     logger.debug("GET request received: Retrieve list of DIDs")
 
@@ -60,12 +85,20 @@ async def list_dids(
     return did_result.results
 
 
-@router.get("/public", response_model=DID)
+@router.get("/public", response_model=DID, summary="Fetch Public DID")
 async def get_public_did(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
     """
     Fetch the current public DID.
+    ---
+
+    This endpoint allows you to fetch the current public DID.
+
+    Response:
+    ---
+        Returns the public DID.
+
     """
     logger.debug("GET request received: Fetch public DID")
 
@@ -82,12 +115,27 @@ async def get_public_did(
     return result.result
 
 
-@router.put("/public", response_model=DID)
+@router.put("/public", response_model=DID, summary="Set Public DID")
 async def set_public_did(
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DID:
-    """Set the current public DID."""
+    """
+    Set the current public DID.
+    ---
+
+    This endpoint allows you to set the current public DID.
+    The tenant needs a connection with the endorser to make a did public.
+
+    Request body:
+    ---
+        did: str
+
+    Response:
+    ---
+        Returns the public DID.
+
+    """
     logger.debug("PUT request received: Set public DID")
 
     async with client_from_auth(auth) as aries_controller:
@@ -98,15 +146,30 @@ async def set_public_did(
     return result
 
 
-@router.patch("/{did}/rotate-keypair", status_code=204)
+@router.patch("/{did}/rotate-keypair", status_code=204, summary="Rotate Key Pair")
 async def rotate_keypair(
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
+    """
+    Rotate key pair for DID.
+    ---
+
+    This endpoint allows you to rotate the key pair for a DID.
+
+    Parameters:
+    ---
+        did: str
+
+    Response:
+    ---
+        204 No Content
+
+    """
     bound_logger = logger.bind(body={"did": did})
     bound_logger.debug("PATCH request received: Rotate keypair for DID")
     async with client_from_auth(auth) as aries_controller:
-        bound_logger.debug("Rotating keypair")
+        bound_logger.debug("Rotating key pair")
         await handle_acapy_call(
             logger=logger, acapy_call=aries_controller.wallet.rotate_keypair, did=did
         )
@@ -114,12 +177,26 @@ async def rotate_keypair(
     bound_logger.debug("Successfully rotated keypair.")
 
 
-@router.get("/{did}/endpoint", response_model=DIDEndpoint)
+@router.get("/{did}/endpoint", response_model=DIDEndpoint, summary="Get DID Endpoint")
 async def get_did_endpoint(
     did: str,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> DIDEndpoint:
-    """Get DID endpoint."""
+    """
+    Get DID endpoint.
+    ---
+
+    This endpoint allows you to fetch the endpoint for a DID.
+
+    Parameters:
+    ---
+        did: str
+
+    Response:
+    ---
+        Returns the endpoint for the DID.
+
+    """
     bound_logger = logger.bind(body={"did": did})
     bound_logger.debug("GET request received: Get endpoint for DID")
     async with client_from_auth(auth) as aries_controller:
@@ -132,13 +209,27 @@ async def get_did_endpoint(
     return result
 
 
-@router.post("/{did}/endpoint", status_code=204)
+@router.post("/{did}/endpoint", status_code=204, summary="Set DID Endpoint")
 async def set_did_endpoint(
     did: str,
     body: SetDidEndpointRequest,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
-    """Update Endpoint in wallet and on ledger if posted to it."""
+    """
+    Update Endpoint in wallet and on ledger if posted to it.
+    ---
+
+    This endpoint allows you to update the endpoint for a DID.
+
+    Parameters:
+    ---
+        did: str
+
+    Request body:
+    ---
+        SetDidEndpointRequest:
+            endpoint: str
+    """
 
     # "Endpoint" type is for making connections using public indy DIDs
     bound_logger = logger.bind(body={"did": did, "body": body})

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from aries_cloudcontroller import DID, DIDCreate, DIDEndpoint, DIDEndpointWithType
+from aries_cloudcontroller import DID, DIDEndpoint, DIDEndpointWithType
 from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -10,7 +10,7 @@ from app.exceptions import (
     handle_acapy_call,
     handle_model_with_validation,
 )
-from app.models.wallet import SetDidEndpointRequest
+from app.models.wallet import DIDCreate, SetDidEndpointRequest
 from app.services import acapy_wallet
 from shared.log_config import get_logger
 

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
-from aries_cloudcontroller import DID, DIDEndpoint, DIDEndpointWithType
+from aries_cloudcontroller import DID
+from aries_cloudcontroller import DIDCreate as DIDCreateAcaPy
+from aries_cloudcontroller import DIDEndpoint, DIDEndpointWithType
 from fastapi import APIRouter, Depends
 
 from app.dependencies.acapy_clients import client_from_auth
@@ -50,12 +52,16 @@ async def create_did(
         Returns the created DID object.
 
     """
-    logger.debug("POST request received: Create DID {}", did_create)
+    logger.debug("POST request received: Create DID")
 
+    acapy_did_create = None
+    if did_create:
+        acapy_did_create = DIDCreateAcaPy(**did_create.model_dump())
+        
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Creating DID")
         result = await acapy_wallet.create_did(
-            did_create=did_create, controller=aries_controller
+            did_create=acapy_did_create, controller=aries_controller
         )
 
     logger.debug("Successfully created DID.")

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -41,11 +41,11 @@ async def create_did(
     Request body:
     ---
         DIDCreate Optional:
-            method: [str]
-            options: [DIDCreateOptions]
-            seed: [str]
-            key_type: [str]
-            did: [str]
+            method: str
+            options: DIDCreateOptions
+            seed: str
+            key_type: str
+            did: str
 
     Response:
     ---
@@ -142,7 +142,7 @@ async def set_public_did(
     The tenant needs an endorser connection to make a DID public.
     By default, only issuers have public DIDs and can update them.
 
-    Request body:
+    Parameters:
     ---
         did: str
 

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -45,11 +45,18 @@ async def create_did(
 
     """
     logger.debug("POST request received: Create DID")
-
+    payload = {
+        "method": did_create.method,
+        "options": {
+            "key_type": did_create.key_type,
+            "did": did_create.did,
+        },
+        "seed": did_create.seed,
+    }
     async with client_from_auth(auth) as aries_controller:
         logger.debug("Creating DID")
         result = await acapy_wallet.create_did(
-            did_create=did_create, controller=aries_controller
+            did_create=payload, controller=aries_controller
         )
 
     logger.debug("Successfully created DID.")

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -32,14 +32,18 @@ async def create_did(
     The `method` parameter is optional and can be set to 'key',
     'sov', `web`, `did:peer:2` or `did:peer:4`.
 
+    The options field is deprecated it has been flattened and the `did` and
+    `key_type` fields are now top level fields. The `options` field will still
+    take precedence over the top level fields if it is present.
+
     Request body:
     ---
-        DIDCreate:
-            method: Optional[str]
-            options: Optional[DIDCreateOptions]
-            seed: Optional[str]
-            key_type: Optional[str]
-            did: Optional[str]
+        DIDCreate Optional:
+            method: [str]
+            options: [DIDCreateOptions]
+            seed: [str]
+            key_type: [str]
+            did: [str]
 
     Response:
     ---

--- a/app/routes/wallet/dids.py
+++ b/app/routes/wallet/dids.py
@@ -23,13 +23,14 @@ router = APIRouter(prefix="/v1/wallet/dids", tags=["wallet"])
 async def create_did(
     did_create: Optional[DIDCreate] = None,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
-):
+) -> DID:
     """
     Create Local DID
     ---
 
     This endpoint allows you to create a new DID in the wallet.
-    The `method` parameter is optional and can be set to 'key' or 'sov'.
+    The `method` parameter is optional and can be set to 'key',
+    'sov', `web`, `did:peer:2` or `did:peer:4`.
 
     Request body:
     ---
@@ -40,7 +41,7 @@ async def create_did(
 
     Response:
     ---
-        Returns the created DID.
+        Returns the created DID object.
 
     """
     logger.debug("POST request received: Create DID")
@@ -67,7 +68,7 @@ async def list_dids(
 
     Response:
     ---
-        Returns a list of DIDs.
+        Returns a list of DID objects.
     """
     logger.debug("GET request received: Retrieve list of DIDs")
 
@@ -94,6 +95,7 @@ async def get_public_did(
     ---
 
     This endpoint allows you to fetch the current public DID.
+    By default, only issuers will have public DIDs.
 
     Response:
     ---
@@ -125,7 +127,8 @@ async def set_public_did(
     ---
 
     This endpoint allows you to set the current public DID.
-    The tenant needs a connection with the endorser to make a did public.
+    The tenant needs a connection with an endorser to make a did public and by default
+    only issuers will have public DIDs and so only issuers can update their public did.
 
     Request body:
     ---
@@ -216,7 +219,7 @@ async def set_did_endpoint(
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> None:
     """
-    Update Endpoint in wallet and on ledger if posted to it
+    Update endpoint of DID in wallet (and on ledger, if it is a public DID)
     ---
 
     This endpoint allows you to update the endpoint for a DID.

--- a/app/tests/routes/wallet/dids/test_create_did.py
+++ b/app/tests/routes/wallet/dids/test_create_did.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aries_cloudcontroller import DIDCreate as AcapyDIDCreate
 from aries_cloudcontroller.exceptions import (
     ApiException,
     BadRequestException,
@@ -19,11 +18,73 @@ from app.routes.wallet.dids import create_did
         (None, None),
         (
             DIDCreate(method="key"),
-            AcapyDIDCreate(method="key", options={"key_type": "ed25519"}),
+            DIDCreate(
+                method="key", options={"key_type": "ed25519"}, key_type="ed25519"
+            ),
         ),
         (
             DIDCreate(method="sov"),
-            AcapyDIDCreate(method="sov", options={"key_type": "ed25519"}),
+            DIDCreate(
+                method="sov", options={"key_type": "ed25519"}, key_type="ed25519"
+            ),
+        ),
+        (
+            DIDCreate(method="did:peer:2"),
+            DIDCreate(
+                method="did:peer:2", options={"key_type": "ed25519"}, key_type="ed25519"
+            ),
+        ),
+        (
+            DIDCreate(method="did:peer:4"),
+            DIDCreate(
+                method="did:peer:4", options={"key_type": "ed25519"}, key_type="ed25519"
+            ),
+        ),
+        (
+            DIDCreate(method="key", key_type="bls12381g2"),
+            DIDCreate(
+                method="key", options={"key_type": "bls12381g2"}, key_type="bls12381g2"
+            ),
+        ),
+        (
+            DIDCreate(method="sov", key_type="bls12381g2"),
+            DIDCreate(
+                method="sov", options={"key_type": "bls12381g2"}, key_type="bls12381g2"
+            ),
+        ),
+        (
+            DIDCreate(method="did:peer:2", key_type="bls12381g2"),
+            DIDCreate(
+                method="did:peer:2",
+                options={"key_type": "bls12381g2"},
+                key_type="bls12381g2",
+            ),
+        ),
+        (
+            DIDCreate(method="did:peer:4", key_type="bls12381g2"),
+            DIDCreate(
+                method="did:peer:4",
+                options={"key_type": "bls12381g2"},
+                key_type="bls12381g2",
+            ),
+        ),
+        (
+            DIDCreate(method="web", did="did:web:1234"),
+            DIDCreate(
+                method="web",
+                options={"key_type": "ed25519", "did": "did:web:1234"},
+                key_type="ed25519",
+                did="did:web:1234",
+            ),
+        ),
+        (
+            DIDCreate(method="web", key_type="bls12381g2", did="did:web:1234"),
+            DIDCreate(
+                method="web",
+                options={"key_type": "bls12381g2", "did": "did:web:1234"},
+                key_type="bls12381g2",
+                did="did:web:1234",
+            ),
         ),
     ],
 )

--- a/app/tests/routes/wallet/dids/test_create_did.py
+++ b/app/tests/routes/wallet/dids/test_create_did.py
@@ -1,7 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from app.models.wallet import DIDCreate
 from aries_cloudcontroller import DIDCreate as AcapyDIDCreate
 from aries_cloudcontroller.exceptions import (
     ApiException,
@@ -9,6 +8,7 @@ from aries_cloudcontroller.exceptions import (
     NotFoundException,
 )
 
+from app.models.wallet import DIDCreate
 from app.routes.wallet.dids import create_did
 
 

--- a/app/tests/routes/wallet/dids/test_create_did.py
+++ b/app/tests/routes/wallet/dids/test_create_did.py
@@ -1,7 +1,8 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aries_cloudcontroller import DIDCreate
+from app.models.wallet import DIDCreate
+from aries_cloudcontroller import DIDCreate as AcapyDIDCreate
 from aries_cloudcontroller.exceptions import (
     ApiException,
     BadRequestException,
@@ -13,9 +14,20 @@ from app.routes.wallet.dids import create_did
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "request_body", [None, DIDCreate(method="key"), DIDCreate(method="sov")]
+    "request_body, create_body",
+    [
+        (None, None),
+        (
+            DIDCreate(method="key"),
+            AcapyDIDCreate(method="key", options={"key_type": "ed25519"}),
+        ),
+        (
+            DIDCreate(method="sov"),
+            AcapyDIDCreate(method="sov", options={"key_type": "ed25519"}),
+        ),
+    ],
 )
-async def test_create_did_success(request_body):
+async def test_create_did_success(request_body, create_body):
     mock_aries_controller = AsyncMock()
     mock_create_did = AsyncMock()
 
@@ -32,7 +44,7 @@ async def test_create_did_success(request_body):
         await create_did(did_create=request_body, auth="mocked_auth")
 
         mock_create_did.assert_awaited_once_with(
-            did_create=request_body, controller=mock_aries_controller
+            did_create=create_body, controller=mock_aries_controller
         )
 
 

--- a/app/tests/routes/wallet/dids/test_create_did.py
+++ b/app/tests/routes/wallet/dids/test_create_did.py
@@ -16,7 +16,10 @@ from app.routes.wallet.dids import create_did
 @pytest.mark.parametrize(
     "request_body, create_body",
     [
-        (None, None),
+        (
+            None,
+            DIDCreateAcaPy(method="sov", options={"key_type": "ed25519"}),
+        ),
         (
             DIDCreate(method="key"),
             DIDCreateAcaPy(

--- a/app/tests/routes/wallet/dids/test_create_did.py
+++ b/app/tests/routes/wallet/dids/test_create_did.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aries_cloudcontroller import DIDCreate as DIDCreateAcaPy
 from aries_cloudcontroller.exceptions import (
     ApiException,
     BadRequestException,
@@ -18,72 +19,72 @@ from app.routes.wallet.dids import create_did
         (None, None),
         (
             DIDCreate(method="key"),
-            DIDCreate(
-                method="key", options={"key_type": "ed25519"}, key_type="ed25519"
+            DIDCreateAcaPy(
+                method="key",
+                options={"key_type": "ed25519"},
             ),
         ),
         (
             DIDCreate(method="sov"),
-            DIDCreate(
-                method="sov", options={"key_type": "ed25519"}, key_type="ed25519"
+            DIDCreateAcaPy(
+                method="sov",
+                options={"key_type": "ed25519"},
             ),
         ),
         (
             DIDCreate(method="did:peer:2"),
-            DIDCreate(
-                method="did:peer:2", options={"key_type": "ed25519"}, key_type="ed25519"
+            DIDCreateAcaPy(
+                method="did:peer:2",
+                options={"key_type": "ed25519"},
             ),
         ),
         (
             DIDCreate(method="did:peer:4"),
-            DIDCreate(
-                method="did:peer:4", options={"key_type": "ed25519"}, key_type="ed25519"
+            DIDCreateAcaPy(
+                method="did:peer:4",
+                options={"key_type": "ed25519"},
             ),
         ),
         (
             DIDCreate(method="key", key_type="bls12381g2"),
-            DIDCreate(
-                method="key", options={"key_type": "bls12381g2"}, key_type="bls12381g2"
+            DIDCreateAcaPy(
+                method="key",
+                options={"key_type": "bls12381g2"},
             ),
         ),
         (
             DIDCreate(method="sov", key_type="bls12381g2"),
-            DIDCreate(
-                method="sov", options={"key_type": "bls12381g2"}, key_type="bls12381g2"
+            DIDCreateAcaPy(
+                method="sov",
+                options={"key_type": "bls12381g2"},
             ),
         ),
         (
             DIDCreate(method="did:peer:2", key_type="bls12381g2"),
-            DIDCreate(
+            DIDCreateAcaPy(
                 method="did:peer:2",
                 options={"key_type": "bls12381g2"},
-                key_type="bls12381g2",
             ),
         ),
         (
             DIDCreate(method="did:peer:4", key_type="bls12381g2"),
-            DIDCreate(
+            DIDCreateAcaPy(
                 method="did:peer:4",
                 options={"key_type": "bls12381g2"},
-                key_type="bls12381g2",
             ),
         ),
         (
             DIDCreate(method="web", did="did:web:1234"),
-            DIDCreate(
+            DIDCreateAcaPy(
                 method="web",
                 options={"key_type": "ed25519", "did": "did:web:1234"},
-                key_type="ed25519",
-                did="did:web:1234",
             ),
         ),
         (
             DIDCreate(method="web", key_type="bls12381g2", did="did:web:1234"),
-            DIDCreate(
+            DIDCreateAcaPy(
                 method="web",
                 options={"key_type": "bls12381g2", "did": "did:web:1234"},
-                key_type="bls12381g2",
-                did="did:web:1234",
             ),
         ),
     ],


### PR DESCRIPTION
Update `wallet/did` docstrings

Create DID endpoint request model now extends AcaPy model, to flatten `options` field. This brings `key_type` and `did` fields up. 

⚠️ Deprecates the `options` field in the DIDCreate request body, and moves the nested `key_type` and `did` fields up one level.