### PR TITLE
:white_check_mark: fix test to work with pytest-xdist

### DIFF
--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -73,9 +73,7 @@ async def test_issue_credential_with_save_exchange_record(
             },
         )
 
-        time.sleep(
-            1
-        )  # short sleep before fetching cred ex records; allow them to update
+        await asyncio.sleep(1)  # short sleep before fetching; allow records to update
 
         # faber requesting auto_remove only removes their cred ex records
         # get exchange record from alice side -- should not exist after complete

--- a/app/tests/e2e/test_wallet_dids.py
+++ b/app/tests/e2e/test_wallet_dids.py
@@ -37,14 +37,23 @@ async def create_did_mock(governance_client: RichAsyncClient):
 async def test_list_dids(
     governance_client: RichAsyncClient, mock_governance_auth: AcaPyAuthVerified
 ):
+    # Capture the existing DIDs before the request
+    initial_dids = await list_dids(auth=mock_governance_auth)
+    initial_dids_set = set(map(lambda x: x.did, initial_dids))
+
+    # Make the GET request
     response = await governance_client.get(WALLET_BASE_PATH)
-
     assert response.status_code == 200
-    response = response.json()
+    response_data = response.json()
 
-    res_method: List[DID] = await list_dids(auth=mock_governance_auth)
-    res_method_dict = list(map(lambda x: x.to_dict(), res_method))
-    assert res_method_dict == response
+    # Filter the response to include only the initial DIDs
+    filtered_response_data = [
+        did_dict for did_dict in response_data if did_dict["did"] in initial_dids_set
+    ]
+
+    # Compare the filtered response with the initial DIDs
+    initial_dids_dict = list(map(lambda x: x.to_dict(), initial_dids))
+    assert filtered_response_data == initial_dids_dict
 
 
 @pytest.mark.anyio

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -646,6 +646,7 @@ async def test_saving_of_presentation_exchange_records(
     assert isinstance(pres_exchange_result, PresentationExchange)
     assert response.status_code == 200
 
+    await asyncio.sleep(1)  # short sleep before fetching records; allow them to update
     # get exchange records from alice side
     if alice_save_exchange_record:
         # Save record is True, should be 1 record

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -630,6 +630,11 @@ async def test_saving_of_presentation_exchange_records(
         VERIFIER_BASE_PATH + "/accept-request",
         json=proof_accept.model_dump(),
     )
+    result = response.json()
+
+    pres_exchange_result = PresentationExchange(**result)
+    assert isinstance(pres_exchange_result, PresentationExchange)
+    assert response.status_code == 200
 
     await assert_both_webhooks_received(
         alice_member_client,
@@ -639,12 +644,6 @@ async def test_saving_of_presentation_exchange_records(
         alice_proof_id,
         acme_proof_id,
     )
-
-    result = response.json()
-
-    pres_exchange_result = PresentationExchange(**result)
-    assert isinstance(pres_exchange_result, PresentationExchange)
-    assert response.status_code == 200
 
     await asyncio.sleep(1)  # short sleep before fetching records; allow them to update
     # get exchange records from alice side


### PR DESCRIPTION
`app/tests/e2e/test_wallet_dids.py::test_list_dids` compares the list_dids HTTP response to a direct call of the method.
When tests are run in parallel with `pytest-xdist`, the results can mismatch if another did was created in the interim.
Instead of removing the assertion, we now compare a filtered result.

Resolves #978 

Edit: includes additional sleep of 1s added to `app/tests/e2e/verifier/test_saving_of_presentation_exchange_records` (known bug - it can take a moment for auto-delete of exchange records to take place), which sporadically came up.