### PR TITLE
🧑‍💻 Programmatically detect IP address

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -41,6 +41,11 @@ description = "Start Tilt"
 depends = ["kind:create"]
 run = "tilt up"
 
+[tasks."tilt:up:expose"]
+description = "Start Tilt with `--expose` flag"
+depends = ["kind:create"]
+run = "tilt up -- --expose"
+
 [tasks."tilt:down"]
 description = "Tilt Down"
 run = "tilt down"

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,6 @@
 load("./tilt/cloudapi/Tiltfile", "setup_cloudapi")
 load("./tilt/metrics/Tiltfile", "setup_metrics_server")
+load("./tilt/utils/Tiltfile", "run_command")
 load("ext://color", "color")
 load("ext://helm_resource", "helm_repo")
 
@@ -48,29 +49,19 @@ charts_dir = "tilt/.charts"
 if not os.path.exists(charts_dir):
     print(color.yellow("Charts not found, cloning charts repo"))
 
-    ssh_result = str(
-        local(
-            "git clone git@github.com:didx-xyz/charts.git "
-            + charts_dir
-            + " 2>&1 | tee /dev/stdout",
-            dir=os.path.dirname(__file__),
-            quiet=True,
-            echo_off=True,
-        )
-    ).strip()
+    ssh_result = run_command(
+        "git clone git@github.com:didx-xyz/charts.git " + charts_dir,
+        dir=os.path.dirname(__file__),
+    )
 
     if "fatal" in ssh_result:
         print(color.red("Failed to clone charts repo via SSH, retrying with HTTPS"))
 
-        https_result = str(
-            local(
-                "git clone https://github.com/didx-xyz/charts.git "
-                + charts_dir
-                + " 2>&1 | tee /dev/stdout",
-                dir=os.path.dirname(__file__),
-                quiet=True,
-                echo_off=True,
-            )
+        https_result = run_command(
+            "git clone https://github.com/didx-xyz/charts.git "
+            + charts_dir
+            + " 2>&1 | tee /dev/stdout",
+            dir=os.path.dirname(__file__),
         )
 
         if "fatal" in https_result:

--- a/Tiltfile
+++ b/Tiltfile
@@ -3,6 +3,7 @@ load("./tilt/metrics/Tiltfile", "setup_metrics_server")
 load("./tilt/utils/Tiltfile", "run_command")
 load("ext://color", "color")
 load("ext://helm_resource", "helm_repo")
+load("ext://uibutton", "cmd_button", "location", "choice_input")
 
 config.define_bool("no-build", False, "Skip building Docker images")
 config.define_bool("destroy", False, "Destroy Kind cluster")
@@ -70,6 +71,36 @@ if not os.path.exists(charts_dir):
     print(color.green("Charts repo cloned"))
 else:
     print(color.green("Charts repo already cloned"))
+
+cmd_button(
+    name="expose",
+    icon_name="public",  # https://fonts.google.com/icons
+    text="Expose Ingresses (Tailscale or Local Network)",
+    location=location.NAV,
+    argv=[
+        "tilt",
+        "patch",
+        "tiltfile",
+        "(Tiltfile)",
+        "--patch",
+        '{"spec": {"args": ["--expose=True"]}}',
+    ],
+)
+
+cmd_button(
+    name="unexpose",
+    icon_name="public_off",
+    text="Switch Ingresses back to 'localhost'",
+    location=location.NAV,
+    argv=[
+        "tilt",
+        "patch",
+        "tiltfile",
+        "(Tiltfile)",
+        "--patch",
+        '{"spec": {"args": ["--expose=False"]}}',
+    ],
+)
 
 # Setup CloudAPI
 build_enabled = not cfg.get("no-build")

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,7 +6,13 @@ load("ext://helm_resource", "helm_repo")
 config.define_bool("no-build", False, "Skip building Docker images")
 config.define_bool("destroy", False, "Destroy Kind cluster")
 config.define_bool("destroy-all", False, "Destroy Kind cluster and delete docker cache")
+config.define_bool(
+    "expose",
+    False,
+    "Detect Host IP and set Ingress Domain Name to expose services outside of 'localhost' context",
+)
 cfg = config.parse()
+
 
 update_settings(
     k8s_upsert_timeout_secs=600,
@@ -76,7 +82,8 @@ else:
 
 # Setup CloudAPI
 build_enabled = not cfg.get("no-build")
-setup_cloudapi(build_enabled)
+expose = cfg.get("expose")
+setup_cloudapi(build_enabled, expose)
 
 if config.tilt_subcommand not in ("down"):
     # _FORCE_ Kube Context to `kind-aries-cloudapi`

--- a/Tiltfile
+++ b/Tiltfile
@@ -75,7 +75,7 @@ else:
 cmd_button(
     name="expose",
     icon_name="public",  # https://fonts.google.com/icons
-    text="Expose Ingresses (Tailscale or Local Network)",
+    text="Expose Ingresses via Tailscale or Local Network",
     location=location.NAV,
     argv=[
         "tilt",

--- a/tilt/cloudapi/Tiltfile
+++ b/tilt/cloudapi/Tiltfile
@@ -14,17 +14,6 @@ pgadmin_version = "1.29.0"
 registry = "localhost:5001"
 
 
-ingress_domain = ""
-if config.tilt_subcommand == "ci":
-    ingress_domain += "127.0.0.1.nip.io"
-else:
-    ingress_domain += generate_ingress_domain()
-print(color.green("Ingress Domain: " + ingress_domain))
-
-redis_insight_host = "redis-insight." + ingress_domain
-pgadmin_host = "pgadmin." + ingress_domain
-
-
 def setup_redis(namespace):
     print(color.green("Installing Redis..."))
 
@@ -50,10 +39,11 @@ def setup_redis(namespace):
     )
 
 
-def setup_redis_insight(namespace):
+def setup_redis_insight(namespace, ingress_domain):
     print(color.green("Installing Redis Insight..."))
 
     values_file = "./tilt/cloudapi/redis-insight.yaml"
+    redis_insight_host = "redis-insight." + ingress_domain
 
     ## Setup Redis Insight
     # https://github.com/mrnim94/redisinsight
@@ -126,10 +116,11 @@ def setup_postgres(namespace):
     )
 
 
-def setup_pgadmin(namespace):
+def setup_pgadmin(namespace, ingress_domain):
     print(color.green("Installing pgAdmin..."))
 
     values_file = "./tilt/cloudapi/pgadmin.yaml"
+    pgadmin_host = "pgadmin." + ingress_domain
 
     ## Setup pgAdmin
     # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
@@ -279,7 +270,7 @@ def build_cloudapi_service(service, image={}):
 
 
 def setup_cloudapi_service(
-    release, chart, namespace, release_config={}, build_enabled=True
+    release, chart, namespace, ingress_domain, release_config={}, build_enabled=True
 ):
     print(color.green("Installing " + release + "..."))
 
@@ -336,7 +327,7 @@ def setup_cloudapi_service(
         print(color.yellow("Skipping " + release + ", not enabled"))
 
 
-def setup_ledger(namespace, build_enabled):
+def setup_ledger(namespace, ingress_domain, build_enabled=True):
     print(color.green("Installing Ledger..."))
 
     # Setup Ledger Nodes
@@ -412,7 +403,7 @@ def add_live_update(live_update_config, enabled):
     return []
 
 
-def setup_cloudapi(build_enabled):
+def setup_cloudapi(build_enabled, expose):
     print(color.green("Installing CloudAPI..."))
 
     # Adopt and manage CloudAPI namespace
@@ -422,10 +413,13 @@ def setup_cloudapi(build_enabled):
         allow_duplicates=True,
     )
 
+    ingress_domain = generate_ingress_domain(expose)
+    print(color.green("Ingress Domain: " + ingress_domain))
+
     setup_redis(namespace)
-    setup_redis_insight(namespace)
+    setup_redis_insight(namespace, ingress_domain)
     setup_postgres(namespace)
-    setup_pgadmin(namespace)
+    setup_pgadmin(namespace, ingress_domain)
     setup_nats(namespace)
     setup_benthos(namespace)
 
@@ -639,6 +633,7 @@ def setup_cloudapi(build_enabled):
             release,
             "./tilt/.charts/charts/aries-cloudapi-python",
             namespace,
+            ingress_domain,
             releases[release],
             build_enabled,
         )

--- a/tilt/cloudapi/Tiltfile
+++ b/tilt/cloudapi/Tiltfile
@@ -1,4 +1,4 @@
-load("../utils/Tiltfile", "namespace_create_wrap")
+load("../utils/Tiltfile", "namespace_create_wrap", "generate_ingress_domain")
 load("ext://color", "color")
 load("ext://helm_resource", "helm_resource", "helm_repo")
 
@@ -6,14 +6,23 @@ load("ext://helm_resource", "helm_resource", "helm_repo")
 redis_version = "11.0.4"
 # https://github.com/mrnim94/redisinsight/tree/master/helm-chart/redisinsight
 redis_insight_version = "1.1.0"
-redis_insight_host = "redis-insight.127.0.0.1.nip.io"
 # https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
 postgres_version = "14.2.28"
 # https://github.com/rowanruseler/helm-charts/tree/main/charts/pgadmin4
 pgadmin_version = "1.29.0"
-pgadmin_host = "pgadmin.127.0.0.1.nip.io"
 
 registry = "localhost:5001"
+
+
+ingress_domain = ""
+if config.tilt_subcommand == "ci":
+    ingress_domain += "127.0.0.1.nip.io"
+else:
+    ingress_domain += generate_ingress_domain()
+print(color.green("Ingress Domain: " + ingress_domain))
+
+redis_insight_host = "redis-insight." + ingress_domain
+pgadmin_host = "pgadmin." + ingress_domain
 
 
 def setup_redis(namespace):
@@ -308,6 +317,8 @@ def setup_cloudapi_service(
                 values_file,
                 "--set",
                 "replicaCount=" + str(release_config.get("replicaCount", 1)),
+                "--set",
+                "ingressDomain=cloudapi." + ingress_domain,
                 "--wait",
             ]
             + flags,
@@ -342,6 +353,8 @@ def setup_ledger(namespace, build_enabled):
             flags=[
                 "--values",
                 values_file,
+                "--set",
+                "ingressDomain=cloudapi." + ingress_domain,
                 "--wait",
             ],
             labels=["02-indy-ledger"],
@@ -436,7 +449,7 @@ def setup_cloudapi(build_enabled):
             "depends": ["postgres", "ledger-browser"],
             "links": [
                 link(
-                    "http://governance-agent.cloudapi.127.0.0.1.nip.io",
+                    "http://governance-agent.cloudapi." + ingress_domain,
                     "Governance Agent",
                 ),
             ],
@@ -447,9 +460,12 @@ def setup_cloudapi(build_enabled):
         "governance-ga-web": {
             "depends": ["governance-ga-agent", "governance-multitenant-agent"],
             "links": [
-                link("http://cloudapi.127.0.0.1.nip.io/governance", "Governance Web"),
                 link(
-                    "http://cloudapi.127.0.0.1.nip.io/governance/docs",
+                    "http://cloudapi." + ingress_domain + "/governance",
+                    "Governance Web",
+                ),
+                link(
+                    "http://cloudapi." + ingress_domain + "/governance/docs",
                     "Governance Web Docs",
                 ),
             ],
@@ -468,7 +484,7 @@ def setup_cloudapi(build_enabled):
             "depends": ["postgres", "ledger-browser"],
             "links": [
                 link(
-                    "http://multitenant-agent.cloudapi.127.0.0.1.nip.io",
+                    "http://multitenant-agent.cloudapi." + ingress_domain,
                     "Multitenant Agent",
                 ),
             ],
@@ -479,9 +495,12 @@ def setup_cloudapi(build_enabled):
         "governance-multitenant-web": {
             "depends": ["governance-ga-agent", "governance-multitenant-agent"],
             "links": [
-                link("http://cloudapi.127.0.0.1.nip.io/tenant-admin", "Tenant Admin"),
                 link(
-                    "http://cloudapi.127.0.0.1.nip.io/tenant-admin/docs",
+                    "http://cloudapi." + ingress_domain + "/tenant-admin",
+                    "Tenant Admin",
+                ),
+                link(
+                    "http://cloudapi." + ingress_domain + "/tenant-admin/docs",
                     "Tenant Admin Docs",
                 ),
             ],
@@ -499,8 +518,10 @@ def setup_cloudapi(build_enabled):
         "governance-tenant-web": {
             "depends": ["governance-ga-agent", "governance-multitenant-agent"],
             "links": [
-                link("http://cloudapi.127.0.0.1.nip.io/tenant", "Tenant"),
-                link("http://cloudapi.127.0.0.1.nip.io/tenant/docs", "Tenant Docs"),
+                link("http://cloudapi." + ingress_domain + "/tenant", "Tenant"),
+                link(
+                    "http://cloudapi." + ingress_domain + "/tenant/docs", "Tenant Docs"
+                ),
             ],
             "image": {
                 "dockerfile": "./dockerfiles/fastapi/Dockerfile",
@@ -516,8 +537,10 @@ def setup_cloudapi(build_enabled):
         "governance-trust-registry-web": {
             "depends": ["governance-trust-registry"],
             "links": [
-                link("http://cloudapi.127.0.0.1.nip.io/public", "Public"),
-                link("http://cloudapi.127.0.0.1.nip.io/public/docs", "Public Docs"),
+                link("http://cloudapi." + ingress_domain + "/public", "Public"),
+                link(
+                    "http://cloudapi." + ingress_domain + "/public/docs", "Public Docs"
+                ),
             ],
             "image": {
                 "dockerfile": "./dockerfiles/fastapi/Dockerfile",
@@ -534,10 +557,10 @@ def setup_cloudapi(build_enabled):
             "depends": ["postgres"],
             "links": [
                 link(
-                    "http://trust-registry.cloudapi.127.0.0.1.nip.io", "Trust Registry"
+                    "http://trust-registry.cloudapi." + ingress_domain, "Trust Registry"
                 ),
                 link(
-                    "http://trust-registry.cloudapi.127.0.0.1.nip.io/docs",
+                    "http://trust-registry.cloudapi." + ingress_domain + "/docs",
                     "Trust Registry Docs",
                 ),
             ],
@@ -556,7 +579,7 @@ def setup_cloudapi(build_enabled):
             "depends": ["redis"],
             "replicaCount": 1,
             "links": [
-                link("http://webhooks.cloudapi.127.0.0.1.nip.io/docs", "Docs"),
+                link("http://webhooks.cloudapi." + ingress_domain + "/docs", "Docs"),
             ],
             "image": {
                 "dockerfile": "./dockerfiles/webhooks/Dockerfile",
@@ -572,7 +595,7 @@ def setup_cloudapi(build_enabled):
         "waypoint": {
             "depends": ["nats", "benthos"],
             "links": [
-                link("http://waypoint.cloudapi.127.0.0.1.nip.io/docs", "Docs"),
+                link("http://waypoint.cloudapi." + ingress_domain + "/docs", "Docs"),
             ],
             "image": {
                 "dockerfile": "./dockerfiles/waypoint/Dockerfile",
@@ -590,7 +613,7 @@ def setup_cloudapi(build_enabled):
             "enabled": ledger_enabled,
             "links": [
                 link(
-                    "http://ledger-browser.cloudapi.127.0.0.1.nip.io", "Ledger Browser"
+                    "http://ledger-browser.cloudapi." + ingress_domain, "Ledger Browser"
                 ),
             ],
         },
@@ -601,12 +624,12 @@ def setup_cloudapi(build_enabled):
                 "governance-multitenant-agent",
             ],
             "links": [
-                link("http://mediator.cloudapi.127.0.0.1.nip.io", "Mediator"),
+                link("http://mediator.cloudapi." + ingress_domain, "Mediator"),
             ],
         },
         "tails-server": {
             "links": [
-                link("http://tails.cloudapi.127.0.0.1.nip.io", "Tails"),
+                link("http://tails.cloudapi." + ingress_domain, "Tails"),
             ]
         },
     }

--- a/tilt/utils/Tiltfile
+++ b/tilt/utils/Tiltfile
@@ -76,7 +76,17 @@ def disable_all_resources():
 ###
 # Generate Ingress Domain based on Tailscale IP or Primary Network Interface IP
 ###
-def generate_ingress_domain():
+def generate_ingress_domain(expose):
+    if not expose:
+        print(
+            color.yellow(
+                "Expose flag not set. Using '127.0.0.1.nip.io' as Ingress Domain."
+            )
+        )
+        return "127.0.0.1.nip.io"
+
+    print(color.yellow("Detecting Host IP and setting Ingress Domain Name..."))
+
     def run_command(cmd):
         full_cmd = cmd + " 2>&1 || true"
         result = local(full_cmd, quiet=True, echo_off=True)

--- a/tilt/utils/Tiltfile
+++ b/tilt/utils/Tiltfile
@@ -74,6 +74,15 @@ def disable_all_resources():
 
 
 ###
+# Run a command and return the output as a String
+###
+def run_command(cmd, dir=os.path.dirname(__file__)):
+    full_cmd = cmd + " 2>&1 || true"
+    result = local(full_cmd, dir=dir, quiet=True, echo_off=True)
+    return str(result).strip()
+
+
+###
 # Generate Ingress Domain based on Tailscale IP or Primary Network Interface IP
 ###
 def generate_ingress_domain(expose):
@@ -86,11 +95,6 @@ def generate_ingress_domain(expose):
         return "127.0.0.1.nip.io"
 
     print(color.yellow("Detecting Host IP and setting Ingress Domain Name..."))
-
-    def run_command(cmd):
-        full_cmd = cmd + " 2>&1 || true"
-        result = local(full_cmd, quiet=True, echo_off=True)
-        return str(result).strip()
 
     def get_primary_ip():
         os_name = os.name

--- a/tilt/utils/Tiltfile
+++ b/tilt/utils/Tiltfile
@@ -1,3 +1,4 @@
+load("ext://color", "color")
 load("ext://namespace", "namespace_inject", "namespace_create")
 load("ext://uibutton", "cmd_button", "location", "text_input")
 
@@ -73,3 +74,61 @@ def disable_all_resources():
 
 
 ###
+# Generate Ingress Domain based on Tailscale IP or Primary Network Interface IP
+###
+def generate_ingress_domain():
+    def run_command(cmd):
+        full_cmd = cmd + " 2>&1 || true"
+        result = local(full_cmd, quiet=True, echo_off=True)
+        return str(result).strip()
+
+    def get_primary_ip():
+        os_name = os.name
+        if os_name == "posix":
+            # Attempt to get IP for macOS
+            interfaces = run_command(
+                "networksetup -listallhardwareports | grep -A 1 'Hardware Port: Wi-Fi' | grep 'Device:' | awk '{print $2}'"
+            ).split()
+            for interface in interfaces:
+                ip = run_command("ipconfig getifaddr " + interface)
+                if ip:
+                    return ip
+
+            # If macOS method fails, try Linux method
+            ip = run_command("ip route get 1 | awk '{print $7;exit}'")
+            if ip:
+                return ip
+
+        print(color.yellow("Warning: Failed to detect IP address."))
+        return None
+
+    def parse_tailscale_ip(output):
+        # Split the output into lines and look for an IP address
+        lines = output.split("\n")
+        for line in lines:
+            parts = line.split()
+            if len(parts) > 0 and parts[0].startswith("100."):
+                return parts[0]
+        return None
+
+    # Check if Tailscale CLI is installed
+    tailscale_installed = run_command("which tailscale")
+    if tailscale_installed and "not found" not in tailscale_installed:
+        # Check if Tailscale is running
+        tailscale_status = run_command("tailscale status")
+        if "failed to connect to local Tailscale service" not in tailscale_status:
+            # Tailscale is running, get the IP address
+            tailscale_ip = parse_tailscale_ip(tailscale_status)
+            if tailscale_ip:
+                return tailscale_ip + ".nip.io"
+        else:
+            print(color.yellow("Warning: Tailscale is installed but not running."))
+
+    # Fallback to primary network interface IP
+    primary_ip = get_primary_ip()
+    if primary_ip:
+        return primary_ip + ".nip.io"
+
+    # Default to localhost if all else fails
+    print(color.yellow("Warning: Failed to detect IP address. Using localhost."))
+    return "127.0.0.1.nip.io"


### PR DESCRIPTION
Programmatically detect Host IP Address and set Kubernetes Ingress Domain accordingly.

* Detect Tailscale
* Detect Host IP Address
* (Unless CI) set Ingress Domain to `${ip_address}.nip.io`
* Allows for routing to services on Tilt/Kind outside of `localhost` context
* It can be toggled via a button in the Tilt UI
![image](https://github.com/user-attachments/assets/59500e71-5b7d-4302-8f42-ab1328e1cf59)

---

Example:

_Tailscale not active_:
* Ingress Domain is `192.168.0.193.nip.io`
* Example ingress: `pgadmin.192.168.0.193.nip.io`

_Tailscale active_:
* Ingress Domain is `100.83.69.38.nip.io`
* Example ingress: `pgadmin.100.83.69.38.nip.io`

To allow connections from within Tailnet to yourself you must [allow incoming connections](https://tailscale.com/kb/1072/client-preferences?q=allow+incoming#allow-incoming-connections).