### PR TITLE
:sparkles: Add `save_exchange_record` to request_credential

### DIFF
--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -211,6 +211,7 @@ async def create_offer(
 )
 async def request_credential(
     credential_exchange_id: str,
+    save_exchange_record: Optional[bool] = Query(default=None, strict=True),
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> CredentialExchange:
     """
@@ -225,6 +226,9 @@ async def request_credential(
     ---
         credential_exchange_id: str
             The holder's reference to the credential exchange that they want to accept
+        save_exchange_record: bool
+            Whether to override environment setting for saving credential exchange records. Default is None (use
+            environment setting). True means save record, False means delete record.
 
     Returns:
     ---
@@ -259,9 +263,15 @@ async def request_credential(
         await assert_valid_issuer(issuer_did, schema_id)
         # Make sure the issuer is allowed to issue this credential according to trust registry rules
 
+        auto_remove = None
+        if save_exchange_record is not None:
+            auto_remove = not save_exchange_record
+
         bound_logger.debug("Requesting credential")
         result = await IssuerV2.request_credential(
-            controller=aries_controller, credential_exchange_id=credential_exchange_id
+            controller=aries_controller,
+            credential_exchange_id=credential_exchange_id,
+            auto_remove=auto_remove,
         )
 
     bound_logger.debug("Successfully sent credential request.")

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -265,7 +265,7 @@ async def request_credential(
         # Make sure the issuer is allowed to issue this credential according to trust registry rules
 
         auto_remove = None
-        if save_exchange_record is not None:
+        if isinstance(save_exchange_record, bool):
             auto_remove = not save_exchange_record
 
         bound_logger.debug("Requesting credential")

--- a/app/routes/issuer.py
+++ b/app/routes/issuer.py
@@ -32,6 +32,7 @@ from app.util.pagination import (
     order_by_query_parameter,
 )
 from app.util.retry_method import coroutine_with_retry_until_value
+from app.util.save_exchange_record import save_exchange_record_query
 from shared.log_config import get_logger
 from shared.models.credential_exchange import CredentialExchange, Role, State
 
@@ -211,7 +212,7 @@ async def create_offer(
 )
 async def request_credential(
     credential_exchange_id: str,
-    save_exchange_record: Optional[bool] = Query(default=None, strict=True),
+    save_exchange_record: Optional[bool] = save_exchange_record_query,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> CredentialExchange:
     """
@@ -226,7 +227,7 @@ async def request_credential(
     ---
         credential_exchange_id: str
             The holder's reference to the credential exchange that they want to accept
-        save_exchange_record: bool
+        save_exchange_record: Optional[bool]
             Whether to override environment setting for saving credential exchange records. Default is None (use
             environment setting). True means save record, False means delete record.
 

--- a/app/services/issuer/acapy_issuer.py
+++ b/app/services/issuer/acapy_issuer.py
@@ -58,6 +58,7 @@ class Issuer(ABC):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
+        auto_remove: Optional[bool] = None,
     ) -> CredentialExchange:
         """
         Request credential
@@ -69,7 +70,8 @@ class Issuer(ABC):
         credential_exchange_id: str
             The credential_exchange_id of the exchange
         auto_remove: Optional[bool]
-            Whether to override environment setting for auto-deleting cred ex records
+            Whether to override environment setting for auto-deleting cred ex records. Default is None (use environment
+            setting)
 
         Returns:
         --------

--- a/app/services/issuer/acapy_issuer_v2.py
+++ b/app/services/issuer/acapy_issuer_v2.py
@@ -131,6 +131,7 @@ class IssuerV2(Issuer):
         cls,
         controller: AcaPyClient,
         credential_exchange_id: str,
+        auto_remove: Optional[bool] = None,
     ) -> CredentialExchange:
         bound_logger = logger.bind(
             body={"credential_exchange_id": credential_exchange_id}
@@ -139,7 +140,7 @@ class IssuerV2(Issuer):
         credential_exchange_id = cred_ex_id_no_version(credential_exchange_id)
 
         bound_logger.debug("Sending v2 credential request")
-        request_body = V20CredRequestRequest()
+        request_body = V20CredRequestRequest(auto_remove=auto_remove)
         record = await handle_acapy_call(
             logger=bound_logger,
             acapy_call=controller.issue_credential_v2_0.send_request,

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -110,6 +110,96 @@ async def test_issue_credential_with_save_exchange_record(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("save_exchange_record", [None, False, True])
+async def test_request_credential_with_save_exchange_record(
+    faber_client: RichAsyncClient,
+    credential_definition_id: str,
+    faber_and_alice_connection: FaberAliceConnect,
+    alice_member_client: RichAsyncClient,
+    save_exchange_record: bool,
+):
+    # This test asserts that the holder can control `save_exchange_records` behaviour
+    credential = {
+        "connection_id": faber_and_alice_connection.faber_connection_id,
+        "indy_credential_detail": {
+            "credential_definition_id": credential_definition_id,
+            "attributes": {"speed": "20", "name": "Alice", "age": "44"},
+        },
+    }
+
+    # Create and send credential offer - issuer
+    faber_send_response = (
+        await faber_client.post(
+            CREDENTIALS_BASE_PATH,
+            json=credential,
+        )
+    ).json()
+
+    faber_credential_exchange_id = faber_send_response["credential_exchange_id"]
+    thread_id = faber_send_response["thread_id"]
+
+    try:
+        # Wait for holder to receive offer
+        payload = await check_webhook_state(
+            client=alice_member_client,
+            topic="credentials",
+            state="offer-received",
+            filter_map={
+                "thread_id": thread_id,
+            },
+        )
+
+        alice_credential_exchange_id = payload["credential_exchange_id"]
+
+        # Send credential request - holder
+        await alice_member_client.post(
+            f"{CREDENTIALS_BASE_PATH}/{alice_credential_exchange_id}/request",
+            params={"save_exchange_record": save_exchange_record},
+        )
+
+        await check_webhook_state(
+            client=alice_member_client,
+            topic="credentials",
+            state="done",
+            filter_map={
+                "credential_exchange_id": alice_credential_exchange_id,
+            },
+        )
+
+        await asyncio.sleep(1)  # short sleep before fetching; allow records to update
+
+        if save_exchange_record:
+            # Get exchange record from alice side - should exist if save_exchange_record=True
+            alice_cred_ex_record = (
+                await alice_member_client.get(
+                    f"{CREDENTIALS_BASE_PATH}/{alice_credential_exchange_id}"
+                )
+            ).json()
+
+            assert (
+                alice_cred_ex_record["credential_exchange_id"]
+                == alice_credential_exchange_id
+            )
+        else:
+            # If save_exchange_record was False, credential should not exist for holder
+            with pytest.raises(HTTPException) as exc:
+                await alice_member_client.get(
+                    f"{CREDENTIALS_BASE_PATH}/{alice_credential_exchange_id}"
+                )
+            assert exc.value.status_code == 404
+
+    finally:
+        # Clean up
+        if save_exchange_record:
+            await alice_member_client.delete(
+                f"{CREDENTIALS_BASE_PATH}/{alice_credential_exchange_id}"
+            )
+        await faber_client.delete(
+            f"{CREDENTIALS_BASE_PATH}/{faber_credential_exchange_id}"
+        )
+
+
+@pytest.mark.anyio
 async def test_get_cred_exchange_records(
     faber_client: RichAsyncClient,
     credential_definition_id: str,

--- a/app/tests/e2e/issuer/test_save_exchange_record.py
+++ b/app/tests/e2e/issuer/test_save_exchange_record.py
@@ -125,6 +125,7 @@ async def test_request_credential_with_save_exchange_record(
             "credential_definition_id": credential_definition_id,
             "attributes": {"speed": "20", "name": "Alice", "age": "44"},
         },
+        "save_exchange_record": True,  # so we can safely delete faber cred ex record in finally block
     }
 
     # Create and send credential offer - issuer
@@ -152,9 +153,13 @@ async def test_request_credential_with_save_exchange_record(
         alice_credential_exchange_id = payload["credential_exchange_id"]
 
         # Send credential request - holder
+        params = {}
+        if save_exchange_record is not None:
+            params = {"save_exchange_record": save_exchange_record}
+
         await alice_member_client.post(
             f"{CREDENTIALS_BASE_PATH}/{alice_credential_exchange_id}/request",
-            params={"save_exchange_record": save_exchange_record},
+            params=params,
         )
 
         await check_webhook_state(

--- a/app/tests/routes/issuer/test_request_credential.py
+++ b/app/tests/routes/issuer/test_request_credential.py
@@ -15,7 +15,8 @@ from app.services.issuer.acapy_issuer_v2 import IssuerV2
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("record_type", ["indy", "ld_proof", "bad"])
-async def test_request_credential_success(record_type):
+@pytest.mark.parametrize("save_exchange_record", [None, True, False])
+async def test_request_credential_success(record_type, save_exchange_record):
     mock_aries_controller = AsyncMock()
     issuer = Mock()
     issuer.request_credential = IssuerV2.request_credential
@@ -53,11 +54,17 @@ async def test_request_credential_success(record_type):
 
         else:
             await request_credential(
-                credential_exchange_id="v2-test_id", auth="mocked_auth"
+                credential_exchange_id="v2-test_id",
+                save_exchange_record=save_exchange_record,
+                auth="mocked_auth",
             )
 
+            auto_remove = (
+                not save_exchange_record if save_exchange_record is not None else None
+            )
             mock_aries_controller.issue_credential_v2_0.send_request.assert_awaited_once_with(
-                cred_ex_id="test_id", body=V20CredRequestRequest()
+                cred_ex_id="test_id",
+                body=V20CredRequestRequest(auto_remove=auto_remove),
             )
 
 

--- a/app/tests/services/issuer/test_issuer.py
+++ b/app/tests/services/issuer/test_issuer.py
@@ -231,12 +231,13 @@ async def test_request_credential(
         to_async(True)
     ):
         await test_module.request_credential(
-            "v2-credential_exchange_id", mock_tenant_auth
+            "v2-credential_exchange_id", auth=mock_tenant_auth
         )
 
         verify(IssuerV2).request_credential(
             controller=mock_agent_controller,
             credential_exchange_id="v2-credential_exchange_id",
+            auto_remove=None,
         )
         verify(test_module).assert_valid_issuer(did, "schema_id2")
 
@@ -250,12 +251,13 @@ async def test_request_credential(
         to_async(True)
     ):
         await test_module.request_credential(
-            "v2-credential_exchange_id", mock_tenant_auth
+            "v2-credential_exchange_id", auth=mock_tenant_auth
         )
 
         verify(IssuerV2).request_credential(
             controller=mock_agent_controller,
             credential_exchange_id="v2-credential_exchange_id",
+            auto_remove=None,
         )
         verify(test_module).assert_valid_issuer(did, None)
 
@@ -275,7 +277,7 @@ async def test_request_credential_x_no_schema_cred_def(
         Exception, match="Record has no credential definition or schema associated."
     ):
         await test_module.request_credential(
-            "v2-credential_exchange_id", mock_tenant_auth
+            "v2-credential_exchange_id", auth=mock_tenant_auth
         )
 
         verify(IssuerV2, times=0).request_credential(

--- a/app/util/save_exchange_record.py
+++ b/app/util/save_exchange_record.py
@@ -25,6 +25,6 @@ class SaveExchangeRecordField(BaseModel):
     @property
     def auto_remove(self) -> Optional[bool]:
         """Returns the inverse of save_exchange_record if set, otherwise None."""
-        if self.save_exchange_record is None:
-            return None
-        return not self.save_exchange_record
+        if isinstance(self.save_exchange_record, bool):
+            return not self.save_exchange_record
+        return None

--- a/app/util/save_exchange_record.py
+++ b/app/util/save_exchange_record.py
@@ -1,13 +1,21 @@
 from typing import Optional
 
+from fastapi import Query
 from pydantic import BaseModel, Field
+
+save_exchange_record_description = (
+    "Controls exchange record retention after exchange is complete. None uses "
+    "wallet default (typically to delete), true forces save, false forces delete."
+)
 
 save_exchange_record_field = Field(
     default=None,
-    description=(
-        "Controls exchange record retention after exchange is complete. None uses "
-        "wallet default (typically to delete), true forces save, false forces delete."
-    ),
+    description=save_exchange_record_description,
+)
+
+save_exchange_record_query = Query(
+    default=None,
+    description=save_exchange_record_description,
 )
 
 


### PR DESCRIPTION
New query param for `POST /v1/issuer/{credential_exchange_id}/request`:
`save_exchange_record` to control whether record is preserved from holder's side