### PR TITLE
:pushpin: Explicitly pin k6 to `v0.52.0`

### DIFF
--- a/scripts/k6/Dockerfile
+++ b/scripts/k6/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # xk6-sse doesn't support k6>=0.53
 # https://github.com/phymbert/xk6-sse/issues/19
 RUN go install go.k6.io/xk6/cmd/xk6@v0.13.0
-RUN xk6 build --output /app/xk6 \
+RUN xk6 build v0.52.0 --output /app/xk6 \
     --with github.com/avitalique/xk6-file@v1.4.0 \
     --with github.com/phymbert/xk6-sse@v0.1.2
 


### PR DESCRIPTION
* Version of k6 being installed was `v0.46.0` which is quite old
* Explicitly pin k6 to `v0.52.0`