### PR TITLE
:wrench: Increase default pagination `limit` to 1000 and :white_check_mark: fix regression tests when fetching many records

### DIFF
--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -173,15 +173,14 @@ async def test_send_jsonld_bbs_oob(
 
     await asyncio.sleep(0.5)  # connection may take moment to reflect
 
-    faber_con = await faber_client.get(CONNECTIONS_BASE_PATH)
+    faber_connections_response = await faber_client.get(
+        CONNECTIONS_BASE_PATH, params={"invitation_msg_id": invitation["@id"]}
+    )
+    faber_connections = faber_connections_response.json()
 
-    faber_connections = faber_con.json()
-    faber_connection_id = None
-    for con in faber_connections:
-        if con["invitation_msg_id"] == invitation["@id"]:
-            faber_connection_id = con["connection_id"]
+    assert faber_connections, "The expected faber-alice connection was not returned"
 
-    assert faber_connection_id, "The expected faber-alice connection was not returned"
+    faber_connection_id = faber_connections[0]["connection_id"]
 
     # Updating JSON-LD credential did:key (bbs)
     credential = deepcopy(credential_)

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -171,18 +171,21 @@ async def test_send_jsonld_bbs_oob(
         },
     )
 
+    await asyncio.sleep(0.5)  # connection may take moment to reflect
+
     faber_con = await faber_client.get(CONNECTIONS_BASE_PATH)
 
     faber_connections = faber_con.json()
+    faber_connection_id = None
     for con in faber_connections:
         if con["invitation_msg_id"] == invitation["@id"]:
             faber_connection_id = con["connection_id"]
 
+    assert faber_connection_id, "The expected faber-alice connection was not returned"
+
     # Updating JSON-LD credential did:key (bbs)
     credential = deepcopy(credential_)
-    credential["connection_id"] = (
-        faber_connection_id  # pylint: disable=possibly-used-before-assignment
-    )
+    credential["connection_id"] = faber_connection_id
     credential["ld_credential_detail"]["credential"]["issuer"] = register_issuer_key_bbs
 
     # Send credential

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -154,6 +154,8 @@ async def test_send_jsonld_oob(
     )
 
     oob_record = accept_response.json()
+    assert_that(oob_record).contains("created_at", "oob_id", "invitation")
+
     alice_connection_id = oob_record["connection_id"]
 
     assert await check_webhook_state(
@@ -164,20 +166,22 @@ async def test_send_jsonld_oob(
             "connection_id": alice_connection_id,
         },
     )
-    assert_that(oob_record).contains("created_at", "oob_id", "invitation")
+
+    await asyncio.sleep(0.5)  # connection may take moment to reflect
 
     faber_con = await faber_client.get(CONNECTIONS_BASE_PATH)
 
     faber_connections = faber_con.json()
+    faber_connection_id = None
     for con in faber_connections:
         if con["invitation_msg_id"] == invitation["@id"]:
             faber_connection_id = con["connection_id"]
 
+    assert faber_connection_id, "The expected faber-alice connection was not returned"
+
     # Updating JSON-LD credential did:key with proofType ed25519
     credential = deepcopy(credential_)
-    credential["connection_id"] = (
-        faber_connection_id  # pylint: disable=possibly-used-before-assignment
-    )
+    credential["connection_id"] = faber_connection_id
     credential["ld_credential_detail"]["credential"][
         "issuer"
     ] = register_issuer_key_ed25519

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -169,15 +169,14 @@ async def test_send_jsonld_oob(
 
     await asyncio.sleep(0.5)  # connection may take moment to reflect
 
-    faber_con = await faber_client.get(CONNECTIONS_BASE_PATH)
+    faber_connections_response = await faber_client.get(
+        CONNECTIONS_BASE_PATH, params={"invitation_msg_id": invitation["@id"]}
+    )
+    faber_connections = faber_connections_response.json()
 
-    faber_connections = faber_con.json()
-    faber_connection_id = None
-    for con in faber_connections:
-        if con["invitation_msg_id"] == invitation["@id"]:
-            faber_connection_id = con["connection_id"]
+    assert faber_connections, "The expected faber-alice connection was not returned"
 
-    assert faber_connection_id, "The expected faber-alice connection was not returned"
+    faber_connection_id = faber_connections[0]["connection_id"]
 
     # Updating JSON-LD credential did:key with proofType ed25519
     credential = deepcopy(credential_)

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -159,7 +159,8 @@ async def test_get_cred_exchange_records(
         await asyncio.sleep(0.25)
         alice_cred_ex_response = (
             await alice_member_client.get(
-                CREDENTIALS_BASE_PATH + "?state=offer-received"
+                CREDENTIALS_BASE_PATH,
+                params={"state": "offer-received", "limit": 10000},
             )
         ).json()
 

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -347,7 +347,9 @@ async def test_get_proof_and_get_proofs(
     acme_proof_id_2 = send_proof_response_2["proof_id"]
     thread_id_2 = send_proof_response_2["thread_id"]
 
-    all_verifier_proofs = (await acme_client.get(f"{VERIFIER_BASE_PATH}/proofs")).json()
+    all_verifier_proofs = (
+        await acme_client.get(f"{VERIFIER_BASE_PATH}/proofs", params={"limit": 10000})
+    ).json()
     all_verifier_proofs = [proof["proof_id"] for proof in all_verifier_proofs]
 
     # Make sure both proofs are in the list

--- a/app/util/pagination.py
+++ b/app/util/pagination.py
@@ -2,5 +2,5 @@
 
 from fastapi import Query
 
-limit_query_parameter = Query(100, description="Number of results to return")
+limit_query_parameter = Query(1000, description="Number of results to return")
 offset_query_parameter = Query(0, description="Offset for pagination")


### PR DESCRIPTION
Problem description: 
- some of our long-running tenants (in regression testing) will continue to generate new connection or proof records
- some of our tests try fetch "all records" (defaulting to fetch 100 records at a time, since the pagination feature was merged)
- when more than 100 records exist, some assertions could now fail

Solution: 
- the known failing tests will now fetch with filtering params, where possible, otherwise we fetch with a limit of 10'000.
- Additionally, I've increased the default pagination limit from 100 to 1'000, mainly to allow some more grace before other tests with increasing records may fail. But also because 100 is not that much.

Note:
- this means the problem can still occur if these regression tenants run long enough to generate >10'000 records.
- so, we should review regression tests and see which tests result in indefinitely increasing records, and perhaps implement some cleanup logic to prevent ever-increasing records.