### PR TITLE
Fix Mise

### DIFF
--- a/.github/workflows/continuous-deploy.yml
+++ b/.github/workflows/continuous-deploy.yml
@@ -422,22 +422,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Mise
-        uses: jdx/mise-action@v2
-        with:
-          cache: true
-          experimental: true # Required for mise tasks
-          install: true
-      - name: Load Mise env
-        run: |
-          mise env -s bash \
-              | grep -v 'export PATH=' \
-              | cut -d' ' -f2 \
-              >> "$GITHUB_ENV"
       - name: Install dependencies
-        run: |
-          source .venv/bin/activate
-          pip install coverage
+        run: pip install coverage
       - name: Download all .coverage artifacts
         uses: actions/download-artifact@v4
         with:
@@ -450,12 +436,10 @@ jobs:
           done
       - name: Combine coverage files
         run: |
-          source .venv/bin/activate
           coverage combine
           coverage report
       - name: Generate XML coverage report
         run: |
-          source .venv/bin/activate
           coverage xml
       - name: Upload coverage to Codacy
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,17 +1,18 @@
 # https://mise.jdx.dev
 [tools]
 "go:github.com/nats-io/natscli/nats" = "0.1"
+"pipx:poetry" = "1.8"
 go = "1.23"
 helm = "3"
 helmfile = "0.169"
 istioctl = "1.23"
 kind = "0.24"
 kubectl = "1.31"
-poetry = { version = "1.8", pyproject = "pyproject.toml" }
 pre-commit = "4.0"
 python = "3.12"
 tilt = "0.33"
 usage = "latest"
+uv = "0.4"
 
 [settings]
 experimental = true
@@ -19,6 +20,8 @@ experimental = true
 # Prevents `poetry install` from running in parallel which
 #   results in multiple threads trying to write to the same file.
 jobs = 1
+# Use UV instead of pipx for installing Python binaries
+pipx_uvx = true
 # Install precompiled python binary
 python_compile = false
 


### PR DESCRIPTION
* Instead of using `poetry` which depends on System Python we use `uv`
as `pipx` to install `poetry` in the Mise managed python venv