### PR TITLE
👷  Increase deploy timeout

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -318,7 +318,7 @@ jobs:
       pull-requests: write # Required to comment on PRs for Pytest coverage comment
     runs-on: ubuntu-latest
 
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     env:
       TAILSCALE_VERSION: 1.70.0


### PR DESCRIPTION
On clean start deployment job can take longer than 10 minutes.