### PR TITLE
:sparkles: Implement retry logic in RichAsyncClient

### DIFF
--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -11,8 +11,21 @@ logger = logging.getLogger(__name__)
 ssl_context = ssl.create_default_context()
 
 
-# Async Client with built in error handling and re-using SSL certs
 class RichAsyncClient(AsyncClient):
+    """Async Client that extends httpx.AsyncClient with built-in error handling and SSL cert reuse.
+
+    - Reuses SSL context for better performance
+    - Retries requests on 503 Service Unavailable errors
+    - Raises HTTPException with detailed error messages
+
+    Args:
+        name (Optional[str]): Optional name for the client, prepended to exceptions.
+        verify: SSL certificate verification context.
+        raise_status_error (bool): Whether to raise an error for 4xx and 5xx status codes.
+        retries (int): Number of retry attempts for failed requests.
+        retry_on (List[int]): List of HTTP status codes that should trigger a retry.
+    """
+
     def __init__(
         self,
         *args,

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -50,7 +50,10 @@ class RichAsyncClient(AsyncClient):
     async def _handle_error(self, e: HTTPStatusError, url: str, method: str) -> None:
         code = e.response.status_code
         message = e.response.text
-        log_message = f"{self.name} {method} `{url}` failed. Status code: {code}. Response: `{message}`."
+        log_message = (
+            f"{self.name} {method} `{url}` failed. "
+            f"Status code: {code}. Response: `{message}`."
+        )
         logger.error(log_message)
         raise HTTPException(status_code=code, detail=message) from e
 

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -26,58 +26,42 @@ class RichAsyncClient(AsyncClient):
         )  # prepend to exception messages to add context
         self.raise_status_error = raise_status_error
 
+    async def _handle_response(self, response: Response) -> Response:
+        if self.raise_status_error:
+            response.raise_for_status()  # Raise exception for 4xx and 5xx status codes
+        return response
+
+    async def _handle_error(self, e: HTTPStatusError, url: str, method: str) -> None:
+        code = e.response.status_code
+        message = e.response.text
+        log_message = f"{self.name} {method} `{url}` failed. Status code: {code}. Response: `{message}`."
+        logger.error(log_message)
+        raise HTTPException(status_code=code, detail=message) from e
+
     async def post(self, url: str, **kwargs) -> Response:
         try:
             response = await super().post(url, **kwargs)
-            if self.raise_status_error:
-                response.raise_for_status()  # Raise exception for 4xx and 5xx status codes
+            return await self._handle_response(response)
         except HTTPStatusError as e:
-            code = e.response.status_code
-            message = e.response.text
-            log_message = f"{self.name} POST `{url}` failed. Status code: {code}. Response: `{message}`."
-            logger.error(log_message)
-
-            raise HTTPException(status_code=code, detail=message) from e
-        return response
+            await self._handle_error(e, url, "POST")
 
     async def get(self, url: str, **kwargs) -> Response:
         try:
             response = await super().get(url, **kwargs)
-            if self.raise_status_error:
-                response.raise_for_status()
+            return await self._handle_response(response)
         except HTTPStatusError as e:
-            code = e.response.status_code
-            message = e.response.text
-            log_message = f"{self.name} GET `{url}` failed. Status code: {code}. Response: `{message}`."
-            logger.error(log_message)
-
-            raise HTTPException(status_code=code, detail=message) from e
-        return response
+            await self._handle_error(e, url, "GET")
 
     async def delete(self, url: str, **kwargs) -> Response:
         try:
             response = await super().delete(url, **kwargs)
-            if self.raise_status_error:
-                response.raise_for_status()
+            return await self._handle_response(response)
         except HTTPStatusError as e:
-            code = e.response.status_code
-            message = e.response.text
-            log_message = f"{self.name} DELETE `{url}` failed. Status code: {code}. Response: `{message}`."
-            logger.error(log_message)
-
-            raise HTTPException(status_code=code, detail=message) from e
-        return response
+            await self._handle_error(e, url, "DELETE")
 
     async def put(self, url: str, **kwargs) -> Response:
         try:
             response = await super().put(url, **kwargs)
-            if self.raise_status_error:
-                response.raise_for_status()
+            return await self._handle_response(response)
         except HTTPStatusError as e:
-            code = e.response.status_code
-            message = e.response.text
-            log_message = f"{self.name} PUT `{url}` failed. Status code: {code}. Response: `{message}`."
-            logger.error(log_message)
-
-            raise HTTPException(status_code=code, detail=message) from e
-        return response
+            await self._handle_error(e, url, "PUT")

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -65,6 +65,11 @@ class RichAsyncClient(AsyncClient):
             except HTTPStatusError as e:
                 code = e.response.status_code
                 if code in self.retry_on and attempt < self.retries - 1:
+                    log_message = (
+                        f"{self.name} {method} `{url}` failed with status code {code}. "
+                        f"Retrying attempt {attempt + 1}/{self.retries}."
+                    )
+                    logger.warning(log_message)
                     await asyncio.sleep(0.5)  # Wait before retrying
                     continue  # Retry the request
                 await self._handle_error(e, url, method)


### PR DESCRIPTION
Since 503 errors can sometimes occur in our EKS tests, this inspired that our RichAsyncClient implementation should be configurable for retries

Current new defaults: up to 3 retries on 503 errors.