### PR TITLE
👷 Validate PR Title

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -20,7 +20,7 @@ jobs:
             const title = context.payload.pull_request.title;
             core.setOutput('title', title);
 
-      - name: PR title must start with emoji
+      - name: PR title should start with emoji
         uses: actions/github-script@v7
         with:
           script: |
@@ -41,7 +41,7 @@ jobs:
             // Find our bot's validation comment if it exists
             const botComment = comments.data.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('Your PR title must start with an emoji!')
+              comment.body.includes('Your PR title should start with an emoji!')
             );
 
             if (!emojiRegex.test(prTitle)) {
@@ -51,13 +51,13 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.issue.number,
-                  body: `⚠️ Your PR title must start with an emoji!\n\nExample valid titles:\n- ✨ Add new feature (or :sparkles: Add new feature)\n- 🐛 Fix login bug (or :bug: Fix login bug)\n- 📝 Update documentation (or :memo: Update documentation)\n\nNeed emoji suggestions? Check out [gitmoji.dev](https://gitmoji.dev) for a comprehensive list of Git-friendly emojis!\n\nPlease update your PR title and try again.`
+                  body: `⚠️ Your PR title should start with an emoji!\n\nExample valid titles:\n- ✨ Add new feature (or :sparkles: Add new feature)\n- 🐛 Fix login bug (or :bug: Fix login bug)\n- 📝 Update documentation (or :memo: Update documentation)\n\nNeed emoji suggestions? Check out [gitmoji.dev](https://gitmoji.dev) for a comprehensive list of Git-friendly emojis!\n\nPlease update your PR title and try again.`
                 });
               }
 
               // Create warning annotation instead of failing
               // Change to `core.setFailed()` to fail the check
-              core.warning(`PR title must start with an emoji! Current title: "${prTitle}". Use either Unicode emoji (🔥) or GitHub shortcode format (:fire:)`);
+              core.warning(`PR title should start with an emoji! Current title: "${prTitle}". Use either Unicode emoji (🔥) or GitHub shortcode format (:fire:)`);
             } else if (botComment) {
               // If title is now valid and we have a comment, delete it
               await github.rest.issues.deleteComment({

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,66 @@
+name: Validate PR Titles
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR Title
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            core.setOutput('title', title);
+
+      - name: PR title must start with emoji
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prTitle = '${{ steps.pr.outputs.title }}';
+
+            // Match either:
+            // 1. Unicode emoji at start (using Unicode properties)
+            // 2. GitHub emoji shortcode format (e.g. :fire:)
+            const emojiRegex = /^(?:[\p{Emoji_Presentation}\p{Extended_Pictographic}]|:[a-z0-9_+-]+:)/u;
+
+            // Get all comments
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            // Find our bot's validation comment if it exists
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Your PR title must start with an emoji!')
+            );
+
+            if (!emojiRegex.test(prTitle)) {
+              // Only add a comment if we haven't already
+              if (!botComment) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `⚠️ Your PR title must start with an emoji!\n\nExample valid titles:\n- ✨ Add new feature (or :sparkles: Add new feature)\n- 🐛 Fix login bug (or :bug: Fix login bug)\n- 📝 Update documentation (or :memo: Update documentation)\n\nNeed emoji suggestions? Check out [gitmoji.dev](https://gitmoji.dev) for a comprehensive list of Git-friendly emojis!\n\nPlease update your PR title and try again.`
+                });
+              }
+
+              core.setFailed(`PR title must start with an emoji! Current title: "${prTitle}". Use either Unicode emoji (🔥) or GitHub shortcode format (:fire:)`);
+            } else if (botComment) {
+              // If title is now valid and we have a comment, delete it
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id
+              });
+            }

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -55,7 +55,9 @@ jobs:
                 });
               }
 
-              core.setFailed(`PR title must start with an emoji! Current title: "${prTitle}". Use either Unicode emoji (🔥) or GitHub shortcode format (:fire:)`);
+              // Create warning annotation instead of failing
+              // Change to `core.setFailed()` to fail the check
+              core.warning(`PR title must start with an emoji! Current title: "${prTitle}". Use either Unicode emoji (🔥) or GitHub shortcode format (:fire:)`);
             } else if (botComment) {
               // If title is now valid and we have a comment, delete it
               await github.rest.issues.deleteComment({


### PR DESCRIPTION
Add action that validates PR titles.

Currently will print a Warning and leave a comment on the PR if the PR title doesn't start with an emoji.

Comment is left once. If the PR is updated with an emoji, the comment is removed.