### PR TITLE
:white_check_mark: ensure test tenants are deleted upon test failure

### DIFF
--- a/shared/constants.py
+++ b/shared/constants.py
@@ -6,7 +6,7 @@ adminApiKey = "adminApiKey"
 
 # pylint: disable=invalid-name
 
-PROJECT_VERSION = os.getenv("PROJECT_VERSION", "0.12.1")
+PROJECT_VERSION = os.getenv("PROJECT_VERSION", "1.0.0rc4")
 
 # the ACAPY_LABEL field with which the governance agent is initialised
 GOVERNANCE_LABEL = os.getenv("GOVERNANCE_ACAPY_LABEL", "Governance").lower()


### PR DESCRIPTION
Adds try-finally blocks to ensure that tenants are deleted in edge cases where test failure occurs after tenant creation.

also fixes test that breaks when many wallets exist, since the new pagination feature changed the default behaviour.

also bumps the project version to match aca-py: 1.0.0rc4