### PR TITLE
:art: Resolve pylint warnings

### DIFF
--- a/app/routes/connections.py
+++ b/app/routes/connections.py
@@ -148,7 +148,7 @@ async def accept_invitation(
 
 
 @router.get("", summary="Fetch Connection Records", response_model=List[Connection])
-async def get_connections(
+async def get_connections(  # pylint: disable=R0913,R0917
     limit: Optional[int] = limit_query_parameter,
     offset: Optional[int] = offset_query_parameter,
     order_by: Optional[str] = order_by_query_parameter,

--- a/app/services/trust_registry/schemas.py
+++ b/app/services/trust_registry/schemas.py
@@ -36,7 +36,7 @@ async def register_schema(schema_id: str) -> None:
             raise TrustRegistryException(
                 f"Error registering schema `{schema_id}`. Error: `{e.detail}`.",
                 e.status_code,
-            )
+            ) from e
 
     bound_logger.debug("Successfully registered schema on trust registry.")
 
@@ -62,7 +62,7 @@ async def fetch_schemas() -> List[Schema]:
             )
             raise TrustRegistryException(
                 f"Unable to fetch schemas: `{e.detail}`.", e.status_code
-            )
+            ) from e
 
     result = [Schema.model_validate(schema) for schema in schemas_res.json()]
     logger.debug("Successfully fetched schemas from trust registry.")
@@ -99,7 +99,7 @@ async def get_schema_by_id(schema_id: str) -> Optional[Schema]:
                 raise TrustRegistryException(
                     f"Unable to fetch schema: `{e.detail}`.",
                     e.status_code,
-                )
+                ) from e
 
     result = Schema.model_validate(schema_response.json())
     logger.debug("Successfully fetched schema from trust registry.")
@@ -129,6 +129,6 @@ async def remove_schema_by_id(schema_id: str) -> None:
             raise TrustRegistryException(
                 f"Error removing schema from trust registry: `{e.detail}`.",
                 e.status_code,
-            )
+            ) from e
 
     bound_logger.debug("Successfully removed schema from trust registry.")

--- a/app/tests/e2e/verifier/test_many_revocations.py
+++ b/app/tests/e2e/verifier/test_many_revocations.py
@@ -115,6 +115,8 @@ async def revoke_many(
 ) -> List[CredentialExchange]:
 
     auto_publish = True
+    if hasattr(request, "param") and request.param == "auto_publish_false":
+        auto_publish = False
 
     for cred in issue_many_creds:
         await faber_client.post(

--- a/app/tests/util/webhooks.py
+++ b/app/tests/util/webhooks.py
@@ -62,7 +62,7 @@ async def check_webhook_state(
                     timeout=max_duration,
                 )
             else:
-                raise Exception(
+                raise Exception(  # pylint: disable=W0719
                     "No longer implemented: cannot wait for event without filter_map"
                 )
         except SseListenerTimeout:

--- a/app/util/acapy_verifier_utils.py
+++ b/app/util/acapy_verifier_utils.py
@@ -16,7 +16,7 @@ from shared.models.trustregistry import Actor
 logger = get_logger(__name__)
 
 
-async def assert_valid_prover(
+async def assert_valid_prover(  # pylint: disable=R0912
     aries_controller: AcaPyClient, presentation: AcceptProofRequest
 ) -> None:
     """Check transaction requirements against trust registry for prover"""

--- a/shared/util/rich_async_client.py
+++ b/shared/util/rich_async_client.py
@@ -34,7 +34,7 @@ class RichAsyncClient(AsyncClient):
         verify=ssl_context,
         raise_status_error=True,
         retries: int = 3,
-        retry_on: List[int] = [502, 503],
+        retry_on: Optional[List[int]] = None,
         retry_wait_seconds: float = 0.5,
         **kwargs,
     ) -> None:
@@ -42,7 +42,7 @@ class RichAsyncClient(AsyncClient):
         self.name = name + " - HTTP" if name else "HTTP"  # prepended to exceptions
         self.raise_status_error = raise_status_error
         self.retries = retries
-        self.retry_on = retry_on
+        self.retry_on = retry_on if retry_on is not None else [502, 503]
         self.retry_wait_seconds = retry_wait_seconds
 
     async def _handle_response(self, response: Response) -> Response:


### PR DESCRIPTION
Resolves:
- using list as default arg in RichAsyncClient
- ignores "too many arguments" / etc warnings for methods that need it
- fix unused argument in test fixture
- ignore too general exception for tests
- add "raise exception from" in schemas service

The only remaining warnings are todo's (excluding some warnings in tests)