### PR TITLE
🩹 Increase expiry time of redis webhook event locks

### DIFF
--- a/shared/services/redis_service.py
+++ b/shared/services/redis_service.py
@@ -231,7 +231,7 @@ class RedisService:
             lock_key: The Redis key of the lock to extend.
             interval: Timedelta object representing how long to wait before extending the lock again.
         """
-        retry_interval = interval.total_seconds() * 0.9
+        retry_interval = interval.total_seconds() * 0.5
         try:
             while True:
                 await asyncio.sleep(retry_interval)

--- a/webhooks/services/acapy_events_processor.py
+++ b/webhooks/services/acapy_events_processor.py
@@ -191,12 +191,12 @@ class AcaPyEventsProcessor:
         lock_key = f"lock:{list_key}"
         extend_lock_task = None
 
-        lock_duration = 500  # milliseconds
+        lock_duration = 2000  # milliseconds
 
         if self.redis_service.set_lock(lock_key, px=lock_duration):
             try:
                 # Start a background task to extend the lock periodically
-                # This is just to ensure that on the off chance that 500ms isn't enough to process all the
+                # This is just to ensure that on the off chance that 2000ms isn't enough to process all the
                 # events in the list, we want to avoid replicas processing the same webhook event twice
                 extend_lock_task = self.redis_service.extend_lock_task(
                     lock_key, interval=datetime.timedelta(milliseconds=lock_duration)

--- a/webhooks/tests/services/test_acapy_events_processor.py
+++ b/webhooks/tests/services/test_acapy_events_processor.py
@@ -164,7 +164,7 @@ async def test_attempt_process_list_events(acapy_events_processor_mock):
     acapy_events_processor_mock._attempt_process_list_events(event_key)
 
     acapy_events_processor_mock.redis_service.set_lock.assert_called_with(
-        lock_key, px=500
+        lock_key, px=2000
     )
     acapy_events_processor_mock._process_list_events.assert_called_with(event_key)
     acapy_events_processor_mock.redis_service.delete_key.assert_called_with(lock_key)


### PR DESCRIPTION
Increases the expiry time of the ACA-Py webhook event locks from 0.5 to 2 seconds, and increases the frequency of the extend lock task.

Resolves #959