### PR TITLE
:pushpin: Pin `xk6` and plugins

### DIFF
--- a/scripts/k6/Dockerfile
+++ b/scripts/k6/Dockerfile
@@ -1,20 +1,16 @@
-# Use the official Go image as the base image
-FROM golang:1.22 AS builder
+FROM docker.io/golang:1.23 AS builder
 
-# Set the working directory inside the container
 WORKDIR /app
 
-# Install xk6 and build with specified extensions in a single step to reduce layers
-RUN go install go.k6.io/xk6/cmd/xk6@latest && \
-    xk6 build --output /usr/local/bin/xk6 \
-    --with github.com/avitalique/xk6-file@latest \
-    --with github.com/phymbert/xk6-sse
+# xk6-sse doesn't support k6>=0.53
+# https://github.com/phymbert/xk6-sse/issues/19
+RUN go install go.k6.io/xk6/cmd/xk6@v0.13.0
+RUN xk6 build --output /app/xk6 \
+    --with github.com/avitalique/xk6-file@v1.4.0 \
+    --with github.com/phymbert/xk6-sse@v0.1.2
 
-# Use a minimal base image for the final stage
-FROM alpine:3.20
+FROM docker.io/alpine:3
 
-# Copy the built xk6 binary from the builder stage
-COPY --from=builder /usr/local/bin/xk6 /usr/local/bin/xk6
+COPY --from=builder /app/xk6 /usr/local/bin/xk6
 
-# # Set the entrypoint to xk6
 ENTRYPOINT ["/usr/local/bin/xk6"]


### PR DESCRIPTION
* `xk6-sse` isn't compatible with `k6>=0.53`
* Pin `xk6` and all plugins to the latest compatible versions
* Also bump Golang to `1.23`