### PR TITLE
:rewind: Revert change to `list_w3c_credentials` endpoint

### DIFF
--- a/app/routes/wallet/credentials.py
+++ b/app/routes/wallet/credentials.py
@@ -238,9 +238,9 @@ async def get_credential_revocation_status(
     summary="Fetch a list of W3C credentials from the wallet",
 )
 async def list_w3c_credentials(
-    schema_ids: Optional[List[str]] = None,
-    issuer_did: Optional[str] = None,
     limit: Optional[int] = None,
+    issuer_did: Optional[str] = None,
+    schema_ids: Optional[List[str]] = None,
     auth: AcaPyAuth = Depends(acapy_auth_from_header),
 ) -> VCRecordList:
     """
@@ -251,12 +251,12 @@ async def list_w3c_credentials(
 
     Optional Parameters:
     ---
-        schema_ids: List[str]
-            Schema identifiers to match
-        issuer_did: str
-            Credential issuer did to match
         limit: int
             Maximum number of results to return
+        issuer_did: str
+            Credential issuer did to match
+        schema_ids: List[str]
+            Schema identifiers to match
 
     Returns:
     ---

--- a/app/routes/wallet/credentials.py
+++ b/app/routes/wallet/credentials.py
@@ -233,7 +233,7 @@ async def get_credential_revocation_status(
 
 
 @router.get(
-    "/list/w3c",
+    "/w3c",
     response_model=VCRecordList,
     summary="Fetch a list of W3C credentials from the wallet",
 )


### PR DESCRIPTION
Following up on #814 https://github.com/didx-xyz/aries-cloudapi-python/commit/2bbe2802e684499743aca3fe9fa7fb258ed8f31a#diff-27b2b23e3c1ffda10f6f3faaf140b96793d52066a3842eb2cde84b36e5558eccR236