### PR TITLE
:construction_worker: Add Style Check for Tiltfiles

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -13,20 +13,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12.4
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12.4
-
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install \
-            isort~=5.13.2 \
-            black~=24.8.0
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+          experimental: true
+          mise_toml: |
+            [tools]
+            "pipx:black" = "24.8"
+            "pipx:isort" = "5.13"
+            python = "3.12"
+            uv = "0.4"
+
+            [settings]
+            pipx_uvx = true
 
       - name: Check import style with isort
         run: isort . --check --profile black --diff
 
       - name: Check code style with Black
         run: black . --check --diff
+
+      - name: Check Tiltfiles with Black
+        run: |
+          find . -type f -name "Tiltfile" | while read -r file; do
+            black --check --diff "$file"
+          done


### PR DESCRIPTION
* Use Mise to install Python and dependencies to run style checks
* Check Tiltfile formatting

---

This also speeds up the Style Check action from ±20s to ±15s.
Probably because of Mise Caching and `uv` is faster than `pip`