### PR TITLE
🧑‍💻 Docker remove Kind Registry and Docker Cache

### DIFF
--- a/.mise/tasks/kind/destroy
+++ b/.mise/tasks/kind/destroy
@@ -4,4 +4,6 @@
 kindClusterName=aries-cloudapi
 kind delete cluster --name $kindClusterName
 
+docker rm -f kind-registry cache-docker
+
 rm -f .mise/kubeconfig.yaml


### PR DESCRIPTION
When running `mise run tilt:down:destroy`, Mise would leave the Docker
Cache and Kind Registry containers dangling.
Don't do that anymore.