### PR TITLE
:arrow_up: Upgrade to our 1.1.1b0 acapy release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The FastAPI app serves as a wrapper around common workflows, facilitating
 real-life applications of the stack. It acts as a form of middleware or interface
 for client applications (e.g., a mobile app) and the backend stack, using
 [Aries CloudController](https://github.com/didx-xyz/aries-cloudcontroller-python)
-and [ACA-Py](https://github.com/hyperledger/aries-cloudagent-python). The aim is
+and [ACA-Py](https://github.com/openwallet-foundation/acapy). The aim is
 to streamline a client's workflow by providing convenient API endpoints for
 common workflows, such as creating wallets, managing connections, credentials,
 proofs, and workflows.

--- a/app/services/acapy_ledger.py
+++ b/app/services/acapy_ledger.py
@@ -160,7 +160,7 @@ async def schema_id_from_credential_definition_id(
     From a credential definition, get the identifier for its schema.
 
     Taken from ACA-Py implementation:
-    https://github.com/hyperledger/aries-cloudagent-python/blob/f9506df755e46c5be93b228c8811276b743a1adc/aries_cloudagent/ledger/indy.py#L790
+    https://github.com/openwallet-foundation/acapy/blob/f9506df755e46c5be93b228c8811276b743a1adc/aries_cloudagent/ledger/indy.py#L790
 
     Parameters:
     ----------

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -29,7 +29,7 @@ async def test_revoke_many_credentials(
     acme_and_alice_connection: AcmeAliceConnect,
 ):
     time.sleep(10)  # moment for revocation registry to update
-    # todo: remove sleep when issue resolved: https://github.com/hyperledger/aries-cloudagent-python/issues/3018
+    # todo: remove sleep when issue resolved: https://github.com/openwallet-foundation/acapy/issues/3018
 
     # Do proof request
     request_body = {

--- a/app/tests/e2e/verifier/test_proof_revoked_credential.py
+++ b/app/tests/e2e/verifier/test_proof_revoked_credential.py
@@ -35,7 +35,7 @@ async def test_proof_revoked_credential(
     acme_and_alice_connection: AcmeAliceConnect,
 ):
     time.sleep(10)  # moment for revocation registry to update
-    # todo: remove sleep when issue resolved: https://github.com/hyperledger/aries-cloudagent-python/issues/3018
+    # todo: remove sleep when issue resolved: https://github.com/openwallet-foundation/acapy/issues/3018
 
     # Do proof request
     request_body = {
@@ -125,7 +125,7 @@ async def test_regression_proof_revoked_credential(
     acme_and_alice_connection: AcmeAliceConnect,
 ):
     time.sleep(10)  # moment for revocation registry to update
-    # todo: remove sleep when issue resolved: https://github.com/hyperledger/aries-cloudagent-python/issues/3018
+    # todo: remove sleep when issue resolved: https://github.com/openwallet-foundation/acapy/issues/3018
 
     referent = get_or_issue_regression_cred_revoked.referent
     credential_definition_id_revocable = (

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.1.1b0
+FROM ghcr.io/didx-xyz/acapy-agent-bbs:py3.12-1.1.1b0
 
 COPY configuration ./configuration
 COPY scripts ./scripts

--- a/dockerfiles/agents/Dockerfile
+++ b/dockerfiles/agents/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.0.0b1
+FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.1.1b0
 
 COPY configuration ./configuration
 COPY scripts ./scripts

--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -7,8 +7,7 @@ ARG PROTOBUF_VERSION=5.28.1
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION}
 
 # install nats-events plugin
-RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-10-09#subdirectory=nats_events
-
+RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-10-22#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.0.0b1
+FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.1.1b0
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile.agent
+++ b/dockerfiles/agents/Dockerfile.agent
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.1.1b0
+FROM ghcr.io/didx-xyz/acapy-agent-bbs:py3.12-1.1.1b0
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -10,7 +10,7 @@ RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION}
 RUN pip install --no-cache-dir git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@1.1.1b0
 
 # install nats-events plugin
-RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-10-09#subdirectory=nats_events
+RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-10-22#subdirectory=nats_events
 
 COPY scripts/startup.sh startup.sh
 RUN chmod +x ./startup.sh

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -7,7 +7,7 @@ ARG PROTOBUF_VERSION=5.28.1
 RUN pip install --no-cache-dir protobuf==${PROTOBUF_VERSION}
 
 # Install wallet group id plugin
-RUN pip install --no-cache-dir git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@1.0.0b1
+RUN pip install --no-cache-dir git+https://github.com/didx-xyz/acapy-wallet-groups-plugin@1.1.1b0
 
 # install nats-events plugin
 RUN pip install --no-cache-dir git+https://github.com/didx-xyz/aries-acapy-plugins@v1-2024-10-09#subdirectory=nats_events

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.0.0b1
+FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.1.1b0
 
 USER root
 

--- a/dockerfiles/agents/Dockerfile.author.agent
+++ b/dockerfiles/agents/Dockerfile.author.agent
@@ -1,4 +1,4 @@
-FROM ghcr.io/didx-xyz/aries-cloudagent-bbs:py3.12-1.1.1b0
+FROM ghcr.io/didx-xyz/acapy-agent-bbs:py3.12-1.1.1b0
 
 USER root
 

--- a/docs/Aries Cloud API Architecture.md
+++ b/docs/Aries Cloud API Architecture.md
@@ -14,4 +14,4 @@ Like the Admin Agent, the Multi-tenant Agent is also exposed via the same Swagge
 
 The Multi-tenant Agent is designed for sub-wallet and tenant management from the tenant's perspective.
 
-For a more comprehensive understanding of multi-tenancy, please refer to the [ACA-Py docs](https://github.com/hyperledger/aries-cloudagent-python/blob/main/Multitenancy.md).
+For a more comprehensive understanding of multi-tenancy, please refer to the [ACA-Py docs](https://github.com/openwallet-foundation/acapy/blob/main/docs/features/Multitenancy.md).

--- a/docs/Governance as Code.md
+++ b/docs/Governance as Code.md
@@ -137,7 +137,7 @@ credentials to holders. The Trust Authority, which administers the trust ecosyst
 the Indy Ledger, acts as the `Transaction Endorser` of the Trust Ecosystem. Meanwhile, Issuers serve as
 `Transaction Authors` within the Trust Ecosystem. For additional information on `Transaction Endorsers` and
 `Transaction Authors`, please refer to
-[Aries Transaction Endorser Support](https://github.com/hyperledger/aries-cloudagent-python/blob/main/Endorser.md).
+[Aries Transaction Endorser Support](https://github.com/openwallet-foundation/acapy/blob/main/docs/features/Endorser.md).
 
 To create credential definitions through the `Transaction Endorser Protocol` for trust ecosystem _issuers_,
 follow the steps below:

--- a/environments/governance-ga/aca-py-agent.default.env
+++ b/environments/governance-ga/aca-py-agent.default.env
@@ -54,7 +54,7 @@ AGENT_ENDPOINT=http://governance-ga-agent:3020
 # ## DO NOT CHANGE VARIABLES BELOW
 # ## Unless you know exactly what you are doing
 # ## Changes will probably break CloudAPI
-# Optional Helper Configurations - See https://github.com/hyperledger/aries-cloudagent-python/blob/main/aries_cloudagent/config/argparse.py
+# Optional Helper Configurations - See https://github.com/openwallet-foundation/acapy/blob/main/acapy_agent/config/argparse.py
 ACAPY_AUTO_ACCEPT_INVITES=false
 ACAPY_AUTO_ACCEPT_REQUESTS=false
 ACAPY_AUTO_PING_CONNECTION=true
@@ -77,7 +77,7 @@ ACAPY_AUTO_ENDORSE_TRANSACTIONS=false
 ACAPY_PUBLIC_INVITES=true
 
 # Enable Public DID Connections. This is required for the CloudAPI to work
-# This is a breaking change in AcaPy 0.8.0 - see https://github.com/hyperledger/aries-cloudagent-python/pull/2034
+# This is a breaking change in AcaPy 0.8.0 - see https://github.com/openwallet-foundation/acapy/pull/2034
 ACAPY_REQUESTS_THROUGH_PUBLIC_DID=true
 #Emit protocol messages with new DIDComm prefix; i.e.https://didcomm.org/' instead of (default) prefix "'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'."
 ACAPY_EMIT_NEW_DIDCOMM_PREFIX=true

--- a/environments/governance-multitenant/aca-py-agent.default.env
+++ b/environments/governance-multitenant/aca-py-agent.default.env
@@ -53,7 +53,7 @@ AGENT_ENDPOINT=http://governance-multitenant-agent:3020
 # ## DO NOT CHANGE VARIABLES BELOW
 # ## Unless you know exactly what you are doing
 # ## Changes will probably break CloudAPI
-# Optional Helper Configurations - See https://github.com/hyperledger/aries-cloudagent-python/blob/main/aries_cloudagent/config/argparse.py
+# Optional Helper Configurations - See https://github.com/openwallet-foundation/acapy/blob/main/aries_cloudagent/config/argparse.py
 ACAPY_AUTO_ACCEPT_INVITES=true
 ACAPY_AUTO_ACCEPT_REQUESTS=true
 ACAPY_AUTO_PING_CONNECTION=true
@@ -81,7 +81,7 @@ ACAPY_ENDORSER_ALIAS=endorser
 ACAPY_PUBLIC_INVITES=true
 
 # Enable Public DID Connections. This is required for the CloudAPI to work
-# This is a breaking change in AcaPy 0.8.0 - see https://github.com/hyperledger/aries-cloudagent-python/pull/2034
+# This is a breaking change in AcaPy 0.8.0 - see https://github.com/openwallet-foundation/acapy/pull/2034
 ACAPY_REQUESTS_THROUGH_PUBLIC_DID=true
 #Emit protocol messages with new DIDComm prefix; i.e.https://didcomm.org/' instead of (default) prefix "'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/'."
 ACAPY_EMIT_NEW_DIDCOMM_PREFIX=true

--- a/shared/models/endorsement.py
+++ b/shared/models/endorsement.py
@@ -71,7 +71,7 @@ def extract_operation_type_from_endorsement_payload(
 
 
 class TransactionTypes:
-    # See aries-cloudagent-python/aries_cloudagent/ledger/merkel_validation/constants.py
+    # See acapy-agent-python/aries_cloudagent/ledger/merkel_validation/constants.py
     ATTRIB = "100"
     CLAIM_DEF = "102"
     REVOC_REG_DEF = "113"


### PR DESCRIPTION
♻️ Synced our fork to latest changes on upstream/main, pulling in our pagination feature: 
https://github.com/didx-xyz/acapy/releases/tag/1.1.1b0

⬆️ Updated acapy-wallet-groups-plugin and our nats_event plugin to use this version too:
- https://github.com/didx-xyz/acapy-wallet-groups-plugin/releases/tag/1.1.1b0
- https://github.com/didx-xyz/aries-acapy-plugins/releases/tag/v1-2024-10-22
  - ✨ acapy-plugins repo has also been reset to be up to date with upstream/main, to make future updates easier
- Note: `aries_cloudagent` imports in these plugins have been refactored to use renamed `acapy_agent` package

🎨 Updated docs/links referencing acapy repo to be up to date