### PR TITLE
:arrow_up: update redis events plugin to latest release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -382,7 +382,7 @@ services:
     #   - -c
     #   - |
     #     pip3 install --no-cache-dir git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@1.0.0rc4
-    #     pip3 install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-07-11#subdirectory=redis_events
+    #     pip3 install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-07-18#subdirectory=redis_events
     #     aca-py start \
     #       -it http "0.0.0.0" "3020" \
     #       -e http://governance-multitenant-agent:3020 \

--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -2,7 +2,7 @@ FROM ghcr.io/hyperledger/aries-cloudagent-python:py3.12-1.0.0rc4
 
 USER root
 # install redis-events plugin
-RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-07-11#subdirectory=redis_events
+RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-07-18#subdirectory=redis_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -6,7 +6,7 @@ USER root
 RUN pip3 install git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@1.0.0rc4
 
 # install redis-events plugin
-RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-07-11#subdirectory=redis_events
+RUN pip3 install git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-07-18#subdirectory=redis_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh


### PR DESCRIPTION
Includes more verbose info logs (https://github.com/didx-xyz/aries-acapy-plugins/pull/419) to debug starting redis cluster with 1 node