### PR TITLE
Revoc reg size

### DIFF
--- a/app/services/definitions/credential_definitions.py
+++ b/app/services/definitions/credential_definitions.py
@@ -12,6 +12,7 @@ from app.services.trust_registry.util.issuer import assert_valid_issuer
 from app.util.assert_public_did import assert_public_did
 from app.util.definitions import credential_definition_from_acapy
 from app.util.transaction_acked import wait_for_transaction_ack
+from shared import REGISTRY_SIZE
 from shared.log_config import get_logger
 
 logger = get_logger(__name__)
@@ -49,7 +50,7 @@ async def create_credential_definition(
         schema_id=credential_definition.schema_id,
         support_revocation=support_revocation,
         tag=credential_definition.tag,
-        revocation_registry_size=32767,
+        revocation_registry_size=REGISTRY_SIZE,
     )
 
     result = await publisher.publish_credential_definition(request_body)

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -68,6 +68,7 @@ MAX_NUM_RETRIES = int(os.getenv("MAX_NUM_RETRIES", "3"))
 
 # timeout for waiting for registries to be created
 REGISTRY_CREATION_TIMEOUT = int(os.getenv("REGISTRY_CREATION_TIMEOUT", "60"))
+REGISTRY_SIZE = int(os.getenv("REGISTRY_SIZE", "32767"))
 
 # Billing Service
 LAGO_URL = os.getenv("LAGO_URL", "")


### PR DESCRIPTION
Set revocation registry size at runtime overriding default max size of `32767` to provide flexibility during testing.

Revocation registry size of `100` speeds up response times significantly:

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/976b7c01-7f89-4284-a49a-172555e46ec2">
