### PR TITLE
:test_tube: point e2e tests to use waypoint

### DIFF
--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -254,8 +254,8 @@ async def test_send_jsonld_request(
             topic="credentials",
             state="offer-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -280,16 +280,16 @@ async def test_send_jsonld_request(
             topic="credentials",
             state="request-sent",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
         check_webhook_state(
             client=faber_client,
             topic="credentials",
             state="request-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -331,8 +331,8 @@ async def test_issue_jsonld_bbs(
             topic="credentials",
             state="offer-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_bbs.py
@@ -253,6 +253,9 @@ async def test_send_jsonld_request(
             client=alice_member_client,
             topic="credentials",
             state="offer-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -276,11 +279,17 @@ async def test_send_jsonld_request(
             client=alice_member_client,
             topic="credentials",
             state="request-sent",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
         check_webhook_state(
             client=faber_client,
             topic="credentials",
             state="request-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -321,6 +330,9 @@ async def test_issue_jsonld_bbs(
             client=alice_member_client,
             topic="credentials",
             state="offer-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -254,6 +254,9 @@ async def test_send_jsonld_request(
             client=alice_member_client,
             topic="credentials",
             state="offer-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -320,6 +323,9 @@ async def test_issue_jsonld_ed(
             client=alice_member_client,
             topic="credentials",
             state="offer-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_key_ed25519.py
@@ -255,8 +255,8 @@ async def test_send_jsonld_request(
             topic="credentials",
             state="offer-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -324,8 +324,8 @@ async def test_issue_jsonld_ed(
             topic="credentials",
             state="offer-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -247,6 +247,9 @@ async def test_send_jsonld_request_sov(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
+        filter_map={
+            "thread_id": thread_id,
+        },
     )
 
     await asyncio.sleep(0.5)  # credential may take moment to reflect after webhook
@@ -268,11 +271,17 @@ async def test_send_jsonld_request_sov(
             client=alice_member_client,
             topic="credentials",
             state="request-sent",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
         check_webhook_state(
             client=faber_client,
             topic="credentials",
             state="request-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"
@@ -317,6 +326,9 @@ async def test_issue_jsonld_sov(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
+        filter_map={
+            "thread_id": thread_id,
+        },
     )
 
     await asyncio.sleep(0.5)  # credential may take moment to reflect after webhook

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -166,6 +166,7 @@ async def test_send_jsonld_oob_sov(
 
     data = response.json()
     cred_ex_id = data["credential_exchange_id"]
+    thread_id = data["thread_id"]
 
     try:
         assert_that(data).contains("credential_exchange_id")
@@ -202,6 +203,9 @@ async def test_send_jsonld_oob_sov(
             client=alice_member_client,
             topic="credentials",
             state="offer-received",
+            filter_map={
+                "thread_id": thread_id
+            }
         )
 
     finally:

--- a/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
+++ b/app/tests/e2e/issuer/ld_proof/test_ld_proof_did_sov.py
@@ -203,9 +203,7 @@ async def test_send_jsonld_oob_sov(
             client=alice_member_client,
             topic="credentials",
             state="offer-received",
-            filter_map={
-                "thread_id": thread_id
-            }
+            filter_map={"thread_id": thread_id},
         )
 
     finally:
@@ -276,16 +274,16 @@ async def test_send_jsonld_request_sov(
             topic="credentials",
             state="request-sent",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
         check_webhook_state(
             client=faber_client,
             topic="credentials",
             state="request-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -213,6 +213,9 @@ async def test_send_credential_request(
         client=alice_member_client,
         topic="credentials",
         state="offer-received",
+        filter_map={
+            "thread_id": thread_id,
+        },
     )
 
     await asyncio.sleep(0.5)  # credential may take moment to reflect after webhook
@@ -234,11 +237,17 @@ async def test_send_credential_request(
             client=alice_member_client,
             topic="credentials",
             state="request-sent",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
         check_webhook_state(
             client=faber_client,
             topic="credentials",
             state="request-received",
+            filter_map={
+            "thread_id": thread_id,
+        },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/issuer/test_indy_credentials.py
+++ b/app/tests/e2e/issuer/test_indy_credentials.py
@@ -238,16 +238,16 @@ async def test_send_credential_request(
             topic="credentials",
             state="request-sent",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
         check_webhook_state(
             client=faber_client,
             topic="credentials",
             state="request-received",
             filter_map={
-            "thread_id": thread_id,
-        },
+                "thread_id": thread_id,
+            },
         ),
     )
     assert all(result), "An expected webhook event was not returned"

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -95,9 +95,7 @@ async def test_proof_model_failures(
             client=alice_member_client,
             topic="proofs",
             state="request-received",
-            filter_map={
-                "connection_id":alice_connection_id
-            }
+            filter_map={"connection_id": alice_connection_id},
         )
 
         # Get proof exchange id

--- a/app/tests/e2e/test_proof_request_models.py
+++ b/app/tests/e2e/test_proof_request_models.py
@@ -38,6 +38,7 @@ async def test_proof_model_failures(
     protocol_version: str,
 ):
     acme_connection_id = acme_and_alice_connection.acme_connection_id
+    alice_connection_id = acme_and_alice_connection.alice_connection_id
 
     if protocol_version == "v1":
 
@@ -94,6 +95,9 @@ async def test_proof_model_failures(
             client=alice_member_client,
             topic="proofs",
             state="request-received",
+            filter_map={
+                "connection_id":alice_connection_id
+            }
         )
 
         # Get proof exchange id

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -517,11 +517,15 @@ async def test_accept_proof_request_verifier_has_issuer_role(
     send_proof_response = await send_proof_request(meld_co_client, request_body)
 
     meld_co_proof_id = send_proof_response["proof_id"]
+    thread_id = send_proof_response["thread_id"]
 
     alice_payload = await check_webhook_state(
         client=alice_member_client,
         topic="proofs",
         state="request-received",
+        filter_map={
+            "thread_id": thread_id
+        }
     )
     alice_proof_id = alice_payload["proof_id"]
 

--- a/app/tests/e2e/verifier/test_verifier.py
+++ b/app/tests/e2e/verifier/test_verifier.py
@@ -523,9 +523,7 @@ async def test_accept_proof_request_verifier_has_issuer_role(
         client=alice_member_client,
         topic="proofs",
         state="request-received",
-        filter_map={
-            "thread_id": thread_id
-        }
+        filter_map={"thread_id": thread_id},
     )
     alice_proof_id = alice_payload["proof_id"]
 

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -135,6 +135,8 @@ async def test_accept_proof_request_verifier_oob_connection(
     acme_wallet_id = get_wallet_id_from_async_client(acme_client)
     verifier_actor = await fetch_actor_by_id(acme_wallet_id)
 
+    # Get Alice's wallet_label from RichAsyncClient instance, striping prefix and suffix added by fixtures
+    # Example of RichAsyncClient name format: "Tenant alice_VCPSU - HTTP"
     their_label = alice_member_client.name[7:-7]
 
     assert verifier_actor

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -136,7 +136,7 @@ async def test_accept_proof_request_verifier_oob_connection(
     verifier_actor = await fetch_actor_by_id(acme_wallet_id)
 
     their_label = alice_member_client.name[7:-7]
-    
+
     assert verifier_actor
     assert verifier_actor.didcomm_invitation
 
@@ -154,9 +154,7 @@ async def test_accept_proof_request_verifier_oob_connection(
         client=acme_client,
         topic="connections",
         state="completed",
-        filter_map={
-            "their_label": their_label
-        }
+        filter_map={"their_label": their_label},
     )
     holder_verifier_connection_id = invitation_response["connection_id"]
     verifier_holder_connection_id = payload["connection_id"]

--- a/app/tests/e2e/verifier/test_verifier_oob.py
+++ b/app/tests/e2e/verifier/test_verifier_oob.py
@@ -135,6 +135,8 @@ async def test_accept_proof_request_verifier_oob_connection(
     acme_wallet_id = get_wallet_id_from_async_client(acme_client)
     verifier_actor = await fetch_actor_by_id(acme_wallet_id)
 
+    their_label = alice_member_client.name[7:-7]
+    
     assert verifier_actor
     assert verifier_actor.didcomm_invitation
 
@@ -152,6 +154,9 @@ async def test_accept_proof_request_verifier_oob_connection(
         client=acme_client,
         topic="connections",
         state="completed",
+        filter_map={
+            "their_label": their_label
+        }
     )
     holder_verifier_connection_id = invitation_response["connection_id"]
     verifier_holder_connection_id = payload["connection_id"]

--- a/app/tests/fixtures/member_async_clients.py
+++ b/app/tests/fixtures/member_async_clients.py
@@ -38,7 +38,7 @@ async def alice_member_client(
     alice_tenant: CreateTenantResponse,
 ) -> AsyncGenerator[RichAsyncClient, Any]:
     async with get_tenant_client(
-        token=alice_tenant.access_token, name="Alice"
+        token=alice_tenant.access_token, name=alice_tenant.wallet_label
     ) as alice_async_client:
         yield alice_async_client
 

--- a/app/tests/util/sse_listener.py
+++ b/app/tests/util/sse_listener.py
@@ -65,7 +65,7 @@ class SseListener:
         """
         Start listening for SSE events. When an event is received that matches the specified parameters.
         """
-        url = f"{base_url}/{self.wallet_id}/{self.topic}/{field}/{field_id}/{desired_state}"
+        url = f"{waypoint_base_url}/{self.wallet_id}/{self.topic}/{field}/{field_id}/{desired_state}"
 
         timeout = Timeout(timeout)
         async with RichAsyncClient(timeout=timeout) as client:

--- a/shared/constants.py
+++ b/shared/constants.py
@@ -59,7 +59,7 @@ SET_LOCKS = bool(os.getenv("SET_LOCKS", ""))
 
 # Sse
 SSE_TIMEOUT = int(
-    os.getenv("SSE_TIMEOUT", "150")
+    os.getenv("SSE_TIMEOUT", "15")
 )  # maximum duration of an SSE connection
 DISCONNECT_CHECK_PERIOD = float(
     os.getenv("DISCONNECT_CHECK_PERIOD", "0.2")

--- a/waypoint/services/nats_service.py
+++ b/waypoint/services/nats_service.py
@@ -116,7 +116,7 @@ class NatsEventsProcessor:
                     break
 
                 try:
-                    messages = await subscription.fetch(10, 1)
+                    messages = await subscription.fetch(1000, 1)
                     for message in messages:
                         if message.headers.get("event_topic") == topic:
                             event = orjson.loads(message.data)

--- a/waypoint/services/nats_service.py
+++ b/waypoint/services/nats_service.py
@@ -1,10 +1,10 @@
 import asyncio
-import json
 import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 
 import nats
+import orjson
 from nats.aio.client import Client as NATS
 from nats.aio.errors import ErrConnectionClosed, ErrNoServers, ErrTimeout
 from nats.errors import BadSubscriptionError, Error, TimeoutError
@@ -119,7 +119,7 @@ class NatsEventsProcessor:
                     messages = await subscription.fetch(10, 1)
                     for message in messages:
                         if message.headers.get("event_topic") == topic:
-                            event = json.loads(message.data)
+                            event = orjson.loads(message.data)
                             yield CloudApiWebhookEventGeneric(**event)
                         await message.ack()
                 except TimeoutError:

--- a/webhooks/tests/e2e/test_sse.py
+++ b/webhooks/tests/e2e/test_sse.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 look_back = 0.5
 
 
+@pytest.mark.skip("Skip SSE tests -- to be removed")
 @pytest.mark.anyio
 async def test_sse_subscribe_wallet_topic(
     alice_member_client: RichAsyncClient,
@@ -51,6 +52,7 @@ async def test_sse_subscribe_wallet_topic(
     )
 
 
+@pytest.mark.skip("Skip SSE tests -- to be removed")
 @pytest.mark.anyio
 async def test_sse_subscribe_event_state(
     alice_member_client: RichAsyncClient,
@@ -84,6 +86,7 @@ async def test_sse_subscribe_event_state(
     )
 
 
+@pytest.mark.skip("Skip SSE tests -- to be removed")
 @pytest.mark.anyio
 async def test_sse_subscribe_filtered_stream(
     alice_member_client: RichAsyncClient,
@@ -120,6 +123,7 @@ async def test_sse_subscribe_filtered_stream(
     )
 
 
+@pytest.mark.skip("Skip SSE tests -- to be removed")
 @pytest.mark.anyio
 async def test_sse_subscribe_event(
     alice_member_client: RichAsyncClient,

--- a/webhooks/tests/e2e/test_webhooks.py
+++ b/webhooks/tests/e2e/test_webhooks.py
@@ -8,6 +8,7 @@ from shared import WEBHOOKS_URL, RichAsyncClient
 CONNECTIONS_BASE_PATH = connections_router.prefix
 
 
+@pytest.mark.skip("Skip Webhooks tests -- to be removed")
 @pytest.mark.anyio
 async def test_wallets_webhooks(
     alice_member_client: RichAsyncClient, bob_member_client: RichAsyncClient
@@ -39,6 +40,7 @@ async def test_wallets_webhooks(
         )
 
 
+@pytest.mark.skip("Skip Webhooks tests -- to be removed")
 @pytest.mark.anyio
 async def test_connection_webhooks(
     alice_member_client: RichAsyncClient, bob_member_client: RichAsyncClient


### PR DESCRIPTION
Making sure all `check_webhook_state` functions use the `filter_map` field. 
Waypoint needs a `field` and `field_id`