### PR TITLE
:art: resolve remaining repo code scanning warnings

### DIFF
--- a/scripts/k6/main.js
+++ b/scripts/k6/main.js
@@ -151,7 +151,7 @@ export function setup() {
     }
   }
 
-  return { bearerToken, issuers };
+  return bearerToken, issuers;
 }
 
 // Helper function to calculate the wallet index based on VU and iteration

--- a/scripts/k6/scenarios/create-invitations.js
+++ b/scripts/k6/scenarios/create-invitations.js
@@ -76,7 +76,7 @@ export function setup() {
     console.error("Failed to bootstrap issuers.");
   }
 
-  return { bearerToken, issuers, holders };
+  return bearerToken, issuers, holders;
 }
 
 function getIssuerIndex(vu, iter) {

--- a/scripts/k6/scenarios/create-issuers.js
+++ b/scripts/k6/scenarios/create-issuers.js
@@ -23,8 +23,8 @@ export const options = {
   scenarios: {
     default: {
       executor: "per-vu-iterations",
-      vus: vus,
-      iterations: iterations,
+      vus,
+      iterations,
       maxDuration: "24h",
     },
   },

--- a/scripts/k6/scenarios/create-issuers.js
+++ b/scripts/k6/scenarios/create-issuers.js
@@ -66,7 +66,7 @@ const wallets = new SharedArray("wallets", () => {
 export function setup() {
   const bearerToken = getBearerToken();
   file.writeString(outputFilepath, "");
-  return { bearerToken };
+  return bearerToken;
 }
 
 const iterationsPerVU = options.scenarios.default.iterations;

--- a/scripts/k6/scenarios/create-schemas.js
+++ b/scripts/k6/scenarios/create-schemas.js
@@ -56,7 +56,7 @@ const schemas = new SharedArray("schemas", () => {
 export function setup() {
   file.writeString(outputFilepath, "");
   const governanceBearerToken = getGovernanceBearerToken();
-  return { governanceBearerToken }; // eslint-disable-line no-eval
+  return governanceBearerToken; // eslint-disable-line no-eval
 }
 
 const iterationsPerVU = options.scenarios.default.iterations;

--- a/scripts/k6/scenarios/create-schemas.js
+++ b/scripts/k6/scenarios/create-schemas.js
@@ -95,20 +95,23 @@ export default function (data) {
     schema.schemaName,
     schema.schemaVersion
   );
-  check(getSchemaResponse, {
-    "getSchema check passes": (r) => {
-      if (r.status !== 200 || r.body === "[]") {
-        return false;
-      }
 
-      try {
-        const schemaData = JSON.parse(r.body);
-        return schemaData.length > 0 && schemaData[0].id != null;
-      } catch (e) {
-        console.error("Failed to parse schema data:", e);
-        return false;
-      }
-    },
+  function isSchemaValid(response) {
+    if (response.status !== 200 || response.body === "[]") {
+      return false;
+    }
+
+    try {
+      const schemaData = JSON.parse(response.body);
+      return schemaData.length > 0 && schemaData[0].id != null;
+    } catch (e) {
+      console.error("Failed to parse schema data:", e);
+      return false;
+    }
+  }
+
+  check(getSchemaResponse, {
+    "getSchema check passes": (r) => isSchemaValid(r),
   });
 
   const { id: schemaId } = JSON.parse(getSchemaResponse.body)[0];

--- a/scripts/k6/scenarios/delete-holders.js
+++ b/scripts/k6/scenarios/delete-holders.js
@@ -60,7 +60,7 @@ const filepath = "output/create-holders.json";
 
 export function setup() {
   const bearerToken = getBearerToken();
-  return { bearerToken };
+  return bearerToken;
 }
 
 const iterationsPerVU = options.scenarios.default.iterations;


### PR DESCRIPTION
:art: Fixes 8 code scanning warnings:
```

Unnecessary block.
Warning
#7004 opened last month • Detected by Pmd (reported by Codacy) in scripts/.../scenarios/create-invitations.js :79
development

Unnecessary block.
Warning
#6982 opened 2 months ago • Detected by Pmd (reported by Codacy) in scripts/.../scenarios/create-schemas.js :59
development

Unnecessary block.
Warning
#6723 opened 3 months ago • Detected by Pmd (reported by Codacy) in scripts/.../scenarios/create-issuers.js :69
development

Unnecessary block.
Warning
#6636 opened 3 months ago • Detected by Pmd (reported by Codacy) in scripts/.../scenarios/delete-holders.js :63
development

Unnecessary block.
Warning
#5795 opened 4 months ago • Detected by Pmd (reported by Codacy) in scripts/k6/main.js :154
development

Arrow function 'getSchema check passes' has a complexity of 5. Maximum allowed is 4.
Warning
#6991 opened 2 months ago • Detected by Eslint (reported by Codacy) in scripts/.../scenarios/create-schemas.js :82
development

Expected property shorthand.
Note
#6710 opened 3 months ago • Detected by Eslint (reported by Codacy) in scripts/.../scenarios/create-issuers.js :30
development

Expected property shorthand.
Note
#6698 opened 3 months ago • Detected by Eslint (reported by Codacy) in scripts/.../scenarios/create-issuers.js :29
development
```




































