### PR TITLE
:adhesive_bandage: Remove `_backfill_events` method from webhooks service startup

### DIFF
--- a/shared/services/redis_service.py
+++ b/shared/services/redis_service.py
@@ -200,7 +200,7 @@ class RedisService:
                     self.logger.trace("No keys found matching pattern in this batch.")
 
                 if all(c == 0 for c in next_cursor.values()):
-                    self.logger.debug("Completed SCAN for pattern: %s", match_pattern)
+                    self.logger.trace("Completed SCAN for pattern: {}", match_pattern)
                     break  # Exit the loop
                 cursor += 1
         except Exception:  # pylint: disable=W0718

--- a/webhooks/services/sse_manager.py
+++ b/webhooks/services/sse_manager.py
@@ -60,8 +60,10 @@ class SseManager:
         Start the background tasks as part of SseManager's lifecycle
         """
         logger.info("Starting SSE Manager background tasks")
+
         # backfill previous events from redis, if any
-        asyncio.create_task(self._backfill_events(), name="Backfill events")
+        # Removing _backfill_events logic for the time being, due to inefficiency
+        # asyncio.create_task(self._backfill_events(), name="Backfill events")
 
         # listen for new events on redis pubsub channel
         self._tasks.append(
@@ -217,6 +219,10 @@ class SseManager:
 
     async def _backfill_events(self) -> None:
         """
+        TODO: This method is very inefficient when many wallets exist.
+        To be refactored, as detailed here:
+        https://github.com/didx-xyz/aries-cloudapi-python/issues/899
+
         Backfill events from Redis that were published within the MAX_EVENT_AGE window.
         """
         logger.info("Start backfilling SSE queue with recent events from redis")

--- a/webhooks/tests/services/test_sse_manager.py
+++ b/webhooks/tests/services/test_sse_manager.py
@@ -40,7 +40,10 @@ def sse_manager(redis_service_mock):  # pylint: disable=redefined-outer-name
 @pytest.mark.anyio
 async def test_start(sse_manager):  # pylint: disable=redefined-outer-name
     # Mock the coroutine methods
-    sse_manager._backfill_events = AsyncMock()
+
+    # Removing _backfill_events logic for the time being, due to inefficiency
+    # sse_manager._backfill_events = AsyncMock()
+
     sse_manager._listen_for_new_events = AsyncMock()
     sse_manager._process_incoming_events = AsyncMock()
     sse_manager._cleanup_cache = AsyncMock()


### PR DESCRIPTION
Backfilling SSE queues with recent events is currently highly inefficient when many wallets exist. Fortunately this is a non-critical feature, and so can just be removed for now. A solution will be implemented as detailed in https://github.com/didx-xyz/aries-cloudapi-python/issues/899