### PR TITLE
🧐 Install Protobuf in Aca-Py Agents

### DIFF
--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -1,8 +1,13 @@
 FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.0.0b1
 
 USER root
-# install redis-events plugin
+
+# Install redis-events plugin
 RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-08-30#subdirectory=redis_events
+
+# Install Google Protobuf
+ARG PROTOBUF_VERSION=5.28.1
+RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION}
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -5,8 +5,12 @@ USER root
 # Install wallet group id plugin
 RUN pip install --no-cache-dir git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@1.0.0b1
 
-# install redis-events plugin
+# Install redis-events plugin
 RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-08-30#subdirectory=redis_events
+
+# Install Google Protobuf
+ARG PROTOBUF_VERSION=5.28.1
+RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION}
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh


### PR DESCRIPTION
DDTrace Profiling complains about missing `google-protobuf` module